### PR TITLE
fix: resolve duplicate messages, broken send, and missing conversation list on login

### DIFF
--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -283,11 +283,19 @@ public class ClientController {
         }
         if (gui != null) {
             ArrayList<Conversation> snapshot = new ArrayList<>(conversations);
-            DefaultListModel<Conversation> model = gui.getConversationListViewModel();
+            DefaultListModel<Conversation> listModel = gui.getConversationListViewModel();
+            boolean isCurrentConv = msg.getConversationId() == currentConversationId;
+            DefaultListModel<Message> msgModel = isCurrentConv ? gui.getConversationViewModel() : null;
             SwingUtilities.invokeLater(() -> {
-                model.clear();
-                for (Conversation c : snapshot) model.addElement(c);
+                listModel.clear();
+                for (Conversation c : snapshot) listModel.addElement(c);
+                if (msgModel != null) {
+                    msgModel.addElement(msg);
+                }
             });
+            if (isCurrentConv) {
+                updateReadMessages(currentConversationId, msg.getSequenceNumber());
+            }
         }
     }
 
@@ -416,8 +424,14 @@ public class ClientController {
     /** Matches DataManager.handleCreateConversation — payload: CreateConversationPayload(participants). */
     public void createConversation(ArrayList<UserInfo> p) {
         if (!loggedIn || currentUser == null) return;
+        ArrayList<UserInfo> participants = new ArrayList<>(p);
+        boolean creatorPresent = false;
+        for (UserInfo u : participants) {
+            if (currentUser.getUserId().equals(u.getUserId())) { creatorPresent = true; break; }
+        }
+        if (!creatorPresent) participants.add(0, currentUser);
         enqueueRequest(new Request(RequestType.CREATE_CONVERSATION,
-                new CreateConversationPayload(p), currentUser.getUserId()));
+                new CreateConversationPayload(participants), currentUser.getUserId()));
     }
 
     /** Matches DataManager.handleAddToConversation — payload: AddToConversationPayload(participants, conversationId). */

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -9,6 +9,7 @@ import javax.swing.event.*;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.util.ArrayList;
 
 public class ClientUI {
 
@@ -85,6 +86,12 @@ public class ClientUI {
             directoryModel.clear();
             for (UserInfo userInfo : controller.getFilteredDirectory("")) {
                 directoryModel.addElement(userInfo);
+            }
+            // Populate conversation list from login result.
+            DefaultListModel<Conversation> convModel = cards.main.conversationListView.getListModel();
+            convModel.clear();
+            for (Conversation c : controller.getFilteredConversationList("")) {
+                convModel.addElement(c);
             }
             cards.main.directoryView.revalidate();
             cards.main.directoryView.repaint();
@@ -398,6 +405,7 @@ public class ClientUI {
         JTextField text;
         JButton sendButton;
         JDialog addDialog;
+        SelectUserWindow addUserWindow;
 
         ConversationView() {
         	participantsLabel = new JLabel();
@@ -461,9 +469,7 @@ public class ClientUI {
                     	panel.add(label, BorderLayout.WEST);
                     }
 
-                    
-
-                    return label;
+                    return panel;
                 }
             });
             
@@ -486,10 +492,11 @@ public class ClientUI {
                     return;
                 }
 
-                SelectUserWindow panel = new SelectUserWindow();
+                addUserWindow = new SelectUserWindow(
+                    users -> controller.addToConversation(users, controller.getCurrentConversationId()));
 
                 addDialog = new JDialog(frame, "Select User", false);
-                addDialog.add(panel);
+                addDialog.add(addUserWindow);
                 addDialog.setSize(300, 400);
                 addDialog.setLocationRelativeTo(frame);
                 addDialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
@@ -542,6 +549,7 @@ public class ClientUI {
                     return;
                 }
             	controller.sendMessage(controller.getCurrentConversation().getConversationId(), text.getText());
+                text.setText("");
             });
                       
         }
@@ -561,6 +569,7 @@ public class ClientUI {
                 for(int i = 0; i < currConv.getMessages().size(); i++) {
                     conversationMessageListModel.addElement(currConv.getMessages().get(i));
                 }
+                text.setEnabled(true);
         	});
         }
         
@@ -675,7 +684,7 @@ public class ClientUI {
                     return;
                 }
                
-            	createConversationUserWindow = new SelectUserWindow();
+            	createConversationUserWindow = new SelectUserWindow(users -> controller.createConversation(users));
                 createDialog = new JDialog(frame, "Select User", false);
                 createDialog.add(createConversationUserWindow);
                 createDialog.setSize(300, 400);
@@ -731,12 +740,15 @@ public class ClientUI {
                 }
                 selecting = selectedValue;
                 // if the another window is not visible, shows the button
-                if(selecting != null && createDialog != null && adminDialog != null && !createDialog.isVisible() && !adminDialog.isVisible()) {
+                if(selecting != null && (createDialog == null || !createDialog.isVisible()) && (adminDialog == null || !adminDialog.isVisible())
+                        && (cards.main.conversationView.addDialog == null || !cards.main.conversationView.addDialog.isVisible())) {
                     createConversationButton.setEnabled(true);
                     // adminButton is always constructed; visibility is toggled at login time
                     adminButton.setEnabled(true);
                 } else if(createDialog != null && createDialog.isVisible()) { // if selectUser window is open
                     createConversationUserWindow.addUser(selecting);
+                } else if(cards.main.conversationView.addDialog != null && cards.main.conversationView.addDialog.isVisible()) {
+                    if(selecting != null) cards.main.conversationView.addUserWindow.addUser(selecting);
                 }
             });
 
