### PR TITLE
fix: remove setLastRead from UserInfo to enforce immutability

### DIFF
--- a/src/shared/networking/User.java
+++ b/src/shared/networking/User.java
@@ -114,10 +114,7 @@ public class User implements Serializable {
             return lastRead.getOrDefault(conversationId, 0L);
         }
 
-        public void setLastRead(long conversationId, long sequenceNumber) {
-            lastRead.put(conversationId, sequenceNumber);
-        }
-
+        @Override
         public String toString(){return name+" ("+userId+")";}
     }
 }


### PR DESCRIPTION
## Summary
- `UserInfo` declared `final` fields and returned an unmodifiable map from `getLastReadMap()`, implying immutability
- `setLastRead` silently mutated the backing `HashMap` through a back door, violating that contract
- Removes `setLastRead` from `UserInfo` entirely — clients should maintain their own read-cursor state optimistically, not mutate server-sourced snapshots

## Verification
`UserInfo.setLastRead` had zero call sites in the codebase, so removal is non-breaking.

Closes #57