### PR TITLE
fix: validate login name format on register (#58)

### DIFF
--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -264,6 +264,7 @@ public class ClientController {
             case USER_ID_TAKEN:
             case USER_ID_INVALID:
             case LOGIN_NAME_TAKEN:
+            case LOGIN_NAME_INVALID:
                 if (gui != null) gui.showRegisterError(rr.getRegisterStatus());
                 break;
         }

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -117,6 +117,9 @@ public class ClientUI {
             case LOGIN_NAME_TAKEN:
                 JOptionPane.showMessageDialog(frame, "Login name is already taken. Please try again.");
                 break;
+            case LOGIN_NAME_INVALID:
+                JOptionPane.showMessageDialog(frame, "Login name is invalid. Use only letters, numbers, hyphens, or underscores.");
+                break;
         }
     }
 

--- a/src/server/DataManager.java
+++ b/src/server/DataManager.java
@@ -569,6 +569,10 @@ public class DataManager {
         if(usersByUserID.containsKey(userId)) {
             return new Response(ResponseType.REGISTER_RESULT, new RegisterResult(shared.enums.RegisterStatus.USER_ID_TAKEN));
         }
+        // check if the login name is valid (non-empty, alphanumeric/underscores/hyphens only)
+        if(loginName == null || loginName.isBlank() || !loginName.matches("[a-zA-Z0-9_\\-]+")) {
+            return new Response(ResponseType.REGISTER_RESULT, new RegisterResult(shared.enums.RegisterStatus.LOGIN_NAME_INVALID));
+        }
         // check if the login name is already taken
         if(usersByLoginName.containsKey(loginName)) {
             return new Response(ResponseType.REGISTER_RESULT, new RegisterResult(shared.enums.RegisterStatus.LOGIN_NAME_TAKEN));

--- a/src/shared/enums/RegisterStatus.java
+++ b/src/shared/enums/RegisterStatus.java
@@ -5,4 +5,5 @@ public enum RegisterStatus {
     USER_ID_TAKEN,
     USER_ID_INVALID,
     LOGIN_NAME_TAKEN,
+    LOGIN_NAME_INVALID,
 }


### PR DESCRIPTION
## Summary
- Adds `LOGIN_NAME_INVALID` back to `RegisterStatus` enum
- Server now rejects login names that are empty, blank, or contain characters outside `[a-zA-Z0-9_-]` in `DataManager.handleRegister`
- Client routes `LOGIN_NAME_INVALID` to the error dialog with a clear message

Closes #58

## Test plan
- [ ] Register with an empty login name — error dialog shown
- [ ] Register with spaces in login name (e.g. `my name`) — error dialog shown
- [ ] Register with valid login name (e.g. `quan-pham`) — succeeds normally
- [ ] Verify no regressions on existing register/login flow