@@ -825,8 +837,12 @@ public class ClientUI {
     					// delegates to ConversationView.setListModel so both the
     					// participant label and the message list are updated together
     					cards.main.conversationView.setListModel(selected);
+    					if (!selected.getMessages().isEmpty()) {
+    					    Message last = selected.getMessages().get(selected.getMessages().size() - 1);
+    					    controller.updateReadMessages(selected.getConversationId(), last.getSequenceNumber());
+    					}
     				}
-            	}    					 				
+            	}
             });           
         }
         
@@ -847,9 +863,10 @@ public class ClientUI {
         JButton removeButton;
         JButton okButton;
         JButton cancelButton;
-    
-        
-        SelectUserWindow() {
+        private final java.util.function.Consumer<ArrayList<UserInfo>> onConfirm;
+
+        SelectUserWindow(java.util.function.Consumer<ArrayList<UserInfo>> onConfirm) {
+            this.onConfirm = onConfirm;
             removeButton = new JButton("Remove");
             removeButton.setEnabled(false);
             okButton = new JButton("OK");
@@ -881,10 +898,12 @@ public class ClientUI {
         	// add action to OK button
             okButton.addActionListener(e -> {
             	if(model.size() != 0) {
-                	// sent the list
+                    ArrayList<UserInfo> selected = new ArrayList<>();
+                    for (int i = 0; i < model.size(); i++) selected.add(model.get(i));
+                    onConfirm.accept(selected);
             	}
                 Window window = SwingUtilities.getWindowAncestor(this);
-                window.dispose();            
+                window.dispose();
             });
             
             // add action to cancel button

--- a/src/server/ServerController.java
+++ b/src/server/ServerController.java
@@ -185,7 +185,15 @@ public class ServerController {
     private void enqueueMessageBroadcast(Request request, Response response) {
         if (!(response.getPayload() instanceof Message)) return;
         Message message = (Message) response.getPayload();
-        enqueueToActiveParticipants(dataManager.getParticipantList(message.getConversationId()), response);
+        String senderId = request.getSenderId();
+        for (UserInfo participant : dataManager.getParticipantList(message.getConversationId())) {
+            if (participant == null || participant.getUserId() == null) continue;
+            String id = participant.getUserId();
+            if (id.equals(senderId)) continue; // sender already gets the response via direct return
+            if (hasActiveSession(id)) {
+                responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(id, response));
+            }
+        }
     }
 
     private void enqueueCreateConversationBroadcast(Response response) {


### PR DESCRIPTION
## Summary

- **Duplicate messages for sender**: `ServerController.enqueueMessageBroadcast` was sending the message to all participants including the sender, who already receives it via the direct `processRequest` return path. Fixed by skipping the sender in the broadcast loop.
- **Message view not updating live**: `ClientController.handleMessageResponse` was only refreshing the conversation list sidebar, not appending the new message to the active conversation view. Fixed by also updating `getConversationViewModel()` when the incoming message belongs to the current conversation.
- **Conversation list empty on login**: `ClientUI.showMainView` was populating the directory list but not the conversation list. Fixed by iterating `controller.getFilteredConversationList("")` and seeding the model.
- **Creator missing from conversation**: `ClientController.createConversation` was not including the logged-in user in the participant list. Fixed by prepending `currentUser` if not already present.
- **Send button text not cleared**: Text field was not cleared after sending. Fixed with `text.setText("")` in the send action listener.
- **Text field permanently disabled**: `text.setEnabled(false)` in the constructor was never reversed. Fixed by calling `text.setEnabled(true)` inside `ConversationView.setListModel`.
- **Cell renderer returning wrong component**: `ConversationView` list cell renderer was returning `label` instead of the `panel` that wraps it, losing layout. Fixed with `return panel`.
- **SelectUserWindow had no confirm callback**: OK button had no action wired up. Refactored to accept a `Consumer<ArrayList<UserInfo>>` so callers (create conversation, add participant) supply their own handler.
- **Add-participant dialog not routing directory clicks**: Clicking a user in the directory while the add-participant dialog was open did nothing. Fixed by checking `addDialog.isVisible()` in the directory selection listener and forwarding to `addUserWindow.addUser(selecting)`.
- **Read messages not updated on conversation select**: Selecting a conversation in the sidebar did not mark messages as read. Fixed by calling `controller.updateReadMessages` with the last message's sequence number.

## Test plan

- [ ] Log in as User A and User B in two separate client windows
- [ ] User A creates a conversation with User B — conversation appears in both lists
- [ ] User A sends a message — appears once in A's view, once in B's view (no duplicates)
- [ ] Log out and log back in — conversation list is pre-populated
- [ ] Open add-participant dialog, click a user in directory — user is added to the selection list
- [ ] Confirm OK — participant is added to the conversation