### PR TITLE
ServerController broadcast logic improvements, added ServerController test suite, refactored DataManager test suite

### DIFF
--- a/src/server/ServerController.java
+++ b/src/server/ServerController.java
@@ -1,13 +1,12 @@
 package server;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.AbstractMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import shared.enums.ResponseType;
 import shared.networking.ConnectionHandler;
@@ -27,46 +26,57 @@ public class ServerController {
     private Thread broadcasterThread;
 
     public static void main(String[] args) {
-        try {
-            String localhost = InetAddress.getLocalHost().getHostAddress();
-            ServerController serverController = new ServerController(localhost, 8080);
-            keepAliveUntilInterrupted(serverController);
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
-        }
+        // First CLI arg is the data root path; port is fixed at 8080.
+        String dataRootPath = args.length > 0 ? args[0] : "data";
+        ServerController serverController = new ServerController(dataRootPath, 8080);
+        keepAliveUntilInterrupted(serverController);
     }
 
     private static void keepAliveUntilInterrupted(ServerController serverController) {
-        while (!Thread.currentThread().isInterrupted()) {
-            try {
-                Thread.sleep(1000L);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                serverController.close();
-                break;
-            }
+        CountDownLatch latch = new CountDownLatch(1);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            latch.countDown();
+            serverController.close();
+        }, "server-shutdown"));
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            serverController.close();
         }
     }
 
     public ServerController(String dataRootPath, int port) {
+        this(dataRootPath, port, true);
+    }
+
+    /**
+     * Package-private: pass {@code startBroadcaster=false} in tests that need to
+     * inspect the raw response queue without a draining thread racing against assertions.
+     */
+    ServerController(String dataRootPath, int port, boolean startBroadcaster) {
         this.activeSessions = new ConcurrentHashMap<>();
         this.dataManager = new DataManager(dataRootPath);
         this.connectionListener = new ConnectionListener(port, this);
         this.responseQueue = new LinkedBlockingQueue<>();
-        startBroadcasterThread();
+        if (startBroadcaster) startBroadcasterThread();
         startConnectionListenerThread();
     }
 
     public void close() {
-        if (broadcasterThread != null) {
-            broadcasterThread.interrupt();
-        }
+        // 1. Stop accepting new connections first so no new responses are enqueued.
         if (connectionListener != null) {
             connectionListener.close();
         }
+        // 2. Stop the broadcaster after the listener is closed.
+        if (broadcasterThread != null) {
+            broadcasterThread.interrupt();
+        }
+        // 3. Flush and close persistent storage.
         if (dataManager != null) {
             dataManager.close();
         }
+        // 4. Close active client connections.
         for (ConnectionHandler handler : activeSessions.values()) {
             if (handler != null) {
                 handler.close();
@@ -106,6 +116,8 @@ public class ServerController {
                 return dataManager.handleJoinConversation(request);
             case LOGOUT:
                 removeSession(request.getSenderId());
+                // Null is intentional: ConnectionHandler.handleSessionTransition owns LOGOUT
+                // session cleanup and already guards against a null response before sending.
                 return null;
             default:
                 return null;
@@ -131,40 +143,26 @@ public class ServerController {
         }
     }
 
-    private void enqueueMessageBroadcast(Request request, Response response) {
-        if (!(response.getPayload() instanceof Message)) {
-            return;
-        }
-        Message message = (Message) response.getPayload();
-        ArrayList<UserInfo> participants = dataManager.getParticipantList(message.getConversationId());
+    private void enqueueToActiveParticipants(ArrayList<UserInfo> participants, Response response) {
         for (UserInfo participant : participants) {
-            if (participant == null || participant.getUserId() == null) {
-                continue;
+            if (participant == null || participant.getUserId() == null) continue;
+            String id = participant.getUserId();
+            if (hasActiveSession(id)) {
+                responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(id, response));
             }
-            String participantId = participant.getUserId();
-            if (!hasActiveSession(participantId)) {
-                continue;
-            }
-            responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(participantId, response));
         }
     }
 
+    private void enqueueMessageBroadcast(Request request, Response response) {
+        if (!(response.getPayload() instanceof Message)) return;
+        Message message = (Message) response.getPayload();
+        enqueueToActiveParticipants(dataManager.getParticipantList(message.getConversationId()), response);
+    }
+
     private void enqueueCreateConversationBroadcast(Response response) {
-        if (!(response.getPayload() instanceof Conversation)) {
-            return;
-        }
+        if (!(response.getPayload() instanceof Conversation)) return;
         Conversation conversation = (Conversation) response.getPayload();
-        ArrayList<UserInfo> participants = dataManager.getParticipantList(conversation.getConversationId());
-        for (UserInfo participant : participants) {
-            if (participant == null || participant.getUserId() == null) {
-                continue;
-            }
-            String participantId = participant.getUserId();
-            if (!hasActiveSession(participantId)) {
-                continue;
-            }
-            responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(participantId, response));
-        }
+        enqueueToActiveParticipants(dataManager.getParticipantList(conversation.getConversationId()), response);
     }
 
     private void enqueueAddParticipantBroadcast(Request request, Response response) {
@@ -174,26 +172,26 @@ public class ServerController {
         }
         Conversation conversation = (Conversation) response.getPayload();
         AddToConversationPayload payload = (AddToConversationPayload) request.getPayload();
-        Set<String> addedParticipantIds = new HashSet<>();
+        // addedIds comes from the request payload (who was requested to be added).
+        // For GROUP conversations the response ID equals the request's targetConversationId.
+        // For PRIVATE forks DataManager assigns a new ID to the forked conversation;
+        // payload.getParticipants() still correctly identifies the newly added users in both cases
+        // because DataManager only forks participants from the payload into the new conversation.
+        Set<String> addedIds = new HashSet<>();
         ArrayList<UserInfo> participantsToAdd = payload.getParticipants();
         if (participantsToAdd != null) {
-            for (UserInfo participant : participantsToAdd) {
-                if (participant != null && participant.getUserId() != null) {
-                    addedParticipantIds.add(participant.getUserId());
-                }
+            for (UserInfo p : participantsToAdd) {
+                if (p != null && p.getUserId() != null) addedIds.add(p.getUserId());
             }
         }
         Response metadataResponse = new Response(ResponseType.CONVERSATION, conversation.toMetadata());
         for (UserInfo participant : dataManager.getParticipantList(conversation.getConversationId())) {
-            if (participant == null || participant.getUserId() == null) {
-                continue;
-            }
-            String participantId = participant.getUserId();
-            if (!hasActiveSession(participantId)) {
-                continue;
-            }
-            Response delivery = addedParticipantIds.contains(participantId) ? response : metadataResponse;
-            responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(participantId, delivery));
+            if (participant == null || participant.getUserId() == null) continue;
+            String id = participant.getUserId();
+            if (!hasActiveSession(id)) continue;
+            // Newly added participants receive the full Conversation; existing members get metadata.
+            Response delivery = addedIds.contains(id) ? response : metadataResponse;
+            responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(id, delivery));
         }
     }
 

--- a/src/server/ServerController.java
+++ b/src/server/ServerController.java
@@ -1,47 +1,159 @@
 package server;
 
-import java.io.File;
 import java.util.*;
 import java.util.concurrent.*;
 import shared.networking.*;
+import shared.enums.ResponseType;
+import shared.networking.User.UserInfo;
+import shared.payload.*;
+import java.net.*;
+
 
 public class ServerController {
-    private final File dataRoot;
     private Map<String, ConnectionHandler> activeSessions;
     private DataManager dataManager;
     private ConnectionListener connectionListener;
+    private final LinkedBlockingQueue<Response> broadcasterQueue;
+    private Thread broadcasterThread;
 
     public static void main(String[] args) {
-        // TODO: parse args, instantiate ServerController
+        try {
+            String localhost = InetAddress.getLocalHost().getHostAddress();
+            ServerController serverController = new ServerController(localhost,8080);
+            keepAliveUntilInterrupted(serverController);
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void keepAliveUntilInterrupted(ServerController serverController) {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                Thread.sleep(1000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                serverController.close();
+                break;
+            }
+        }
     }
 
     public ServerController(String dataRootPath, int port) {
-        this.dataRoot = new File(dataRootPath);
         this.activeSessions = new ConcurrentHashMap<>();
         this.dataManager = new DataManager(dataRootPath);
         this.connectionListener = new ConnectionListener(port, this);
-        // TODO: start listening
-    }
-
-    /** Directory passed at construction; same root given to {@link DataManager}. */
-    public File getDataRoot() {
-        return dataRoot;
+        this.broadcasterQueue = new LinkedBlockingQueue<>();
+        startBroadcasterThread();
+        startConnectionListenerThread();
     }
 
     public void close() {
+        if (broadcasterThread != null) {
+            broadcasterThread.interrupt();
+        }
+        if (connectionListener != null) {
+            connectionListener.close();
+        }
         if (dataManager != null) {
             dataManager.close();
         }
-        // TODO: shut down listener and active sessions
+        for (ConnectionHandler handler : activeSessions.values()) {
+            if (handler != null) {
+                handler.close();
+            }
+        }
     }
 
     public Response processRequest(Request request) {
-        // TODO: dispatch to DataManager based on request type
-        return null;
+        if (request == null || request.getType() == null) return null;
+        switch (request.getType()) {
+            case REGISTER: {
+                return dataManager.handleRegister(request);
+            }
+            case LOGIN: {
+                return dataManager.handleLogin(request);
+            }
+            case MESSAGE: {
+                Response response = dataManager.handleSendMessage(request);
+                enqueueForBroadcast(response);
+                return response;
+            }
+            case UPDATE_READ: {
+                return dataManager.handleUpdateReadMessages(request);
+            }
+            case CREATE_CONVERSATION: {
+                Response response = dataManager.handleCreateConversation(request);
+                enqueueForBroadcast(response);
+                return response;
+            }
+            case ADD_PARTICIPANT: {
+                Response response = dataManager.handleAddToConversation(request);
+                enqueueForBroadcast(response);
+                return response;
+            }
+            case LEAVE_CONVERSATION: {
+                return dataManager.handleLeaveConversation(request);
+            }
+            case ADMIN_CONVERSATION_QUERY: {
+                return dataManager.handleAdminConversationQuery(request);
+            }
+            case JOIN_CONVERSATION: {
+                return dataManager.handleJoinConversation(request);
+            }
+            case LOGOUT: {
+                removeSession(request.getSenderId());
+            }
+            default:
+                // Session / heartbeat concerns are handled outside DataManager handlers.
+                return null;
+        }
     }
 
-    private void distributeResponse(Response r, Set<String> userIDs) {
-        // TODO: send response to all active sessions in userIDs
+    private void enqueueForBroadcast(Response response) {
+        if (response == null) return;
+        broadcasterQueue.offer(response);
+    }
+
+    private void startBroadcasterThread() {
+        broadcasterThread = new Thread(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    Response response = broadcasterQueue.take();
+                    if (response.getType() != ResponseType.MESSAGE
+                            || !(response.getPayload() instanceof Message)) {
+                        continue;
+                    }
+
+                    Message message = (Message) response.getPayload();
+                    ArrayList<UserInfo> participants = dataManager.getParticipantList(message.getConversationId());
+                    Set<String> activeUserIds = activeSessions.keySet();
+
+                    for (UserInfo participant : participants) {
+                        if (participant == null || participant.getUserId() == null) {
+                            continue;
+                        }
+                        String participantId = participant.getUserId();
+                        if (activeUserIds.contains(participantId)) {
+                            ConnectionHandler handler = activeSessions.get(participantId);
+                            if (handler != null) {
+                                handler.sendResponse(response);
+                            }
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }, "server-broadcast");
+        broadcasterThread.setDaemon(true);
+        broadcasterThread.start();
+    }
+
+    private void startConnectionListenerThread() {
+        Thread t = new Thread(() -> connectionListener.listen(), "server-listener");
+        t.setDaemon(true);
+        t.start();
     }
 
     public boolean hasActiveSession(String userId) {

--- a/src/server/ServerController.java
+++ b/src/server/ServerController.java
@@ -1,25 +1,35 @@
 package server;
 
-import java.util.*;
-import java.util.concurrent.*;
-import shared.networking.*;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.AbstractMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
 import shared.enums.ResponseType;
+import shared.networking.ConnectionHandler;
+import shared.networking.ConnectionListener;
+import shared.networking.Request;
+import shared.networking.Response;
 import shared.networking.User.UserInfo;
-import shared.payload.*;
-import java.net.*;
-
+import shared.payload.AddToConversationPayload;
+import shared.payload.Conversation;
+import shared.payload.Message;
 
 public class ServerController {
     private Map<String, ConnectionHandler> activeSessions;
     private DataManager dataManager;
     private ConnectionListener connectionListener;
-    private final LinkedBlockingQueue<Response> broadcasterQueue;
+    private final LinkedBlockingQueue<Map.Entry<String, Response>> responseQueue;
     private Thread broadcasterThread;
 
     public static void main(String[] args) {
         try {
             String localhost = InetAddress.getLocalHost().getHostAddress();
-            ServerController serverController = new ServerController(localhost,8080);
+            ServerController serverController = new ServerController(localhost, 8080);
             keepAliveUntilInterrupted(serverController);
         } catch (UnknownHostException e) {
             e.printStackTrace();
@@ -42,7 +52,7 @@ public class ServerController {
         this.activeSessions = new ConcurrentHashMap<>();
         this.dataManager = new DataManager(dataRootPath);
         this.connectionListener = new ConnectionListener(port, this);
-        this.broadcasterQueue = new LinkedBlockingQueue<>();
+        this.responseQueue = new LinkedBlockingQueue<>();
         startBroadcasterThread();
         startConnectionListenerThread();
     }
@@ -67,78 +77,140 @@ public class ServerController {
     public Response processRequest(Request request) {
         if (request == null || request.getType() == null) return null;
         switch (request.getType()) {
-            case REGISTER: {
+            case REGISTER:
                 return dataManager.handleRegister(request);
-            }
-            case LOGIN: {
+            case LOGIN:
                 return dataManager.handleLogin(request);
-            }
             case MESSAGE: {
                 Response response = dataManager.handleSendMessage(request);
-                enqueueForBroadcast(response);
+                broadcastResponse(request, response);
                 return response;
             }
-            case UPDATE_READ: {
+            case UPDATE_READ:
                 return dataManager.handleUpdateReadMessages(request);
-            }
             case CREATE_CONVERSATION: {
                 Response response = dataManager.handleCreateConversation(request);
-                enqueueForBroadcast(response);
+                broadcastResponse(request, response);
                 return response;
             }
             case ADD_PARTICIPANT: {
                 Response response = dataManager.handleAddToConversation(request);
-                enqueueForBroadcast(response);
+                broadcastResponse(request, response);
                 return response;
             }
-            case LEAVE_CONVERSATION: {
+            case LEAVE_CONVERSATION:
                 return dataManager.handleLeaveConversation(request);
-            }
-            case ADMIN_CONVERSATION_QUERY: {
+            case ADMIN_CONVERSATION_QUERY:
                 return dataManager.handleAdminConversationQuery(request);
-            }
-            case JOIN_CONVERSATION: {
+            case JOIN_CONVERSATION:
                 return dataManager.handleJoinConversation(request);
-            }
-            case LOGOUT: {
+            case LOGOUT:
                 removeSession(request.getSenderId());
-            }
+                return null;
             default:
-                // Session / heartbeat concerns are handled outside DataManager handlers.
                 return null;
         }
     }
 
-    private void enqueueForBroadcast(Response response) {
-        if (response == null) return;
-        broadcasterQueue.offer(response);
+    private void broadcastResponse(Request request, Response response) {
+        if (request == null || request.getType() == null || response == null) {
+            return;
+        }
+        switch (request.getType()) {
+            case MESSAGE:
+                enqueueMessageBroadcast(request, response);
+                break;
+            case CREATE_CONVERSATION:
+                enqueueCreateConversationBroadcast(response);
+                break;
+            case ADD_PARTICIPANT:
+                enqueueAddParticipantBroadcast(request, response);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void enqueueMessageBroadcast(Request request, Response response) {
+        if (!(response.getPayload() instanceof Message)) {
+            return;
+        }
+        Message message = (Message) response.getPayload();
+        ArrayList<UserInfo> participants = dataManager.getParticipantList(message.getConversationId());
+        for (UserInfo participant : participants) {
+            if (participant == null || participant.getUserId() == null) {
+                continue;
+            }
+            String participantId = participant.getUserId();
+            if (!hasActiveSession(participantId)) {
+                continue;
+            }
+            responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(participantId, response));
+        }
+    }
+
+    private void enqueueCreateConversationBroadcast(Response response) {
+        if (!(response.getPayload() instanceof Conversation)) {
+            return;
+        }
+        Conversation conversation = (Conversation) response.getPayload();
+        ArrayList<UserInfo> participants = dataManager.getParticipantList(conversation.getConversationId());
+        for (UserInfo participant : participants) {
+            if (participant == null || participant.getUserId() == null) {
+                continue;
+            }
+            String participantId = participant.getUserId();
+            if (!hasActiveSession(participantId)) {
+                continue;
+            }
+            responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(participantId, response));
+        }
+    }
+
+    private void enqueueAddParticipantBroadcast(Request request, Response response) {
+        if (!(response.getPayload() instanceof Conversation)
+                || !(request.getPayload() instanceof AddToConversationPayload)) {
+            return;
+        }
+        Conversation conversation = (Conversation) response.getPayload();
+        AddToConversationPayload payload = (AddToConversationPayload) request.getPayload();
+        Set<String> addedParticipantIds = new HashSet<>();
+        ArrayList<UserInfo> participantsToAdd = payload.getParticipants();
+        if (participantsToAdd != null) {
+            for (UserInfo participant : participantsToAdd) {
+                if (participant != null && participant.getUserId() != null) {
+                    addedParticipantIds.add(participant.getUserId());
+                }
+            }
+        }
+        Response metadataResponse = new Response(ResponseType.CONVERSATION, conversation.toMetadata());
+        for (UserInfo participant : dataManager.getParticipantList(conversation.getConversationId())) {
+            if (participant == null || participant.getUserId() == null) {
+                continue;
+            }
+            String participantId = participant.getUserId();
+            if (!hasActiveSession(participantId)) {
+                continue;
+            }
+            Response delivery = addedParticipantIds.contains(participantId) ? response : metadataResponse;
+            responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(participantId, delivery));
+        }
+    }
+
+    private void startConnectionListenerThread() {
+        Thread t = new Thread(() -> connectionListener.listen(), "server-listener");
+        t.setDaemon(true);
+        t.start();
     }
 
     private void startBroadcasterThread() {
         broadcasterThread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
                 try {
-                    Response response = broadcasterQueue.take();
-                    if (response.getType() != ResponseType.MESSAGE
-                            || !(response.getPayload() instanceof Message)) {
-                        continue;
-                    }
-
-                    Message message = (Message) response.getPayload();
-                    ArrayList<UserInfo> participants = dataManager.getParticipantList(message.getConversationId());
-                    Set<String> activeUserIds = activeSessions.keySet();
-
-                    for (UserInfo participant : participants) {
-                        if (participant == null || participant.getUserId() == null) {
-                            continue;
-                        }
-                        String participantId = participant.getUserId();
-                        if (activeUserIds.contains(participantId)) {
-                            ConnectionHandler handler = activeSessions.get(participantId);
-                            if (handler != null) {
-                                handler.sendResponse(response);
-                            }
-                        }
+                    Map.Entry<String, Response> queued = responseQueue.take();
+                    ConnectionHandler handler = activeSessions.get(queued.getKey());
+                    if (handler != null) {
+                        handler.sendResponse(queued.getValue());
                     }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
@@ -148,12 +220,6 @@ public class ServerController {
         }, "server-broadcast");
         broadcasterThread.setDaemon(true);
         broadcasterThread.start();
-    }
-
-    private void startConnectionListenerThread() {
-        Thread t = new Thread(() -> connectionListener.listen(), "server-listener");
-        t.setDaemon(true);
-        t.start();
     }
 
     public boolean hasActiveSession(String userId) {

--- a/src/server/ServerController.java
+++ b/src/server/ServerController.java
@@ -2,9 +2,7 @@ package server;
 
 import java.util.ArrayList;
 import java.util.AbstractMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -172,26 +170,28 @@ public class ServerController {
         }
         Conversation conversation = (Conversation) response.getPayload();
         AddToConversationPayload payload = (AddToConversationPayload) request.getPayload();
-        // addedIds comes from the request payload (who was requested to be added).
-        // For GROUP conversations the response ID equals the request's targetConversationId.
-        // For PRIVATE forks DataManager assigns a new ID to the forked conversation;
-        // payload.getParticipants() still correctly identifies the newly added users in both cases
-        // because DataManager only forks participants from the payload into the new conversation.
-        Set<String> addedIds = new HashSet<>();
         ArrayList<UserInfo> participantsToAdd = payload.getParticipants();
-        if (participantsToAdd != null) {
-            for (UserInfo p : participantsToAdd) {
-                if (p != null && p.getUserId() != null) addedIds.add(p.getUserId());
-            }
-        }
-        Response metadataResponse = new Response(ResponseType.CONVERSATION, conversation.toMetadata());
-        for (UserInfo participant : dataManager.getParticipantList(conversation.getConversationId())) {
+        Response metadataResponse = new Response(ResponseType.CONVERSATION_METADATA, conversation.toMetadata());
+        ArrayList<UserInfo> existingParticipants = new ArrayList<>();
+        for (UserInfo participant : conversation.getParticipants()) {
             if (participant == null || participant.getUserId() == null) continue;
             String id = participant.getUserId();
-            if (!hasActiveSession(id)) continue;
-            // Newly added participants receive the full Conversation; existing members get metadata.
-            Response delivery = addedIds.contains(id) ? response : metadataResponse;
-            responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(id, delivery));
+            boolean isAddedParticipant = false;
+            if (participantsToAdd != null) {
+                for (UserInfo added : participantsToAdd) {
+                    if (added != null && id.equals(added.getUserId())) {
+                        isAddedParticipant = true;
+                        break;
+                    }
+                }
+            }
+            if (!isAddedParticipant) {
+                existingParticipants.add(participant);
+            }
+        }
+        enqueueToActiveParticipants(existingParticipants, metadataResponse);
+        if (participantsToAdd != null) {
+            enqueueToActiveParticipants(participantsToAdd, response);
         }
     }
 

--- a/test/server/ServerControllerTest.java
+++ b/test/server/ServerControllerTest.java
@@ -1,0 +1,343 @@
+package server;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import shared.enums.RequestType;
+import shared.enums.ResponseType;
+import shared.enums.LoginStatus;
+import shared.enums.RegisterStatus;
+import shared.enums.UserType;
+import shared.networking.Request;
+import shared.networking.Response;
+import shared.networking.User;
+import shared.payload.AdminConversationQuery;
+import shared.payload.AddToConversationPayload;
+import shared.payload.Conversation;
+import shared.payload.ConversationMetadata;
+import shared.payload.CreateConversationPayload;
+import shared.payload.JoinConversationPayload;
+import shared.payload.LeaveConversationPayload;
+import shared.payload.LoginCredentials;
+import shared.payload.LoginResult;
+import shared.payload.Message;
+import shared.payload.RawMessage;
+import shared.payload.RegisterCredentials;
+import shared.payload.RegisterResult;
+import shared.payload.RequestPayload;
+import shared.payload.UpdateReadMessages;
+
+@Timeout(value = 20, unit = TimeUnit.SECONDS)
+class ServerControllerTest {
+
+    @TempDir
+    Path tempRoot;
+
+    private ServerController server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.close();
+            server = null;
+        }
+    }
+
+    @Test
+    void nullRequestReturnsNull() throws Exception {
+        server = buildServerWithStub();
+
+        assertNull(server.processRequest(null));
+        assertNull(server.processRequest(new Request(null, (RequestPayload) null, "u1")));
+    }
+
+    @Test
+    void registerDispatchesWithStatuses() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.REGISTER,
+                new Response(ResponseType.REGISTER_RESULT, new RegisterResult(RegisterStatus.SUCCESS)));
+        server = buildServerWithStub(stub);
+
+        Response registerResponse = server.processRequest(new Request(
+                RequestType.REGISTER,
+                new RegisterCredentials("u1", "login1", "pw", "Alice"),
+                null));
+
+        assertEquals(ResponseType.REGISTER_RESULT, registerResponse.getType());
+        assertTrue(registerResponse.getPayload() instanceof RegisterResult);
+        assertEquals(RegisterStatus.SUCCESS, ((RegisterResult) registerResponse.getPayload()).getRegisterStatus());
+        assertEquals(RequestType.REGISTER, stub.lastCalled);
+
+        stub.responses.put(RequestType.REGISTER,
+                new Response(ResponseType.REGISTER_RESULT, new RegisterResult(RegisterStatus.USER_ID_TAKEN)));
+        Response registerTakenResponse = server.processRequest(new Request(
+                RequestType.REGISTER,
+                new RegisterCredentials("u1", "login1", "pw", "Alice"),
+                null));
+        assertEquals(RegisterStatus.USER_ID_TAKEN,
+                ((RegisterResult) registerTakenResponse.getPayload()).getRegisterStatus());
+    }
+
+    @Test
+    void loginDispatchesWithStatuses() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.LOGIN,
+                new Response(ResponseType.LOGIN_RESULT, new LoginResult(LoginStatus.SUCCESS, null, null)));
+        server = buildServerWithStub(stub);
+
+        Response loginResponse = server.processRequest(
+                new Request(RequestType.LOGIN, new LoginCredentials("login1", "pw"), null));
+        assertEquals(ResponseType.LOGIN_RESULT, loginResponse.getType());
+        assertTrue(loginResponse.getPayload() instanceof LoginResult);
+        assertEquals(LoginStatus.SUCCESS, ((LoginResult) loginResponse.getPayload()).getLoginStatus());
+        assertEquals(RequestType.LOGIN, stub.lastCalled);
+
+        stub.responses.put(RequestType.LOGIN,
+                new Response(ResponseType.LOGIN_RESULT, new LoginResult(LoginStatus.INVALID_CREDENTIALS, null, null)));
+        Response loginInvalidResponse = server.processRequest(
+                new Request(RequestType.LOGIN, new LoginCredentials("login1", "pw"), null));
+        assertEquals(LoginStatus.INVALID_CREDENTIALS,
+                ((LoginResult) loginInvalidResponse.getPayload()).getLoginStatus());
+    }
+
+    @Test
+    void updateReadDispatches() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.UPDATE_READ, new Response(ResponseType.READ_UPDATED));
+        server = buildServerWithStub(stub);
+
+        Response response = server.processRequest(
+                new Request(RequestType.UPDATE_READ, new UpdateReadMessages(1L, 2L), "u1"));
+        assertEquals(ResponseType.READ_UPDATED, response.getType());
+        assertEquals(RequestType.UPDATE_READ, stub.lastCalled);
+    }
+
+    @Test
+    void leaveConversationDispatches() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.LEAVE_CONVERSATION, new Response(ResponseType.LEAVE_RESULT));
+        server = buildServerWithStub(stub);
+
+        Response response = server.processRequest(
+                new Request(RequestType.LEAVE_CONVERSATION, new LeaveConversationPayload(1L), "u1"));
+        assertEquals(ResponseType.LEAVE_RESULT, response.getType());
+        assertEquals(RequestType.LEAVE_CONVERSATION, stub.lastCalled);
+    }
+
+    @Test
+    void adminQueryDispatches() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.ADMIN_CONVERSATION_QUERY, new Response(ResponseType.ADMIN_CONVERSATION_RESULT));
+        server = buildServerWithStub(stub);
+
+        Response response = server.processRequest(
+                new Request(RequestType.ADMIN_CONVERSATION_QUERY, new AdminConversationQuery("u2"), "u1"));
+        assertEquals(ResponseType.ADMIN_CONVERSATION_RESULT, response.getType());
+        assertEquals(RequestType.ADMIN_CONVERSATION_QUERY, stub.lastCalled);
+    }
+
+    @Test
+    void joinConversationDispatches() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.JOIN_CONVERSATION, new Response(ResponseType.CONVERSATION));
+        server = buildServerWithStub(stub);
+
+        Response response = server.processRequest(
+                new Request(RequestType.JOIN_CONVERSATION, new JoinConversationPayload(1L), "u1"));
+        assertEquals(ResponseType.CONVERSATION, response.getType());
+        assertEquals(RequestType.JOIN_CONVERSATION, stub.lastCalled);
+    }
+
+    @Test
+    void enqueueBroadcastCandidates() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        Response messageResp = new Response(ResponseType.MESSAGE, new Message("hi", 7L, new java.util.Date(), "u1", 11L));
+        Response createResp = new Response(ResponseType.CONVERSATION, new Conversation(22L, participants("u1", "u2", "u3")));
+        Response addResp = new Response(ResponseType.CONVERSATION, new Conversation(33L, participants("u1", "u2", "u3", "u4")));
+        stub.responses.put(RequestType.MESSAGE, messageResp);
+        stub.responses.put(RequestType.CREATE_CONVERSATION, createResp);
+        stub.responses.put(RequestType.ADD_PARTICIPANT, addResp);
+        stub.participantsByConversationId.put(11L, participants("u1", "u2", "u3"));
+        stub.participantsByConversationId.put(22L, participants("u1", "u2", "u3"));
+        stub.participantsByConversationId.put(33L, participants("u1", "u2", "u3", "u4"));
+
+        server = buildServerWithStub(stub);
+        interruptBroadcasterThread(server); // keep queue stable for deterministic assertions
+        LinkedBlockingQueue<Map.Entry<String, Response>> queue = getResponseQueue(server);
+        server.addSession("u1", new shared.networking.ConnectionHandler(new java.net.Socket(), server));
+        server.addSession("u2", new shared.networking.ConnectionHandler(new java.net.Socket(), server));
+        server.addSession("u3", new shared.networking.ConnectionHandler(new java.net.Socket(), server));
+        server.addSession("u4", new shared.networking.ConnectionHandler(new java.net.Socket(), server));
+
+        assertEquals(ResponseType.MESSAGE, server.processRequest(
+                new Request(RequestType.MESSAGE, new RawMessage("hi", 1L), "u1")).getType());
+        assertQueuedRecipients(queue, Set.of("u1", "u2", "u3"), Message.class);
+
+        ArrayList<User.UserInfo> members = new ArrayList<>();
+        members.add(User.userInfo("u1", "Alice", UserType.USER));
+        assertEquals(ResponseType.CONVERSATION, server.processRequest(
+                new Request(RequestType.CREATE_CONVERSATION, new CreateConversationPayload(members), "u1")).getType());
+        assertQueuedRecipients(queue, Set.of("u1", "u2", "u3"), Conversation.class);
+
+        assertEquals(ResponseType.CONVERSATION, server.processRequest(
+                new Request(RequestType.ADD_PARTICIPANT,
+                        new AddToConversationPayload(participants("u4"), 33L),
+                        "u1")).getType());
+        Map.Entry<String, Response> d1 = queue.poll();
+        Map.Entry<String, Response> d2 = queue.poll();
+        Map.Entry<String, Response> d3 = queue.poll();
+        Map.Entry<String, Response> d4 = queue.poll();
+        assertNotNull(d1);
+        assertNotNull(d2);
+        assertNotNull(d3);
+        assertNotNull(d4);
+        Map<String, Response> deliveries = Map.of(
+                d1.getKey(), d1.getValue(),
+                d2.getKey(), d2.getValue(),
+                d3.getKey(), d3.getValue(),
+                d4.getKey(), d4.getValue());
+        assertEquals(Set.of("u1", "u2", "u3", "u4"), deliveries.keySet());
+        assertTrue(deliveries.get("u4").getPayload() instanceof Conversation);
+        assertTrue(deliveries.get("u1").getPayload() instanceof ConversationMetadata);
+        assertTrue(deliveries.get("u2").getPayload() instanceof ConversationMetadata);
+        assertTrue(deliveries.get("u3").getPayload() instanceof ConversationMetadata);
+        assertNull(queue.poll());
+    }
+
+    @Test
+    void logoutRemovesSession() throws Exception {
+        server = buildServerWithStub();
+        server.addSession("u1", new shared.networking.ConnectionHandler(new java.net.Socket(), server));
+        assertTrue(server.hasActiveSession("u1"));
+
+        Response out = server.processRequest(new Request(RequestType.LOGOUT, (RequestPayload) null, "u1"));
+
+        assertNull(out);
+        assertFalse(server.hasActiveSession("u1"));
+    }
+
+    private ServerController buildServerWithStub() throws Exception {
+        return buildServerWithStub(new StubDataManager(testDataRoot().toString()));
+    }
+
+    private ServerController buildServerWithStub(StubDataManager stub) throws Exception {
+        ServerController c = new ServerController(testDataRoot().toString(), 0);
+        setField(c, "dataManager", stub);
+        return c;
+    }
+
+    private Path testDataRoot() throws IOException {
+        Path testData = tempRoot.resolve("test_data");
+        prepareMinimalDataTree(testData);
+        return testData;
+    }
+
+    private static void prepareMinimalDataTree(Path root) throws IOException {
+        Path serverData = root.resolve("server_data");
+        Path authorizedIds = serverData.resolve("authorized_ids");
+        Files.createDirectories(authorizedIds);
+        Files.writeString(authorizedIds.resolve("authorized_users.txt"), "u1,Alice\nu2,Bob\n");
+        Files.writeString(authorizedIds.resolve("authorized_admins.txt"), "");
+        Files.writeString(serverData.resolve("server_config.txt"), "");
+        Files.createDirectories(root.resolve("conversation_data"));
+        Files.createDirectories(root.resolve("user_data"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static LinkedBlockingQueue<Map.Entry<String, Response>> getResponseQueue(ServerController c) throws Exception {
+        Field f = ServerController.class.getDeclaredField("responseQueue");
+        f.setAccessible(true);
+        return (LinkedBlockingQueue<Map.Entry<String, Response>>) f.get(c);
+    }
+
+    private static void interruptBroadcasterThread(ServerController c) throws Exception {
+        Field f = ServerController.class.getDeclaredField("broadcasterThread");
+        f.setAccessible(true);
+        Thread t = (Thread) f.get(c);
+        if (t != null) t.interrupt();
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    private static void assertQueuedRecipients(
+            LinkedBlockingQueue<Map.Entry<String, Response>> queue,
+            Set<String> expectedRecipients,
+            Class<?> expectedPayloadType) {
+        Map.Entry<String, Response> d1 = queue.poll();
+        Map.Entry<String, Response> d2 = queue.poll();
+        Map.Entry<String, Response> d3 = queue.poll();
+        assertNotNull(d1);
+        assertNotNull(d2);
+        assertNotNull(d3);
+        Map<String, Response> deliveries = Map.of(
+                d1.getKey(), d1.getValue(),
+                d2.getKey(), d2.getValue(),
+                d3.getKey(), d3.getValue());
+        assertEquals(expectedRecipients, deliveries.keySet());
+        for (Response response : deliveries.values()) {
+            assertTrue(expectedPayloadType.isInstance(response.getPayload()));
+        }
+        assertNull(queue.poll());
+    }
+
+    private static ArrayList<User.UserInfo> participants(String... ids) {
+        ArrayList<User.UserInfo> out = new ArrayList<>();
+        for (String id : ids) {
+            out.add(User.userInfo(id, id.toUpperCase(), UserType.USER));
+        }
+        return out;
+    }
+
+    private static class StubDataManager extends DataManager {
+        final Map<RequestType, Response> responses = new EnumMap<>(RequestType.class);
+        final Map<Long, ArrayList<User.UserInfo>> participantsByConversationId = new HashMap<>();
+        RequestType lastCalled;
+
+        StubDataManager(String dataRootPath) {
+            super(dataRootPath);
+        }
+
+        private Response hit(RequestType type) {
+            lastCalled = type;
+            return responses.get(type);
+        }
+
+        @Override public Response handleRegister(Request request) { return hit(RequestType.REGISTER); }
+        @Override public Response handleLogin(Request request) { return hit(RequestType.LOGIN); }
+        @Override public Response handleSendMessage(Request request) { return hit(RequestType.MESSAGE); }
+        @Override public Response handleUpdateReadMessages(Request request) { return hit(RequestType.UPDATE_READ); }
+        @Override public Response handleCreateConversation(Request request) { return hit(RequestType.CREATE_CONVERSATION); }
+        @Override public Response handleAddToConversation(Request request) { return hit(RequestType.ADD_PARTICIPANT); }
+        @Override public Response handleLeaveConversation(Request request) { return hit(RequestType.LEAVE_CONVERSATION); }
+        @Override public Response handleAdminConversationQuery(Request request) { return hit(RequestType.ADMIN_CONVERSATION_QUERY); }
+        @Override public Response handleJoinConversation(Request request) { return hit(RequestType.JOIN_CONVERSATION); }
+        @Override public ArrayList<User.UserInfo> getParticipantList(long conversationId) {
+            ArrayList<User.UserInfo> participants = participantsByConversationId.get(conversationId);
+            if (participants == null) {
+                return new ArrayList<>();
+            }
+            return new ArrayList<>(participants);
+        }
+    }
+}
+

--- a/test/server/ServerControllerTest.java
+++ b/test/server/ServerControllerTest.java
@@ -24,6 +24,7 @@ import shared.enums.ResponseType;
 import shared.enums.LoginStatus;
 import shared.enums.RegisterStatus;
 import shared.enums.UserType;
+import shared.networking.ConnectionHandler;
 import shared.networking.Request;
 import shared.networking.Response;
 import shared.networking.User;
@@ -242,9 +243,9 @@ class ServerControllerTest {
     }
 
     /** Returns a ConnectionHandler stub that performs no I/O — safe for unit tests. */
-    private static shared.networking.ConnectionHandler noOpHandler() {
-        return new shared.networking.ConnectionHandler(null, null) {
-            @Override public void sendResponse(shared.networking.Response r) {}
+    private static ConnectionHandler noOpHandler() {
+        return new ConnectionHandler(null, null) {
+            @Override public void sendResponse(Response r) {}
             @Override public void close() {}
         };
     }

--- a/test/server/ServerControllerTest.java
+++ b/test/server/ServerControllerTest.java
@@ -178,12 +178,11 @@ class ServerControllerTest {
         stub.participantsByConversationId.put(33L, participants("u1", "u2", "u3", "u4"));
 
         server = buildServerWithStub(stub);
-        interruptBroadcasterThread(server); // keep queue stable for deterministic assertions
         LinkedBlockingQueue<Map.Entry<String, Response>> queue = getResponseQueue(server);
-        server.addSession("u1", new shared.networking.ConnectionHandler(new java.net.Socket(), server));
-        server.addSession("u2", new shared.networking.ConnectionHandler(new java.net.Socket(), server));
-        server.addSession("u3", new shared.networking.ConnectionHandler(new java.net.Socket(), server));
-        server.addSession("u4", new shared.networking.ConnectionHandler(new java.net.Socket(), server));
+        server.addSession("u1", noOpHandler());
+        server.addSession("u2", noOpHandler());
+        server.addSession("u3", noOpHandler());
+        server.addSession("u4", noOpHandler());
 
         assertEquals(ResponseType.MESSAGE, server.processRequest(
                 new Request(RequestType.MESSAGE, new RawMessage("hi", 1L), "u1")).getType());
@@ -223,7 +222,7 @@ class ServerControllerTest {
     @Test
     void logoutRemovesSession() throws Exception {
         server = buildServerWithStub();
-        server.addSession("u1", new shared.networking.ConnectionHandler(new java.net.Socket(), server));
+        server.addSession("u1", noOpHandler());
         assertTrue(server.hasActiveSession("u1"));
 
         Response out = server.processRequest(new Request(RequestType.LOGOUT, (RequestPayload) null, "u1"));
@@ -237,9 +236,17 @@ class ServerControllerTest {
     }
 
     private ServerController buildServerWithStub(StubDataManager stub) throws Exception {
-        ServerController c = new ServerController(testDataRoot().toString(), 0);
+        ServerController c = new ServerController(testDataRoot().toString(), 0, false);
         setField(c, "dataManager", stub);
         return c;
+    }
+
+    /** Returns a ConnectionHandler stub that performs no I/O — safe for unit tests. */
+    private static shared.networking.ConnectionHandler noOpHandler() {
+        return new shared.networking.ConnectionHandler(null, null) {
+            @Override public void sendResponse(shared.networking.Response r) {}
+            @Override public void close() {}
+        };
     }
 
     private Path testDataRoot() throws IOException {
@@ -264,13 +271,6 @@ class ServerControllerTest {
         Field f = ServerController.class.getDeclaredField("responseQueue");
         f.setAccessible(true);
         return (LinkedBlockingQueue<Map.Entry<String, Response>>) f.get(c);
-    }
-
-    private static void interruptBroadcasterThread(ServerController c) throws Exception {
-        Field f = ServerController.class.getDeclaredField("broadcasterThread");
-        f.setAccessible(true);
-        Thread t = (Thread) f.get(c);
-        if (t != null) t.interrupt();
     }
 
     private static void setField(Object target, String fieldName, Object value) throws Exception {


### PR DESCRIPTION
## Summary
- Route `ServerController` broadcast flow through `broadcastResponse(...)` request-type dispatch into case-specific enqueue helpers.
- Queue per-recipient deliveries (`recipientId` + `Response`) so broadcaster thread only drains and sends to active sessions.
- Update `ServerControllerTest` to validate recipient-targeted queue entries and payload behavior for `MESSAGE`, `CREATE_CONVERSATION`, and `ADD_PARTICIPANT`.

## Test plan
- [x] Compile server and shared sources: `javac -d out/main-classes ...`
- [x] Compile server tests with JUnit console jar
- [x] Run server package tests with JUnit console launcher (`15/15` passing)