### PR TITLE
fix: display sender name instead of user ID in message list

### DIFF
--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -9,6 +9,8 @@ import javax.swing.event.*;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 
 public class ClientUI {
@@ -449,22 +451,38 @@ public class ClientUI {
                     JPanel panel = new JPanel(new BorderLayout());
                     
                     Message msg = (Message) value;
-                                        
+
+                    // Resolve sender's display name from conversation participants
+                    String senderName = msg.getSenderId();
+                    Conversation conv = controller.getCurrentConversation();
+                    if (conv != null) {
+                        for (UserInfo p : conv.getParticipants()) {
+                            if (p.getUserId().equals(msg.getSenderId())) {
+                                senderName = p.getName();
+                                break;
+                            }
+                        }
+                    }
+                    String ts = msg.getTimestamp().toInstant()
+                            .atZone(ZoneId.systemDefault())
+                            .format(DateTimeFormatter.ofPattern("LLL dd HH:mm"));
+                    String displayText = ts + " " + senderName + ": " + msg.getText();
+
                     long lastReadSeq = controller.getCurrentUserInfo().getLastRead(controller.getCurrentConversationId());
-                    
+
                     // displaying the current user's messages on the right side
                     if(msg.getSenderId().equals(controller.getCurrentUserInfo().getUserId())) {
                     	label.setBackground(Color.LIGHT_GRAY);
                     	label.setFont(label.getFont().deriveFont(Font.PLAIN));
-                        label.setText(msg.toString());
+                        label.setText(displayText);
                     	panel.add(label, BorderLayout.EAST);
                     } else { // displaying the other participants' messages on the left side
                     	if (msg.getSequenceNumber() > lastReadSeq ) {
                             label.setFont(label.getFont().deriveFont(Font.BOLD));
-                            label.setText("● " + msg.toString());
+                            label.setText("● " + displayText);
                         } else {
                             label.setFont(label.getFont().deriveFont(Font.PLAIN));
-                            label.setText(msg.toString());
+                            label.setText(displayText);
                         }
                     	panel.add(label, BorderLayout.WEST);
                     }


### PR DESCRIPTION
## Summary

- The message cell renderer was calling `msg.toString()` which embeds the raw `senderId` (e.g. `N4R8T1BZQK: hello`). This made it hard to tell who sent a message.
- Now resolves the sender's display name by looking them up in the current conversation's participant list, falling back to the user ID if not found.
- Message format is now `"Apr 27 20:21 Quan Pham: hello"` instead of `"Apr 27 20:21 N4R8T1BZQK: hello"`.

## Test plan

- [ ] Open a conversation with multiple participants
- [ ] Send messages from different accounts — each message shows the sender's real name
- [ ] Messages from the current user still appear on the right with their name
- [ ] Messages from others appear on the left with their name