### PR TITLE
refactor: make ClientUI own list-model state and updates

### DIFF
--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -285,8 +285,6 @@ public class ClientController {
             gui.updateConversationListModel(snapshot);
             if (isCurrentConv) {
                 gui.appendMessageToConversationView(msg);
-            }
-            if (isCurrentConv) {
                 updateReadMessages(currentConversationId, msg.getSequenceNumber());
             }
         }
@@ -334,6 +332,9 @@ public class ClientController {
         // AdminConversationResult carries ConversationMetadata — store it directly.
         AdminConversationResult acr = (AdminConversationResult) response.getPayload();
         currentAdminConversationSearch = new ArrayList<>(acr.getConversations());
+        if (gui != null) {
+            gui.updateAdminConversationSearchModel(currentAdminConversationSearch);
+        }
     }
 
     /** Lazily opens a TCP connection to the server and initializes the input and output streams*/

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -8,8 +8,6 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.util.*;
 import java.util.concurrent.LinkedBlockingDeque;
-import javax.swing.DefaultListModel;
-import javax.swing.SwingUtilities;
 import shared.enums.*;
 import shared.networking.*;
 import shared.networking.User.UserInfo;
@@ -283,16 +281,11 @@ public class ClientController {
         }
         if (gui != null) {
             ArrayList<Conversation> snapshot = new ArrayList<>(conversations);
-            DefaultListModel<Conversation> listModel = gui.getConversationListViewModel();
             boolean isCurrentConv = msg.getConversationId() == currentConversationId;
-            DefaultListModel<Message> msgModel = isCurrentConv ? gui.getConversationViewModel() : null;
-            SwingUtilities.invokeLater(() -> {
-                listModel.clear();
-                for (Conversation c : snapshot) listModel.addElement(c);
-                if (msgModel != null) {
-                    msgModel.addElement(msg);
-                }
-            });
+            gui.updateConversationListModel(snapshot);
+            if (isCurrentConv) {
+                gui.appendMessageToConversationView(msg);
+            }
             if (isCurrentConv) {
                 updateReadMessages(currentConversationId, msg.getSequenceNumber());
             }
@@ -306,11 +299,7 @@ public class ClientController {
         conversations.add(0, conv);
         if (gui != null) {
             ArrayList<Conversation> snapshot = new ArrayList<>(conversations);
-            DefaultListModel<Conversation> model = gui.getConversationListViewModel();
-            SwingUtilities.invokeLater(() -> {
-                model.clear();
-                for (Conversation c : snapshot) model.addElement(c);
-            });
+            gui.updateConversationListModel(snapshot);
         }
     }
 
@@ -327,22 +316,10 @@ public class ClientController {
         if (gui != null) {
             ArrayList<Conversation> snapshot = new ArrayList<>(conversations);
             Conversation current = getCurrentConversation();
-            DefaultListModel<Conversation> conversationListModel = gui.getConversationListViewModel();
-            DefaultListModel<Message> conversationViewModel = gui.getConversationViewModel();
-
-            SwingUtilities.invokeLater(() -> {
-                // Update conversation list (sidebar)
-                conversationListModel.clear();
-                for (Conversation c : snapshot) conversationListModel.addElement(c);
-
-                // Update conversation view (message panel) to show the new current conversation
-                conversationViewModel.clear();
-                if (current != null) {
-                    for (Message msg : current.getMessages()) {
-                        conversationViewModel.addElement(msg);
-                    }
-                }
-            });
+            // Update conversation list (sidebar)
+            gui.updateConversationListModel(snapshot);
+            // Update conversation view (message panel) to show the new current conversation
+            gui.updateMessageListModel(current);
         }
     }
 
@@ -478,19 +455,13 @@ public class ClientController {
     /** Filters local directory and refreshes the directory list model in the GUI. */
     public void searchDirectory(String query) {
         if (gui == null) return;
-        gui.getDirectoryViewModel().clear();
-        for (UserInfo u : getFilteredDirectory(query)) {
-            gui.getDirectoryViewModel().addElement(u);
-        }
+        gui.updateDirectoryModel(getFilteredDirectory(query));
     }
 
     /** Filters local conversation list and refreshes the conversation list model in the GUI. */
     public void searchConversationList(String query) {
         if (gui == null) return;
-        gui.getConversationListViewModel().clear();
-        for (Conversation c : getFilteredConversationList(query)) {
-            gui.getConversationListViewModel().addElement(c);
-        }
+        gui.updateConversationListModel(getFilteredConversationList(query));
     }
 
     public UserInfo getCurrentUserInfo() { return currentUser; }

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -21,6 +21,9 @@ public class ClientUI {
     private ClientController controller;
     private JFrame frame;
     private ScreenCards cards;
+    private DefaultListModel<UserInfo> directoryModel;
+    private DefaultListModel<Message> conversationMessageModel;
+    private DefaultListModel<Conversation> conversationListModel;
     /** Fires on the EDT every 5s to compare wall clock to {@link #lastUserActivityMillis}. */
     private final Timer userIdlePollTimer;
 
@@ -33,6 +36,9 @@ public class ClientUI {
         frame = new JFrame();
         frame.setTitle("Communication Application");
         cards = new ScreenCards();
+        directoryModel = cards.main.directoryView.getListModel();
+        conversationMessageModel = cards.main.conversationView.getListModel();
+        conversationListModel = cards.main.conversationListView.getListModel();
         frame.add(cards);
         frame.pack();                 
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -84,16 +90,14 @@ public class ClientUI {
             boolean isAdmin = currentUser != null && currentUser.getUserType() == UserType.ADMIN;
             cards.main.directoryView.adminButton.setVisible(isAdmin);
             // Refresh directory list from the latest controller-side cache on main-view entry.
-            DefaultListModel<UserInfo> directoryModel = cards.main.directoryView.getListModel();
             directoryModel.clear();
             for (UserInfo userInfo : controller.getFilteredDirectory("")) {
                 directoryModel.addElement(userInfo);
             }
             // Populate conversation list from login result.
-            DefaultListModel<Conversation> convModel = cards.main.conversationListView.getListModel();
-            convModel.clear();
+            conversationListModel.clear();
             for (Conversation c : controller.getFilteredConversationList("")) {
-                convModel.addElement(c);
+                conversationListModel.addElement(c);
             }
             cards.main.directoryView.revalidate();
             cards.main.directoryView.repaint();
@@ -146,22 +150,44 @@ public class ClientUI {
         }
     }
 
-    public DefaultListModel<UserInfo> getDirectoryViewModel() { return cards.main.directoryView.getListModel(); }
-    public DefaultListModel<Message> getConversationViewModel() { return cards.main.conversationView.getListModel(); }
-    public DefaultListModel<Conversation> getConversationListViewModel() { return cards.main.conversationListView.getListModel(); }
-    
-    public DefaultListModel<ConversationMetadata> getAdminConversationSearchWindowModel() {
-        if (cards.main.directoryView.adminConversationSearchWindow == null
-                || cards.main.directoryView.adminConversationSearchWindow.model == null) {
-            return new DefaultListModel<>();
-        }
-        return cards.main.directoryView.adminConversationSearchWindow.model;
-    }
-
     public boolean isSelectingUsers() {
         return cards.main.directoryView.isCreatingConversation() || cards.main.conversationView.isAddingUser();
     }
     public boolean isAdminSearchingConversation() { return cards.main.directoryView.isAdminSearching(); }
+
+    public void updateDirectoryModel(ArrayList<UserInfo> users) {
+        SwingUtilities.invokeLater(() -> {
+            directoryModel.clear();
+            for (UserInfo user : users) {
+                directoryModel.addElement(user);
+            }
+        });
+    }
+
+    public void updateConversationListModel(ArrayList<Conversation> conversations) {
+        SwingUtilities.invokeLater(() -> {
+            conversationListModel.clear();
+            for (Conversation conversation : conversations) {
+                conversationListModel.addElement(conversation);
+            }
+        });
+    }
+
+    public void updateMessageListModel(Conversation conversation) {
+        SwingUtilities.invokeLater(() -> {
+            conversationMessageModel.clear();
+            if (conversation == null) {
+                return;
+            }
+            for (Message message : conversation.getMessages()) {
+                conversationMessageModel.addElement(message);
+            }
+        });
+    }
+
+    public void appendMessageToConversationView(Message message) {
+        SwingUtilities.invokeLater(() -> conversationMessageModel.addElement(message));
+    }
 
     // =========================================================================
     class ScreenCards extends JPanel {

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -189,6 +189,20 @@ public class ClientUI {
         SwingUtilities.invokeLater(() -> conversationMessageModel.addElement(message));
     }
 
+    public void updateAdminConversationSearchModel(ArrayList<ConversationMetadata> conversations) {
+        SwingUtilities.invokeLater(() -> {
+            if (cards.main.directoryView.adminConversationSearchWindow == null
+                    || cards.main.directoryView.adminConversationSearchWindow.model == null) {
+                return;
+            }
+            DefaultListModel<ConversationMetadata> model = cards.main.directoryView.adminConversationSearchWindow.model;
+            model.clear();
+            for (ConversationMetadata conversation : conversations) {
+                model.addElement(conversation);
+            }
+        });
+    }
+
     // =========================================================================
     class ScreenCards extends JPanel {
         CardLayout layout;

--- a/src/client/ClientUITest.java
+++ b/src/client/ClientUITest.java
@@ -1,8 +1,0 @@
-package client;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-public class ClientUITest {
-	
-}


### PR DESCRIPTION
Move list-model update helpers from ClientController into ClientUI so the view layer owns list-model mutation. Introduce high-level ClientUI fields for directory, conversation list, and message list models to improve readability and centralize model access.