### PR TITLE
ClientUI refactors/bugfixes

### DIFF
--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -71,16 +71,26 @@ public class ClientController {
 
     private volatile long lastServerActivityMillis = System.currentTimeMillis();
 
+    /*
+     * Entry point for the client application.
+     *
+     * Usage: java ClientController [host] [port]
+     *
+     *   host - IP address or hostname of the server to connect to.
+     *          Defaults to "localhost" if not provided.
+     *   port - TCP port the server is listening on.
+     *          Defaults to 8080 if not provided.
+     *          Must match the port the server was started with.
+     *          Configurable so clients can reach servers on different ports
+     *          across environments (dev, staging, prod).
+     *
+     * Example:
+     *   java ClientController 192.168.1.10 8080
+     */
     public static void main(String[] args) {
-        new ClientController("localhost", 8080);
-        while (!Thread.currentThread().isInterrupted()) {
-            try {
-                Thread.sleep(1000L);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
+        String host = args.length > 0 ? args[0] : "localhost";
+        int port = args.length > 1 ? Integer.parseInt(args[1]) : 8080;
+        new ClientController(host, port);
     }
 
     public ClientController(String hostIp, int hostPort) {

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -208,11 +208,7 @@ public class ClientController {
                         conversations = lr.getConversationList() != null
                                 ? lr.getConversationList() : new ArrayList<>();
                         if (gui != null) {
-                            if (currentUser.getUserType() == UserType.ADMIN) {
-                                gui.showAdminMainView();
-                            } else {
-                                gui.showMainView();
-                            }
+                            gui.showMainView();
                         }
                         break;
                     case INVALID_CREDENTIALS:
@@ -292,7 +288,7 @@ public class ClientController {
                     ArrayList<Conversation> snapshot = new ArrayList<>(conversations);
                     Conversation current = getCurrentConversation();
                     DefaultListModel conversationListModel = gui.getConversationListViewModel();
-                    DefaultListModel conversationViewModel = gui.getConversationViewModel();
+                    DefaultListModel<Message> conversationViewModel = gui.getConversationViewModel();
                     
                     SwingUtilities.invokeLater(() -> {
                         // Update conversation list (sidebar)

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -476,12 +476,11 @@ public class ClientUI {
             final String finalMember = member;
         	SwingUtilities.invokeLater(() -> {
         		participantsLabel.setText(finalMember);
+                conversationMessageListModel.clear();
+                for(int i = 0; i < currConv.getMessages().size(); i++) {
+                    conversationMessageListModel.addElement(currConv.getMessages().get(i));
+                }
         	});
-        	
-            conversationMessageListModel.clear();
-        	for(int i = 0; i < currConv.getMessages().size(); i++) {
-        		conversationMessageListModel.addElement(currConv.getMessages().get(i));
-        	}
         }
         
         public DefaultListModel<Message> getListModel() {
@@ -679,7 +678,7 @@ public class ClientUI {
             if(adminDialog == null) {
                 return false;
             }
-        	return createDialog.isVisible();
+        	return adminDialog.isVisible();
         }
         
         public DefaultListModel<ConversationMetadata> getAdminConversationModel() {

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -1,17 +1,14 @@
 package client;
 
-import shared.networking.User.UserInfo;
 import shared.enums.*;
 import shared.networking.User.UserInfo;
 import shared.payload.*;
 
 import javax.swing.*;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
+import javax.swing.event.*;
 
 import java.awt.*;
 import java.awt.event.*;
-import java.util.ArrayList;
 
 public class ClientUI {
 
@@ -60,9 +57,31 @@ public class ClientUI {
         }
     }
 
-    public void showLoginView() { cards.layout.show(cards, "login"); }
+    public void showLoginView() {
+        SwingUtilities.invokeLater(() -> {
+            cards.main.directoryView.adminButton.setVisible(false);
+            cards.main.directoryView.revalidate();
+            cards.main.directoryView.repaint();
+            cards.layout.show(cards, "login");
+        });
+    }
     public void showRegisterView() { cards.layout.show(cards, "register"); }
-    public void showMainView() { cards.layout.show(cards, "main"); }
+    
+    // currentUser is set by the time this is called
+    public void showMainView() {
+        SwingUtilities.invokeLater(() -> {
+            UserInfo currentUser = controller.getCurrentUserInfo();
+            boolean isAdmin = currentUser != null && currentUser.getUserType() == UserType.ADMIN;
+            cards.main.directoryView.adminButton.setVisible(isAdmin);
+            cards.main.directoryView.revalidate();
+            cards.main.directoryView.repaint();
+            if (currentUser != null) {
+                cards.main.directoryView.profileUserIdLabel.setText(currentUser.getUserId());
+                cards.main.directoryView.profileNameLabel.setText(currentUser.getName());
+            }
+            cards.layout.show(cards, "main");
+        });
+    }
 
     public void showRegisterError(RegisterStatus registerStatus) {
     	// need to identify which status???
@@ -74,22 +93,22 @@ public class ClientUI {
     	JOptionPane.showMessageDialog(frame, "Log in is failed. Start over again.");
     }
 
-
-    public void chooseMainView() { showMainView(); }
-    public void chooseLoginView() { showLoginView(); }
-    public void chooseRegisterView() { showRegisterView(); }
-
-    public DefaultListModel<UserInfo> getDirectoryViewModel() { return cards.getMainDirectoryListModel(); }
-    public void setDirectoryViewModel(DefaultListModel model) {cards.setMainDirectoryListModel(model); }
-    public DefaultListModel<Conversation> getConversationViewModel() { return cards.getMainConversationMessageListModel(); }
-    public void setConversationViewModel(Conversation currentCon) {cards.setMainConversationMessageListModel(currentCon); }
-    public DefaultListModel<Conversation> getConversationListViewModel() { return cards.getMainConversationListModel(); }
-    public void setConversationListViewModel(DefaultListModel model) {cards.setMainConversationListModel(model); }
+    public DefaultListModel<UserInfo> getDirectoryViewModel() { return cards.main.directoryView.getListModel(); }
+    public DefaultListModel<Message> getConversationViewModel() { return cards.main.conversationView.getListModel(); }
+    public DefaultListModel<Conversation> getConversationListViewModel() { return cards.main.conversationListView.getListModel(); }
     
-    public DefaultListModel<Conversation> getAdminConversationSearchWindowModel() { return cards.getMainAdminConversationModel(); }
+    public DefaultListModel<ConversationMetadata> getAdminConversationSearchWindowModel() {
+        if (cards.main.directoryView.adminConversationSearchWindow == null
+                || cards.main.directoryView.adminConversationSearchWindow.model == null) {
+            return new DefaultListModel<>();
+        }
+        return cards.main.directoryView.adminConversationSearchWindow.model;
+    }
 
-    public boolean isSelectingUsers() { return cards.isSelectingUser(); }
-    public boolean isAdminSearchingConversation() { return cards.isAdminSearching(); }
+    public boolean isSelectingUsers() {
+        return cards.main.directoryView.isCreatingConversation() || cards.main.conversationView.isAddingUser();
+    }
+    public boolean isAdminSearchingConversation() { return cards.main.directoryView.isAdminSearching(); }
 
     // =========================================================================
     class ScreenCards extends JPanel {
@@ -107,42 +126,6 @@ public class ClientUI {
             add(login, "login");
             add(register, "register");
             add(main, "main");
-        }
-        
-        public void setMainDirectoryListModel(DefaultListModel model) {
-        	main.setDirectoryListModel(model);
-        }
-        
-        public DefaultListModel getMainDirectoryListModel() {
-        	return main.getDirectoryListModel();
-        }
-        
-        public void setMainConversationMessageListModel(Conversation currConv) {
-        	main.setMessageListModel(currConv);
-        }
-        
-        public DefaultListModel getMainConversationMessageListModel() {
-        	return main.getMessageListModel();
-        }
-        
-        public void setMainConversationListModel(DefaultListModel model) {
-        	main.setConversationListModel(model);
-        }
-        
-        public DefaultListModel getMainConversationListModel() {
-        	return main.getConversationListModel();
-        }
-        
-        public Boolean isSelectingUser() {
-        	return main.isSelectingUser();
-        }
-        
-        public Boolean isAdminSearching() {
-        	return main.isAdminSearching();
-        }
-        
-        public DefaultListModel<Conversation> getMainAdminConversationModel() {
-        	return main.getAdminConversationModel();
         }
     }
 
@@ -359,48 +342,13 @@ public class ClientUI {
  
         }
         
-        public void setDirectoryListModel(DefaultListModel model) {
-        	directoryView.setListModel(model);
-        }
-        
-        public DefaultListModel getDirectoryListModel() {
-        	return directoryView.getListModel();
-        }
-        
-        public void setMessageListModel(Conversation model) {
-        	conversationView.setListModel(model);
-        }
-        
-        public DefaultListModel getMessageListModel() {
-        	return conversationView.getListModel();
-        }
-        
-        public void setConversationListModel(DefaultListModel model) {
-        	conversationListView.setListModel(model);
-        }
-        
-        public DefaultListModel getConversationListModel() {
-        	return conversationListView.getListModel();
-        }
-        
-        public Boolean isSelectingUser() {
-        	return directoryView.isCreatingConversation() || conversationView.isAddingUser();
-        }
-        
-        public Boolean isAdminSearching() {
-        	return directoryView.isAdminSearching();
-        }
-        
-        public DefaultListModel<Conversation> getAdminConversationModel() {
-        	return directoryView.getAdminConversationModel();
-        }
     }
 
     // =========================================================================
     class ConversationView extends JPanel {
         JLabel participantsLabel;
-        DefaultListModel<Message> messageModel = new DefaultListModel<>();
-        JList<Message> list = new JList<>(messageModel);
+        DefaultListModel<Message> conversationMessageListModel = new DefaultListModel<>();
+        JList<Message> list = new JList<>(conversationMessageListModel);
         JButton addButton;
         JButton leaveButton;
         JTextField text;
@@ -508,12 +456,16 @@ public class ClientUI {
             
             // add action to send button
             sendButton.addActionListener(e -> {
-            	controller.sendMessage(controller.getCurrentConversation(), text.getText());
+                if(controller.getCurrentConversation() == null) {
+                    return;
+                }
+            	controller.sendMessage(controller.getCurrentConversation().getConversationId(), text.getText());
             });
                       
         }
         
         public void setListModel(Conversation currConv) {
+            // COMMENT: you can just use conversation.toString() to generate a participant
         	String member = "";
         	for(int i = 0; i < currConv.getParticipants().size(); i++) {
         		if(i != 0) {
@@ -521,27 +473,30 @@ public class ClientUI {
         		}
         		member += currConv.getParticipants().get(i).getName();
         	}
+            final String finalMember = member;
+        	SwingUtilities.invokeLater(() -> {
+        		participantsLabel.setText(finalMember);
+        	});
         	
-        	participantsLabel.setText(member);
-        	
+            conversationMessageListModel.clear();
         	for(int i = 0; i < currConv.getMessages().size(); i++) {
-        		messageModel.addElement(currConv.getMessages().get(i));
+        		conversationMessageListModel.addElement(currConv.getMessages().get(i));
         	}
         }
         
-        public DefaultListModel getListModel() {
-        	return this.messageModel;
+        public DefaultListModel<Message> getListModel() {
+        	return this.conversationMessageListModel;
         }
         
         public Boolean isAddingUser() {
-        	return addDialog.isVisible();
+        	return addDialog != null && addDialog.isVisible();
         }
     }
 
     // =========================================================================
     class DirectoryView extends JPanel {
-        JLabel userLabel;
-        JLabel nameLabel;
+        JLabel profileUserIdLabel;
+        JLabel profileNameLabel;
         JTextField searchField;
         DefaultListModel<UserInfo> listModel = new DefaultListModel<>();
         JList<UserInfo> list = new JList<>(listModel);
@@ -551,12 +506,12 @@ public class ClientUI {
         JDialog createDialog;
         JDialog adminDialog;
         UserInfo selecting;
-        SelectUserWindow createPane;
-        AdminConversationSearchWindow adminPane;
+        SelectUserWindow createConversationUserWindow;
+        AdminConversationSearchWindow adminConversationSearchWindow;
         
         DirectoryView() {
-        	userLabel = new JLabel(controller.getCurrentUserInfo().getUserId());
-        	nameLabel = new JLabel(controller.getCurrentUserInfo().getName());
+        	profileUserIdLabel = new JLabel();
+        	profileNameLabel = new JLabel();
             
             
             searchField = new JTextField(15);
@@ -564,14 +519,12 @@ public class ClientUI {
             createConversationButton = new JButton("Create Conversation");
             // gray-out until select the user
             createConversationButton.setEnabled(false);
-                                    
-            // user is admin
-            if(controller.getCurrentUserInfo().getUserType().equals(UserType.ADMIN)) {
-            	adminButton = new JButton("Admin");
-            	// gray-out until select the user
-                adminButton.setEnabled(false);
-            }
-                      
+                          
+            // construct admin button unconditionally and enable later if the user is admin
+            adminButton = new JButton("Admin");
+            adminButton.setEnabled(false);
+            adminButton.setVisible(false);
+
             setLayout(new BorderLayout());
             setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
             
@@ -584,10 +537,10 @@ public class ClientUI {
             
             gridConst.gridx = 0;
             gridConst.gridy = 0;
-            userPane.add(userLabel, gridConst);
+            userPane.add(profileUserIdLabel, gridConst);
             
             gridConst.gridy = 1;
-            userPane.add(nameLabel, gridConst);
+            userPane.add(profileNameLabel, gridConst);
             
             gridConst.gridy = 2;
             userPane.add(searchField, gridConst);
@@ -641,9 +594,9 @@ public class ClientUI {
                     return;
                 }
                
-            	createPane = new SelectUserWindow();
+            	createConversationUserWindow = new SelectUserWindow();
                 createDialog = new JDialog(frame, "Select User", false);
-                createDialog.add(createPane);
+                createDialog.add(createConversationUserWindow);
                 createDialog.setSize(300, 400);
                 createDialog.setLocationRelativeTo(frame);
                 createDialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
@@ -667,10 +620,13 @@ public class ClientUI {
                     return;
                 }
             	
+                if(selecting == null) {
+                    return;
+                }
             	controller.adminGetUserConversations(selecting.getUserId());
-            	adminPane= new AdminConversationSearchWindow();
+            	adminConversationSearchWindow= new AdminConversationSearchWindow();
                 adminDialog = new JDialog(frame, "Searching Conversations", false);
-                adminDialog.add(adminPane);
+                adminDialog.add(adminConversationSearchWindow);
                 adminDialog.setSize(300, 400);
                 adminDialog.setLocationRelativeTo(frame);
                 adminDialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
@@ -690,38 +646,47 @@ public class ClientUI {
             list.addListSelectionListener(e-> {
             	if (!e.getValueIsAdjusting()) {
 						 selecting = list.getSelectedValue();
-						 // if the another window is not visible, shows the buttons
-						 if(selecting != null && !createDialog.isVisible() && !adminDialog.isVisible()) {
+						 // if the another window is not visible, shows the button
+						 if(selecting != null && createDialog != null && adminDialog != null && !createDialog.isVisible() && !adminDialog.isVisible()) {
 							 createConversationButton.setEnabled(true);
 							 if(adminButton != null) {
 								 adminButton.setEnabled(true);
 							 }
 						 } else if(createDialog.isVisible()) { // if selectUser window is open
-							 createPane.addUser(selecting);
+							 createConversationUserWindow.addUser(selecting);
 						 }							
 			    }
             });
             
         }           
         
-        public void setListModel(DefaultListModel model) {
+        public void setListModel(DefaultListModel<UserInfo> model) {
         	this.listModel = model;
         }
         
-        public DefaultListModel getListModel() {
+        public DefaultListModel<UserInfo> getListModel() {
         	return this.listModel;
         }
 
         public Boolean isCreatingConversation() {
+            if(createDialog == null) {
+                return false;
+            }
         	return createDialog.isVisible();
         }
 
         public Boolean isAdminSearching() {
+            if(adminDialog == null) {
+                return false;
+            }
         	return createDialog.isVisible();
         }
         
-        public DefaultListModel<Conversation> getAdminConversationModel() {
-        	return adminPane.getAdminConversationSearch();
+        public DefaultListModel<ConversationMetadata> getAdminConversationModel() {
+            if(adminConversationSearchWindow == null) {
+                return new DefaultListModel<>();
+            }
+        	return adminConversationSearchWindow.getAdminConversationSearch();
         }
         
         
@@ -762,18 +727,25 @@ public class ClientUI {
                 }
             });
             
+            // TODO: label the conversation
+            // TODO: unread markers
             // add action for selecting an item from the list
             list.addListSelectionListener(e-> {
             	if (!e.getValueIsAdjusting()) {
     				if(list.getSelectedValue() != null) {
     					controller.setCurrentConversationId(list.getSelectedValue().getConversationId());
+                        DefaultListModel<Message> conversationMessageModel = cards.main.conversationView.conversationMessageListModel;
+                        conversationMessageModel.clear();
+                        for(Message message: list.getSelectedValue().getMessages()) {
+                            conversationMessageModel.addElement(message);
+                        }
     				}
             	}    					 				
             });           
         }
         
         
-        public void setListModel(DefaultListModel model) {
+        public void setListModel(DefaultListModel<Conversation> model) {
         	this.listModel = model;
         }
         
@@ -863,13 +835,11 @@ public class ClientUI {
     // =========================================================================
     class AdminConversationSearchWindow extends JPanel {
         JTextField searchField;
-        DefaultListModel<Conversation> model = new DefaultListModel<>();
-        JList<Conversation> list = new JList<>(model);
+        DefaultListModel<ConversationMetadata> model = new DefaultListModel<>();
+        JList<ConversationMetadata> list = new JList<>(model);
         JButton okButton;
         JButton cancelButton;
-        
-
-
+    
         AdminConversationSearchWindow() {
             searchField = new JTextField(15);
             okButton = new JButton("OK");
@@ -902,7 +872,7 @@ public class ClientUI {
                     String text = searchField.getText().toUpperCase();
                     model.clear();
                                       
-                    for(Conversation item: controller.getFilteredAdminConversationSearch(text)) {
+                    for(ConversationMetadata item: controller.getFilteredAdminConversationSearch(text)) {
                     	model.addElement(item);
                     }
                 }
@@ -911,7 +881,7 @@ public class ClientUI {
         	// add action for selecting an item from the list
             list.addListSelectionListener(e-> {
             	if (!e.getValueIsAdjusting()) {
-						 Conversation selecting = list.getSelectedValue();
+						 ConversationMetadata selecting = list.getSelectedValue();
 						 // if the another window is not visible, shows the buttons
 						 okButton.setEnabled(selecting != null);
 			    }
@@ -919,6 +889,9 @@ public class ClientUI {
             
         	// add action to okButton
             okButton.addActionListener(e -> {
+                if(list.getSelectedValue() == null) {
+                    return;
+                }
             	controller.joinConversation(list.getSelectedValue().getConversationId());
                 Window window = SwingUtilities.getWindowAncestor(this);
                 window.dispose();            
@@ -932,7 +905,7 @@ public class ClientUI {
             });
         }
         
-        public DefaultListModel<Conversation> getAdminConversationSearch() {
+        public DefaultListModel<ConversationMetadata> getAdminConversationSearch() {
         	return model;
         }
         

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -65,7 +65,7 @@ public class ClientUI {
             cards.layout.show(cards, "login");
         });
     }
-    public void showRegisterView() { cards.layout.show(cards, "register"); }
+    public void showRegisterView() { SwingUtilities.invokeLater(() -> cards.layout.show(cards, "register")); }
     
     // currentUser is set by the time this is called
     public void showMainView() {
@@ -465,7 +465,6 @@ public class ClientUI {
         }
         
         public void setListModel(Conversation currConv) {
-            // COMMENT: you can just use conversation.toString() to generate a participant
         	String member = "";
         	for(int i = 0; i < currConv.getParticipants().size(); i++) {
         		if(i != 0) {
@@ -487,7 +486,7 @@ public class ClientUI {
         	return this.conversationMessageListModel;
         }
         
-        public Boolean isAddingUser() {
+        public boolean isAddingUser() {
         	return addDialog != null && addDialog.isVisible();
         }
     }
@@ -648,10 +647,9 @@ public class ClientUI {
 						 // if the another window is not visible, shows the button
 						 if(selecting != null && createDialog != null && adminDialog != null && !createDialog.isVisible() && !adminDialog.isVisible()) {
 							 createConversationButton.setEnabled(true);
-							 if(adminButton != null) {
-								 adminButton.setEnabled(true);
-							 }
-						 } else if(createDialog.isVisible()) { // if selectUser window is open
+							 // adminButton is always constructed; visibility is toggled at login time
+							 adminButton.setEnabled(true);
+						 } else if(createDialog != null && createDialog.isVisible()) { // if selectUser window is open
 							 createConversationUserWindow.addUser(selecting);
 						 }							
 			    }
@@ -667,18 +665,12 @@ public class ClientUI {
         	return this.listModel;
         }
 
-        public Boolean isCreatingConversation() {
-            if(createDialog == null) {
-                return false;
-            }
-        	return createDialog.isVisible();
+        public boolean isCreatingConversation() {
+            return createDialog != null && createDialog.isVisible();
         }
 
-        public Boolean isAdminSearching() {
-            if(adminDialog == null) {
-                return false;
-            }
-        	return adminDialog.isVisible();
+        public boolean isAdminSearching() {
+            return adminDialog != null && adminDialog.isVisible();
         }
         
         public DefaultListModel<ConversationMetadata> getAdminConversationModel() {
@@ -732,12 +724,11 @@ public class ClientUI {
             list.addListSelectionListener(e-> {
             	if (!e.getValueIsAdjusting()) {
     				if(list.getSelectedValue() != null) {
-    					controller.setCurrentConversationId(list.getSelectedValue().getConversationId());
-                        DefaultListModel<Message> conversationMessageModel = cards.main.conversationView.conversationMessageListModel;
-                        conversationMessageModel.clear();
-                        for(Message message: list.getSelectedValue().getMessages()) {
-                            conversationMessageModel.addElement(message);
-                        }
+    					Conversation selected = list.getSelectedValue();
+    					controller.setCurrentConversationId(selected.getConversationId());
+    					// delegates to ConversationView.setListModel so both the
+    					// participant label and the message list are updated together
+    					cards.main.conversationView.setListModel(selected);
     				}
             	}    					 				
             });           

--- a/src/server/ServerController.java
+++ b/src/server/ServerController.java
@@ -1,47 +1,244 @@
 package server;
 
-import java.io.File;
-import java.util.*;
-import java.util.concurrent.*;
-import shared.networking.*;
+import java.util.ArrayList;
+import java.util.AbstractMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import shared.enums.ResponseType;
+import shared.networking.ConnectionHandler;
+import shared.networking.ConnectionListener;
+import shared.networking.Request;
+import shared.networking.Response;
+import shared.networking.User.UserInfo;
+import shared.payload.AddToConversationPayload;
+import shared.payload.Conversation;
+import shared.payload.Message;
 
 public class ServerController {
-    private final File dataRoot;
     private Map<String, ConnectionHandler> activeSessions;
     private DataManager dataManager;
     private ConnectionListener connectionListener;
+    private final LinkedBlockingQueue<Map.Entry<String, Response>> responseQueue;
+    private Thread broadcasterThread;
 
+    /*
+     * Entry point for the server application.
+     *
+     * Usage: java ServerController [dataRootPath] [port]
+     *
+     *   dataRootPath - directory where persistent data (users, messages) is stored.
+     *                  Defaults to "data" if not provided.
+     *   port         - TCP port the server listens on for incoming client connections.
+     *                  Defaults to 8080 if not provided.
+     *                  Must be configurable so different environments (dev, staging, prod)
+     *                  and multiple server instances can each bind to their own port.
+     *
+     * Example:
+     *   java ServerController data 8080
+     */
     public static void main(String[] args) {
-        // TODO: parse args, instantiate ServerController
+        String dataRootPath = args.length > 0 ? args[0] : "data";
+        int port = args.length > 1 ? Integer.parseInt(args[1]) : 8080;
+        ServerController serverController = new ServerController(dataRootPath, port);
+        keepAliveUntilInterrupted(serverController);
     }
 
+    private static void keepAliveUntilInterrupted(ServerController serverController) {
+        CountDownLatch latch = new CountDownLatch(1);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            latch.countDown();
+            serverController.close();
+        }, "server-shutdown"));
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            serverController.close();
+        }
+    }
+
+    /*
+     * Production entry point — always starts the broadcaster thread.
+     * Use this constructor everywhere outside of tests.
+     */
     public ServerController(String dataRootPath, int port) {
-        this.dataRoot = new File(dataRootPath);
+        this(dataRootPath, port, true);
+    }
+
+    /*
+     * Package-private: used by tests only.
+     * Pass startBroadcaster=false to inspect the raw response queue
+     * without a background thread racing against test assertions.
+     * Production code always uses the 2-arg constructor above.
+     */
+    ServerController(String dataRootPath, int port, boolean startBroadcaster) {
         this.activeSessions = new ConcurrentHashMap<>();
         this.dataManager = new DataManager(dataRootPath);
         this.connectionListener = new ConnectionListener(port, this);
-        // TODO: start listening
-    }
-
-    /** Directory passed at construction; same root given to {@link DataManager}. */
-    public File getDataRoot() {
-        return dataRoot;
+        this.responseQueue = new LinkedBlockingQueue<>();
+        if (startBroadcaster) startBroadcasterThread();
+        startConnectionListenerThread();
     }
 
     public void close() {
+        // 1. Stop accepting new connections first so no new responses are enqueued.
+        if (connectionListener != null) {
+            connectionListener.close();
+        }
+        // 2. Stop the broadcaster after the listener is closed.
+        if (broadcasterThread != null) {
+            broadcasterThread.interrupt();
+        }
+        // 3. Flush and close persistent storage.
         if (dataManager != null) {
             dataManager.close();
         }
-        // TODO: shut down listener and active sessions
+        // 4. Close active client connections.
+        for (ConnectionHandler handler : activeSessions.values()) {
+            if (handler != null) {
+                handler.close();
+            }
+        }
     }
 
     public Response processRequest(Request request) {
-        // TODO: dispatch to DataManager based on request type
-        return null;
+        if (request == null || request.getType() == null) return null;
+        switch (request.getType()) {
+            case REGISTER:
+                return dataManager.handleRegister(request);
+            case LOGIN:
+                return dataManager.handleLogin(request);
+            case MESSAGE: {
+                Response response = dataManager.handleSendMessage(request);
+                broadcastResponse(request, response);
+                return response;
+            }
+            case UPDATE_READ:
+                return dataManager.handleUpdateReadMessages(request);
+            case CREATE_CONVERSATION: {
+                Response response = dataManager.handleCreateConversation(request);
+                broadcastResponse(request, response);
+                return response;
+            }
+            case ADD_PARTICIPANT: {
+                Response response = dataManager.handleAddToConversation(request);
+                broadcastResponse(request, response);
+                return response;
+            }
+            case LEAVE_CONVERSATION:
+                return dataManager.handleLeaveConversation(request);
+            case ADMIN_CONVERSATION_QUERY:
+                return dataManager.handleAdminConversationQuery(request);
+            case JOIN_CONVERSATION:
+                return dataManager.handleJoinConversation(request);
+            case LOGOUT:
+                removeSession(request.getSenderId());
+                // Null is intentional: ConnectionHandler.handleSessionTransition owns LOGOUT
+                // session cleanup and already guards against a null response before sending.
+                return null;
+            default:
+                return null;
+        }
     }
 
-    private void distributeResponse(Response r, Set<String> userIDs) {
-        // TODO: send response to all active sessions in userIDs
+    private void broadcastResponse(Request request, Response response) {
+        if (request == null || request.getType() == null || response == null) {
+            return;
+        }
+        switch (request.getType()) {
+            case MESSAGE:
+                enqueueMessageBroadcast(request, response);
+                break;
+            case CREATE_CONVERSATION:
+                enqueueCreateConversationBroadcast(response);
+                break;
+            case ADD_PARTICIPANT:
+                enqueueAddParticipantBroadcast(request, response);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void enqueueToActiveParticipants(ArrayList<UserInfo> participants, Response response) {
+        for (UserInfo participant : participants) {
+            if (participant == null || participant.getUserId() == null) continue;
+            String id = participant.getUserId();
+            if (hasActiveSession(id)) {
+                responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(id, response));
+            }
+        }
+    }
+
+    private void enqueueMessageBroadcast(Request request, Response response) {
+        if (!(response.getPayload() instanceof Message)) return;
+        Message message = (Message) response.getPayload();
+        enqueueToActiveParticipants(dataManager.getParticipantList(message.getConversationId()), response);
+    }
+
+    private void enqueueCreateConversationBroadcast(Response response) {
+        if (!(response.getPayload() instanceof Conversation)) return;
+        Conversation conversation = (Conversation) response.getPayload();
+        enqueueToActiveParticipants(dataManager.getParticipantList(conversation.getConversationId()), response);
+    }
+
+    private void enqueueAddParticipantBroadcast(Request request, Response response) {
+        if (!(response.getPayload() instanceof Conversation)
+                || !(request.getPayload() instanceof AddToConversationPayload)) {
+            return;
+        }
+        Conversation conversation = (Conversation) response.getPayload();
+        AddToConversationPayload payload = (AddToConversationPayload) request.getPayload();
+        // addedIds comes from the request payload (who was requested to be added).
+        // For GROUP conversations the response ID equals the request's targetConversationId.
+        // For PRIVATE forks DataManager assigns a new ID to the forked conversation;
+        // payload.getParticipants() still correctly identifies the newly added users in both cases
+        // because DataManager only forks participants from the payload into the new conversation.
+        Set<String> addedIds = new HashSet<>();
+        ArrayList<UserInfo> participantsToAdd = payload.getParticipants();
+        if (participantsToAdd != null) {
+            for (UserInfo p : participantsToAdd) {
+                if (p != null && p.getUserId() != null) addedIds.add(p.getUserId());
+            }
+        }
+        Response metadataResponse = new Response(ResponseType.CONVERSATION, conversation.toMetadata());
+        for (UserInfo participant : dataManager.getParticipantList(conversation.getConversationId())) {
+            if (participant == null || participant.getUserId() == null) continue;
+            String id = participant.getUserId();
+            if (!hasActiveSession(id)) continue;
+            // Newly added participants receive the full Conversation; existing members get metadata.
+            Response delivery = addedIds.contains(id) ? response : metadataResponse;
+            responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(id, delivery));
+        }
+    }
+
+    private void startConnectionListenerThread() {
+        Thread t = new Thread(() -> connectionListener.listen(), "server-listener");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    private void startBroadcasterThread() {
+        broadcasterThread = new Thread(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    Map.Entry<String, Response> queued = responseQueue.take();
+                    ConnectionHandler handler = activeSessions.get(queued.getKey());
+                    if (handler != null) {
+                        handler.sendResponse(queued.getValue());
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }, "server-broadcast");
+        broadcasterThread.setDaemon(true);
+        broadcasterThread.start();
     }
 
     public boolean hasActiveSession(String userId) {

--- a/test/server/ServerControllerTest.java
+++ b/test/server/ServerControllerTest.java
@@ -1,0 +1,344 @@
+package server;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import shared.enums.RequestType;
+import shared.enums.ResponseType;
+import shared.enums.LoginStatus;
+import shared.enums.RegisterStatus;
+import shared.enums.UserType;
+import shared.networking.ConnectionHandler;
+import shared.networking.Request;
+import shared.networking.Response;
+import shared.networking.User;
+import shared.payload.AdminConversationQuery;
+import shared.payload.AddToConversationPayload;
+import shared.payload.Conversation;
+import shared.payload.ConversationMetadata;
+import shared.payload.CreateConversationPayload;
+import shared.payload.JoinConversationPayload;
+import shared.payload.LeaveConversationPayload;
+import shared.payload.LoginCredentials;
+import shared.payload.LoginResult;
+import shared.payload.Message;
+import shared.payload.RawMessage;
+import shared.payload.RegisterCredentials;
+import shared.payload.RegisterResult;
+import shared.payload.RequestPayload;
+import shared.payload.UpdateReadMessages;
+
+@Timeout(value = 20, unit = TimeUnit.SECONDS)
+class ServerControllerTest {
+
+    @TempDir
+    Path tempRoot;
+
+    private ServerController server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.close();
+            server = null;
+        }
+    }
+
+    @Test
+    void nullRequestReturnsNull() throws Exception {
+        server = buildServerWithStub();
+
+        assertNull(server.processRequest(null));
+        assertNull(server.processRequest(new Request(null, (RequestPayload) null, "u1")));
+    }
+
+    @Test
+    void registerDispatchesWithStatuses() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.REGISTER,
+                new Response(ResponseType.REGISTER_RESULT, new RegisterResult(RegisterStatus.SUCCESS)));
+        server = buildServerWithStub(stub);
+
+        Response registerResponse = server.processRequest(new Request(
+                RequestType.REGISTER,
+                new RegisterCredentials("u1", "login1", "pw", "Alice"),
+                null));
+
+        assertEquals(ResponseType.REGISTER_RESULT, registerResponse.getType());
+        assertTrue(registerResponse.getPayload() instanceof RegisterResult);
+        assertEquals(RegisterStatus.SUCCESS, ((RegisterResult) registerResponse.getPayload()).getRegisterStatus());
+        assertEquals(RequestType.REGISTER, stub.lastCalled);
+
+        stub.responses.put(RequestType.REGISTER,
+                new Response(ResponseType.REGISTER_RESULT, new RegisterResult(RegisterStatus.USER_ID_TAKEN)));
+        Response registerTakenResponse = server.processRequest(new Request(
+                RequestType.REGISTER,
+                new RegisterCredentials("u1", "login1", "pw", "Alice"),
+                null));
+        assertEquals(RegisterStatus.USER_ID_TAKEN,
+                ((RegisterResult) registerTakenResponse.getPayload()).getRegisterStatus());
+    }
+
+    @Test
+    void loginDispatchesWithStatuses() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.LOGIN,
+                new Response(ResponseType.LOGIN_RESULT, new LoginResult(LoginStatus.SUCCESS, null, null)));
+        server = buildServerWithStub(stub);
+
+        Response loginResponse = server.processRequest(
+                new Request(RequestType.LOGIN, new LoginCredentials("login1", "pw"), null));
+        assertEquals(ResponseType.LOGIN_RESULT, loginResponse.getType());
+        assertTrue(loginResponse.getPayload() instanceof LoginResult);
+        assertEquals(LoginStatus.SUCCESS, ((LoginResult) loginResponse.getPayload()).getLoginStatus());
+        assertEquals(RequestType.LOGIN, stub.lastCalled);
+
+        stub.responses.put(RequestType.LOGIN,
+                new Response(ResponseType.LOGIN_RESULT, new LoginResult(LoginStatus.INVALID_CREDENTIALS, null, null)));
+        Response loginInvalidResponse = server.processRequest(
+                new Request(RequestType.LOGIN, new LoginCredentials("login1", "pw"), null));
+        assertEquals(LoginStatus.INVALID_CREDENTIALS,
+                ((LoginResult) loginInvalidResponse.getPayload()).getLoginStatus());
+    }
+
+    @Test
+    void updateReadDispatches() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.UPDATE_READ, new Response(ResponseType.READ_UPDATED));
+        server = buildServerWithStub(stub);
+
+        Response response = server.processRequest(
+                new Request(RequestType.UPDATE_READ, new UpdateReadMessages(1L, 2L), "u1"));
+        assertEquals(ResponseType.READ_UPDATED, response.getType());
+        assertEquals(RequestType.UPDATE_READ, stub.lastCalled);
+    }
+
+    @Test
+    void leaveConversationDispatches() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.LEAVE_CONVERSATION, new Response(ResponseType.LEAVE_RESULT));
+        server = buildServerWithStub(stub);
+
+        Response response = server.processRequest(
+                new Request(RequestType.LEAVE_CONVERSATION, new LeaveConversationPayload(1L), "u1"));
+        assertEquals(ResponseType.LEAVE_RESULT, response.getType());
+        assertEquals(RequestType.LEAVE_CONVERSATION, stub.lastCalled);
+    }
+
+    @Test
+    void adminQueryDispatches() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.ADMIN_CONVERSATION_QUERY, new Response(ResponseType.ADMIN_CONVERSATION_RESULT));
+        server = buildServerWithStub(stub);
+
+        Response response = server.processRequest(
+                new Request(RequestType.ADMIN_CONVERSATION_QUERY, new AdminConversationQuery("u2"), "u1"));
+        assertEquals(ResponseType.ADMIN_CONVERSATION_RESULT, response.getType());
+        assertEquals(RequestType.ADMIN_CONVERSATION_QUERY, stub.lastCalled);
+    }
+
+    @Test
+    void joinConversationDispatches() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.JOIN_CONVERSATION, new Response(ResponseType.CONVERSATION));
+        server = buildServerWithStub(stub);
+
+        Response response = server.processRequest(
+                new Request(RequestType.JOIN_CONVERSATION, new JoinConversationPayload(1L), "u1"));
+        assertEquals(ResponseType.CONVERSATION, response.getType());
+        assertEquals(RequestType.JOIN_CONVERSATION, stub.lastCalled);
+    }
+
+    @Test
+    void enqueueBroadcastCandidates() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        Response messageResp = new Response(ResponseType.MESSAGE, new Message("hi", 7L, new java.util.Date(), "u1", 11L));
+        Response createResp = new Response(ResponseType.CONVERSATION, new Conversation(22L, participants("u1", "u2", "u3")));
+        Response addResp = new Response(ResponseType.CONVERSATION, new Conversation(33L, participants("u1", "u2", "u3", "u4")));
+        stub.responses.put(RequestType.MESSAGE, messageResp);
+        stub.responses.put(RequestType.CREATE_CONVERSATION, createResp);
+        stub.responses.put(RequestType.ADD_PARTICIPANT, addResp);
+        stub.participantsByConversationId.put(11L, participants("u1", "u2", "u3"));
+        stub.participantsByConversationId.put(22L, participants("u1", "u2", "u3"));
+        stub.participantsByConversationId.put(33L, participants("u1", "u2", "u3", "u4"));
+
+        server = buildServerWithStub(stub);
+        LinkedBlockingQueue<Map.Entry<String, Response>> queue = getResponseQueue(server);
+        server.addSession("u1", noOpHandler());
+        server.addSession("u2", noOpHandler());
+        server.addSession("u3", noOpHandler());
+        server.addSession("u4", noOpHandler());
+
+        assertEquals(ResponseType.MESSAGE, server.processRequest(
+                new Request(RequestType.MESSAGE, new RawMessage("hi", 1L), "u1")).getType());
+        assertQueuedRecipients(queue, Set.of("u1", "u2", "u3"), Message.class);
+
+        ArrayList<User.UserInfo> members = new ArrayList<>();
+        members.add(User.userInfo("u1", "Alice", UserType.USER));
+        assertEquals(ResponseType.CONVERSATION, server.processRequest(
+                new Request(RequestType.CREATE_CONVERSATION, new CreateConversationPayload(members), "u1")).getType());
+        assertQueuedRecipients(queue, Set.of("u1", "u2", "u3"), Conversation.class);
+
+        assertEquals(ResponseType.CONVERSATION, server.processRequest(
+                new Request(RequestType.ADD_PARTICIPANT,
+                        new AddToConversationPayload(participants("u4"), 33L),
+                        "u1")).getType());
+        Map.Entry<String, Response> d1 = queue.poll();
+        Map.Entry<String, Response> d2 = queue.poll();
+        Map.Entry<String, Response> d3 = queue.poll();
+        Map.Entry<String, Response> d4 = queue.poll();
+        assertNotNull(d1);
+        assertNotNull(d2);
+        assertNotNull(d3);
+        assertNotNull(d4);
+        Map<String, Response> deliveries = Map.of(
+                d1.getKey(), d1.getValue(),
+                d2.getKey(), d2.getValue(),
+                d3.getKey(), d3.getValue(),
+                d4.getKey(), d4.getValue());
+        assertEquals(Set.of("u1", "u2", "u3", "u4"), deliveries.keySet());
+        assertTrue(deliveries.get("u4").getPayload() instanceof Conversation);
+        assertTrue(deliveries.get("u1").getPayload() instanceof ConversationMetadata);
+        assertTrue(deliveries.get("u2").getPayload() instanceof ConversationMetadata);
+        assertTrue(deliveries.get("u3").getPayload() instanceof ConversationMetadata);
+        assertNull(queue.poll());
+    }
+
+    @Test
+    void logoutRemovesSession() throws Exception {
+        server = buildServerWithStub();
+        server.addSession("u1", noOpHandler());
+        assertTrue(server.hasActiveSession("u1"));
+
+        Response out = server.processRequest(new Request(RequestType.LOGOUT, (RequestPayload) null, "u1"));
+
+        assertNull(out);
+        assertFalse(server.hasActiveSession("u1"));
+    }
+
+    private ServerController buildServerWithStub() throws Exception {
+        return buildServerWithStub(new StubDataManager(testDataRoot().toString()));
+    }
+
+    private ServerController buildServerWithStub(StubDataManager stub) throws Exception {
+        ServerController c = new ServerController(testDataRoot().toString(), 0, false);
+        setField(c, "dataManager", stub);
+        return c;
+    }
+
+    /** Returns a ConnectionHandler stub that performs no I/O — safe for unit tests. */
+    private static ConnectionHandler noOpHandler() {
+        return new ConnectionHandler(null, null) {
+            @Override public void sendResponse(Response r) {}
+            @Override public void close() {}
+        };
+    }
+
+    private Path testDataRoot() throws IOException {
+        Path testData = tempRoot.resolve("test_data");
+        prepareMinimalDataTree(testData);
+        return testData;
+    }
+
+    private static void prepareMinimalDataTree(Path root) throws IOException {
+        Path serverData = root.resolve("server_data");
+        Path authorizedIds = serverData.resolve("authorized_ids");
+        Files.createDirectories(authorizedIds);
+        Files.writeString(authorizedIds.resolve("authorized_users.txt"), "u1,Alice\nu2,Bob\n");
+        Files.writeString(authorizedIds.resolve("authorized_admins.txt"), "");
+        Files.writeString(serverData.resolve("server_config.txt"), "");
+        Files.createDirectories(root.resolve("conversation_data"));
+        Files.createDirectories(root.resolve("user_data"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static LinkedBlockingQueue<Map.Entry<String, Response>> getResponseQueue(ServerController c) throws Exception {
+        Field f = ServerController.class.getDeclaredField("responseQueue");
+        f.setAccessible(true);
+        return (LinkedBlockingQueue<Map.Entry<String, Response>>) f.get(c);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    private static void assertQueuedRecipients(
+            LinkedBlockingQueue<Map.Entry<String, Response>> queue,
+            Set<String> expectedRecipients,
+            Class<?> expectedPayloadType) {
+        Map.Entry<String, Response> d1 = queue.poll();
+        Map.Entry<String, Response> d2 = queue.poll();
+        Map.Entry<String, Response> d3 = queue.poll();
+        assertNotNull(d1);
+        assertNotNull(d2);
+        assertNotNull(d3);
+        Map<String, Response> deliveries = Map.of(
+                d1.getKey(), d1.getValue(),
+                d2.getKey(), d2.getValue(),
+                d3.getKey(), d3.getValue());
+        assertEquals(expectedRecipients, deliveries.keySet());
+        for (Response response : deliveries.values()) {
+            assertTrue(expectedPayloadType.isInstance(response.getPayload()));
+        }
+        assertNull(queue.poll());
+    }
+
+    private static ArrayList<User.UserInfo> participants(String... ids) {
+        ArrayList<User.UserInfo> out = new ArrayList<>();
+        for (String id : ids) {
+            out.add(User.userInfo(id, id.toUpperCase(), UserType.USER));
+        }
+        return out;
+    }
+
+    private static class StubDataManager extends DataManager {
+        final Map<RequestType, Response> responses = new EnumMap<>(RequestType.class);
+        final Map<Long, ArrayList<User.UserInfo>> participantsByConversationId = new HashMap<>();
+        RequestType lastCalled;
+
+        StubDataManager(String dataRootPath) {
+            super(dataRootPath);
+        }
+
+        private Response hit(RequestType type) {
+            lastCalled = type;
+            return responses.get(type);
+        }
+
+        @Override public Response handleRegister(Request request) { return hit(RequestType.REGISTER); }
+        @Override public Response handleLogin(Request request) { return hit(RequestType.LOGIN); }
+        @Override public Response handleSendMessage(Request request) { return hit(RequestType.MESSAGE); }
+        @Override public Response handleUpdateReadMessages(Request request) { return hit(RequestType.UPDATE_READ); }
+        @Override public Response handleCreateConversation(Request request) { return hit(RequestType.CREATE_CONVERSATION); }
+        @Override public Response handleAddToConversation(Request request) { return hit(RequestType.ADD_PARTICIPANT); }
+        @Override public Response handleLeaveConversation(Request request) { return hit(RequestType.LEAVE_CONVERSATION); }
+        @Override public Response handleAdminConversationQuery(Request request) { return hit(RequestType.ADMIN_CONVERSATION_QUERY); }
+        @Override public Response handleJoinConversation(Request request) { return hit(RequestType.JOIN_CONVERSATION); }
+        @Override public ArrayList<User.UserInfo> getParticipantList(long conversationId) {
+            ArrayList<User.UserInfo> participants = participantsByConversationId.get(conversationId);
+            if (participants == null) {
+                return new ArrayList<>();
+            }
+            return new ArrayList<>(participants);
+        }
+    }
+}
+


### PR DESCRIPTION
1. Added clarity-focused field renames in ClientUI for cross-component readability.
2. Added null checks in high-risk UI paths (dialogs, selection-dependent actions, admin search model access).
3. Refactored AdminConversationSearchWindow model/list typing from Conversation to ConversationMetadata.
4. Added logic to repaint/update ConversationView when a new conversation is selected.
5. Refactored admin button construction/usage so visibility is toggled lazily at login/main-view time.
6. Wrapped setText UI updates in SwingUtilities.invokeLater where needed for EDT safety.
7. Removed showAdminMainView and routed main-view transitions through showMainView.
8. Removed redundant pass-through accessor methods in ClientUI and rewired top-level getters directly to nested components.
9. Toggled admin controls off on logout by hiding the admin button when returning to login view (showLoginView), preventing stale admin UI state across sessions.