### PR TITLE
fix: polish login/register flow and Select User picker

### DIFF
--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -4,6 +4,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
 import java.util.*;
@@ -53,6 +54,10 @@ public class ClientController {
 
     private boolean loggedIn;
     private UserInfo currentUser;
+    /** #140/#142: true while a LOGIN or REGISTER request is enqueued and unresolved. */
+    private volatile boolean authInFlight = false;
+    /** #139: cached on register() so handleRegisterResultResponse can pre-fill the login screen. */
+    private volatile String lastRegisteredLoginName = null;
 
     // -------------------------------------------------------------------------
     // Client-side caches backing list views / filters
@@ -238,6 +243,8 @@ public class ClientController {
 
     private void handleLoginResultResponse(Response response) {
         LoginResult lr = (LoginResult) response.getPayload();
+        authInFlight = false;
+        if (gui != null) gui.setLoginInFlight(false);
         switch (lr.getLoginStatus()) {
             case SUCCESS:
                 loggedIn = true;
@@ -260,9 +267,12 @@ public class ClientController {
 
     private void handleRegisterResultResponse(Response response) {
         RegisterResult rr = (RegisterResult) response.getPayload();
+        authInFlight = false;
+        if (gui != null) gui.setLoginInFlight(false);
         switch (rr.getRegisterStatus()) {
             case SUCCESS:
-                if (gui != null) gui.showLoginView();
+                // #139B: pre-fill the just-registered loginName on the login screen.
+                if (gui != null) gui.showLoginView(lastRegisteredLoginName);
                 break;
             case USER_ID_TAKEN:
             case USER_ID_INVALID:
@@ -387,7 +397,9 @@ public class ClientController {
     private synchronized void ensureConnected() throws IOException {
         if (connectionStatus == ConnectionStatus.CONNECTED) return;
         connectionStatus = ConnectionStatus.CONNECTING;
-        socket = new Socket(hostIp, hostPort);
+        // #138: bounded connect timeout so unreachable server fails fast instead of hanging ~75s.
+        socket = new Socket();
+        socket.connect(new InetSocketAddress(hostIp, hostPort), CONNECT_TIMEOUT_MS);
         // OOS must be created and flushed BEFORE OIS on both sides to avoid header deadlock
         // (mirrors the convention in ConnectionHandler on the server).
         outputStream = new ObjectOutputStream(socket.getOutputStream());
@@ -397,18 +409,27 @@ public class ClientController {
         lastServerActivityMillis = System.currentTimeMillis();
     }
 
+    private static final int CONNECT_TIMEOUT_MS = 7000;
+
     // -------------------------------------------------------------------------
     // Public action methods — each maps 1-to-1 with a DataManager handler.
     // -------------------------------------------------------------------------
 
     /** Matches DataManager.handleRegister — payload: RegisterCredentials(userId, loginName, password, name). */
     public void register(String userId, String realName, String loginName, char[] password) {
+        if (authInFlight) return; // #140: drop rapid duplicate clicks
+        authInFlight = true;
+        lastRegisteredLoginName = loginName;
+        if (gui != null) gui.setLoginInFlight(true);
         RegisterCredentials creds = new RegisterCredentials(userId, loginName, new String(password), realName);
         enqueueRequest(new Request(RequestType.REGISTER, creds, null));
     }
 
     /** Matches DataManager.handleLogin — payload: LoginCredentials(loginName, password). */
     public void login(String loginName, char[] password) {
+        if (authInFlight) return; // #140: drop rapid duplicate clicks
+        authInFlight = true;
+        if (gui != null) gui.setLoginInFlight(true);
         LoginCredentials creds = new LoginCredentials(loginName, new String(password));
         enqueueRequest(new Request(RequestType.LOGIN, creds, null));
     }
@@ -617,8 +638,18 @@ public class ClientController {
                     ensureConnected();
                     sendRequest(r);
                 } catch (IOException e) {
-                    requestQueue.addFirst(r);
                     connectionStatus = ConnectionStatus.NOT_CONNECTED;
+                    if (authInFlight) {
+                        // #138: drop the queued auth request and notify the user instead of
+                        // silently retrying the unreachable server forever.
+                        authInFlight = false;
+                        if (gui != null) {
+                            gui.setLoginInFlight(false);
+                            gui.showNetworkError();
+                        }
+                    } else {
+                        requestQueue.addFirst(r);
+                    }
                     e.printStackTrace();
                     try {
                         Thread.sleep(300L);

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -111,6 +111,11 @@ public class ClientUI {
     }
 
     public void showLoginView() {
+        showLoginView(null);
+    }
+
+    /** #139B: pre-fill login id (e.g. with the just-registered loginName) before showing the screen. */
+    public void showLoginView(String prefilledLoginId) {
         SwingUtilities.invokeLater(() -> {
             // Fix 5: dispose any open dialogs before switching to login
             DirectoryView dv = cards.main.directoryView;
@@ -120,6 +125,9 @@ public class ClientUI {
             if (cv.addDialog != null && cv.addDialog.isVisible()) cv.addDialog.dispose();
 
             clearLoginAndRegisterFields();
+            if (prefilledLoginId != null && !prefilledLoginId.isEmpty()) {
+                cards.login.login_idField.setText(prefilledLoginId);
+            }
             cards.main.directoryView.adminButton.setVisible(false);
             cards.main.directoryView.revalidate();
             cards.main.directoryView.repaint();
@@ -172,6 +180,28 @@ public class ClientUI {
         });
     }
 
+    /** #141: wrap a password field with a Show/Hide toggle button. The wrapper JPanel takes the
+     *  field's place in any layout; the field reference itself is unchanged. */
+    private static JPanel passwordFieldWithToggle(JPasswordField field) {
+        JPanel wrap = new JPanel(new BorderLayout(2, 0));
+        JButton toggle = new JButton("Show");
+        toggle.setMargin(new Insets(0, 6, 0, 6));
+        toggle.setFocusable(true);
+        char defaultEcho = field.getEchoChar();
+        toggle.addActionListener(e -> {
+            if (field.getEchoChar() == 0) {
+                field.setEchoChar(defaultEcho == 0 ? '•' : defaultEcho);
+                toggle.setText("Show");
+            } else {
+                field.setEchoChar((char) 0);
+                toggle.setText("Hide");
+            }
+        });
+        wrap.add(field, BorderLayout.CENTER);
+        wrap.add(toggle, BorderLayout.EAST);
+        return wrap;
+    }
+
     private void clearLoginAndRegisterFields() {
         cards.login.login_idField.setText("");
         cards.login.passwordField.setText("");
@@ -183,34 +213,76 @@ public class ClientUI {
     }
 
     public void showRegisterError(RegisterStatus registerStatus) {
-        switch (registerStatus) {
-            case USER_ID_TAKEN:
-                JOptionPane.showMessageDialog(frame, "User ID is already taken. Please try again.");
-                break;
-            case USER_ID_INVALID:
-                JOptionPane.showMessageDialog(frame, "User ID is invalid. Please try again.");
-                break;
-            case LOGIN_NAME_TAKEN:
-                JOptionPane.showMessageDialog(frame, "Login name is already taken. Please try again.");
-                break;
-            case LOGIN_NAME_INVALID:
-                JOptionPane.showMessageDialog(frame, "Login name is invalid. Use only letters, numbers, hyphens, or underscores.");
-                break;
-        }
+        SwingUtilities.invokeLater(() -> {
+            String msg;
+            switch (registerStatus) {
+                case USER_ID_TAKEN:
+                    msg = "Employee ID is already registered. Please try again.";
+                    break;
+                case USER_ID_INVALID:
+                    // Server returns this status when the Employee ID isn't in the authorized
+                    // list OR the User Name doesn't match the name on file for that ID.
+                    msg = "Employee ID and User Name don't match the authorized list. "
+                        + "Please verify both fields and try again.";
+                    break;
+                case LOGIN_NAME_TAKEN:
+                    msg = "Login ID is already taken. Please try again.";
+                    break;
+                case LOGIN_NAME_INVALID:
+                    msg = "Login ID is invalid. Use only letters, numbers, hyphens, or underscores.";
+                    break;
+                default:
+                    return;
+            }
+            JOptionPane.showMessageDialog(frame, msg, "Registration Error", JOptionPane.ERROR_MESSAGE);
+        });
     }
 
     public void showLoginError(LoginStatus loginStatus) {
-    	switch (loginStatus) {
-            case INVALID_CREDENTIALS:
-                JOptionPane.showMessageDialog(frame, "Invalid credentials. Please try again.");
-                break;
-            case NO_ACCOUNT_EXISTS:
-                JOptionPane.showMessageDialog(frame, "No account exists. Please create an account.");
-                break;
-            case DUPLICATE_SESSION:
-                JOptionPane.showMessageDialog(frame, "Duplicate session. Please log in again.");
-                break;
-        }
+        SwingUtilities.invokeLater(() -> {
+            // #139A: always clear the password on login failure.
+            cards.login.passwordField.setText("");
+            String msg;
+            String title = "Login Error";
+            switch (loginStatus) {
+                case INVALID_CREDENTIALS:
+                    msg = "Invalid credentials. Please try again.";
+                    break;
+                case NO_ACCOUNT_EXISTS:
+                    msg = "No account exists. Please create an account.";
+                    break;
+                case DUPLICATE_SESSION:
+                    // #144: coherent, actionable copy that doesn't contradict itself.
+                    title = "Session Already Active";
+                    msg = "You are already logged in from another location. Please log out of "
+                        + "that session first, then try again. If you closed the app without "
+                        + "logging out, the previous session may still be active on the server.";
+                    break;
+                default:
+                    return;
+            }
+            JOptionPane.showMessageDialog(frame, msg, title, JOptionPane.ERROR_MESSAGE);
+        });
+    }
+
+    /** #138: shown when the server is unreachable so the user isn't stuck staring at a hung UI. */
+    public void showNetworkError() {
+        SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(
+                frame,
+                "Cannot reach the server. Please check that the server is running and try again.",
+                "Connection Error",
+                JOptionPane.ERROR_MESSAGE));
+    }
+
+    /** #140/#142: drives the visible "submit in flight" state for both login and register. */
+    public void setLoginInFlight(boolean inFlight) {
+        SwingUtilities.invokeLater(() -> {
+            if (cards == null) return; // pre-EDT init guard
+            cards.login.loginButton.setEnabled(!inFlight);
+            cards.login.loginButton.setText(inFlight ? "Logging in..." : "Login");
+            cards.register.createButton.setEnabled(!inFlight);
+            cards.register.createButton.setText(inFlight ? "Creating..." : "Create Account");
+        });
     }
 
     public boolean isSelectingUsers() {
@@ -422,6 +494,16 @@ public class ClientUI {
         	createButton = new JButton("Create Account");
         	backButton = new JButton("Back");
 
+        	// #143: tooltips clarify which ID is which.
+        	userId.setToolTipText("Your organization-assigned employee ID. Must be pre-authorized.");
+        	loginName.setToolTipText("Choose a username for logging in. Letters, numbers, hyphens, or underscores only.");
+
+        	// #146: heading at the top of the form.
+        	JLabel heading = new JLabel("Register / Create Account", SwingConstants.CENTER);
+        	heading.setFont(heading.getFont().deriveFont(Font.BOLD, heading.getFont().getSize() + 6f));
+        	heading.setBorder(BorderFactory.createEmptyBorder(20, 0, 10, 0));
+        	add(heading, BorderLayout.NORTH);
+
         	// layout for  the buttons
             JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 10, 0));
             buttonPanel.add(createButton);
@@ -432,10 +514,10 @@ public class ClientUI {
             gridConst.insets = new Insets(5, 5, 5, 5);
             gridConst.fill = GridBagConstraints.HORIZONTAL;
 
-            // put the label for User ID
+            // #143: "User ID" → "Employee ID" (organization-assigned, validated against authorized list).
             gridConst.gridx = 0;
             gridConst.gridy = 0;
-            inputPanel.add(new JLabel("User ID"), gridConst);
+            inputPanel.add(new JLabel("Employee ID"), gridConst);
 
             // put the text field on the right side of the label
             gridConst.gridx = 1;
@@ -466,18 +548,18 @@ public class ClientUI {
             gridConst.gridy = 3;
             inputPanel.add(new JLabel("Password"), gridConst);
 
-            // put the password text field on the right side of the label
+            // #141: password text field with Show/Hide toggle on the right side of the label
             gridConst.gridx = 1;
-            inputPanel.add(password, gridConst);
+            inputPanel.add(passwordFieldWithToggle(password), gridConst);
 
             // put the label for the password (confirmation)
             gridConst.gridx = 0;
             gridConst.gridy = 4;
             inputPanel.add(new JLabel("Confirm Password"), gridConst);
 
-            // put the password text field (confirmation) on the right side of the label
+            // #141: confirmation password field also gets a toggle
             gridConst.gridx = 1;
-            inputPanel.add(passwordAgain, gridConst);
+            inputPanel.add(passwordFieldWithToggle(passwordAgain), gridConst);
 
             // put the button layout below the fields
             gridConst.gridx = 1;
@@ -487,28 +569,28 @@ public class ClientUI {
             // locate these parts at the center of the window
             add(inputPanel, BorderLayout.CENTER);
 
-            // add an action when click "Create Account" button
-            createButton.addActionListener(e -> {
-            	char[] pwd1 = password.getPassword();
-            	char[] pwd2 = passwordAgain.getPassword();
-            	// if the passwords are the same, send the information to clientController
-            	if(java.util.Arrays.equals(pwd1, pwd2)) {
-            		controller.register(userId.getText(), name.getText(), loginName.getText(), password.getPassword());
-            	} else {
-            		// if not, show the error message
-            		// Fix 4: use frame as parent instead of null
-            		JOptionPane.showMessageDialog(frame, "Passwords don't match. Type them again.", "Error", JOptionPane.ERROR_MESSAGE);
-            	}
-            	// fill with 0 for secure reason
-            	java.util.Arrays.fill(pwd1, '0');
+            // #137: extract submit lambda so Enter on any field also fires it.
+            ActionListener createAction = e -> {
+                char[] pwd1 = password.getPassword();
+                char[] pwd2 = passwordAgain.getPassword();
+                if (java.util.Arrays.equals(pwd1, pwd2)) {
+                    controller.register(userId.getText(), name.getText(), loginName.getText(), password.getPassword());
+                } else {
+                    // Fix 4: use frame as parent instead of null
+                    JOptionPane.showMessageDialog(frame, "Passwords don't match. Type them again.", "Error", JOptionPane.ERROR_MESSAGE);
+                }
+                java.util.Arrays.fill(pwd1, '0');
                 java.util.Arrays.fill(pwd2, '0');
-            });
+            };
+            createButton.addActionListener(createAction);
+            userId.addActionListener(createAction);
+            name.addActionListener(createAction);
+            loginName.addActionListener(createAction);
+            password.addActionListener(createAction);
+            passwordAgain.addActionListener(createAction);
 
-            // add an action when click
-            backButton.addActionListener(e -> {
-            	// go back to login window
-            	cards.layout.show(cards, "login");
-            });
+            // #148: route through showLoginView so clearLoginAndRegisterFields() is called.
+            backButton.addActionListener(e -> showLoginView());
         }
     }
 
@@ -528,6 +610,16 @@ public class ClientUI {
             passwordField = new JPasswordField(15);
             loginButton = new JButton("Login");
             createButton = new JButton("Create Account");
+
+            // #143: tooltip clarifies the field is the login username, not the Employee ID.
+            login_idField.setToolTipText("Your chosen login username (not your Employee ID).");
+
+            // #146: heading at the top of the form.
+            JLabel heading = new JLabel("Login", SwingConstants.CENTER);
+            heading.setFont(heading.getFont().deriveFont(Font.BOLD, heading.getFont().getSize() + 6f));
+            heading.setBorder(BorderFactory.createEmptyBorder(20, 0, 10, 0));
+            add(heading, BorderLayout.NORTH);
+
             JPanel inputPanel = new JPanel(new GridBagLayout());
             GridBagConstraints gridConst = new GridBagConstraints();
             gridConst.insets = new Insets(5, 5, 5, 5);
@@ -545,9 +637,9 @@ public class ClientUI {
             gridConst.gridx = 0;
             gridConst.gridy = 1;
             inputPanel.add(new JLabel("Password"), gridConst);
-            // add text field on the right side of the label
+            // #141: password text field with Show/Hide toggle on the right side of the label
             gridConst.gridx = 1;
-            inputPanel.add(passwordField, gridConst);
+            inputPanel.add(passwordFieldWithToggle(passwordField), gridConst);
             // add login button next to the fields
             gridConst.gridx = 2;
             gridConst.gridy = 0;
@@ -574,9 +666,8 @@ public class ClientUI {
             login_idField.addActionListener(loginAction);
             passwordField.addActionListener(loginAction);
 
-            createButton.addActionListener(e -> {
-            	cards.layout.show(cards, "register");
-            });
+            // #148 (symmetric): route through showRegisterView so fields are cleared.
+            createButton.addActionListener(e -> showRegisterView());
         }
     }
 
@@ -826,6 +917,11 @@ public class ClientUI {
                     @Override
                     public void windowClosed(WindowEvent e) {
                         addDialog = null;
+                    }
+                    // #149: focus the list on open so Tab order is correct and Delete works.
+                    @Override
+                    public void windowOpened(WindowEvent e) {
+                        addUserWindow.list.requestFocusInWindow();
                     }
                 });
 
@@ -1101,6 +1197,11 @@ public class ClientUI {
                     @Override
                     public void windowClosed(WindowEvent e) {
                         createDialog = null;
+                    }
+                    // #149: focus the list on open so Tab order is correct and Delete works.
+                    @Override
+                    public void windowOpened(WindowEvent e) {
+                        createConversationUserWindow.list.requestFocusInWindow();
                     }
                 });
 
@@ -1384,6 +1485,17 @@ public class ClientUI {
 						 // if the another window is not visible, shows the button
 						 removeButton.setEnabled(selecting != null);
 			    }
+            });
+
+            // #149: Delete key on the list invokes Remove (so the button is reachable by keyboard).
+            list.getInputMap(JComponent.WHEN_FOCUSED)
+                    .put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), "removeSelected");
+            list.getInputMap(JComponent.WHEN_FOCUSED)
+                    .put(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0), "removeSelected");
+            list.getActionMap().put("removeSelected", new AbstractAction() {
+                @Override public void actionPerformed(ActionEvent e) {
+                    if (removeButton.isEnabled()) removeButton.doClick();
+                }
             });
         }
 

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -925,6 +925,11 @@ public class ClientUI {
                     }
                 });
 
+                // Single-user picker fix: clear directory selection so the first click
+                // always emits a fresh ListSelectionEvent (see createConversationButton).
+                cards.main.directoryView.list.clearSelection();
+                cards.main.directoryView.selecting = null;
+
                 addDialog.setVisible(true);
 
             });
@@ -1204,6 +1209,13 @@ public class ClientUI {
                         createConversationUserWindow.list.requestFocusInWindow();
                     }
                 });
+
+                // Single-user picker fix: clear directory selection so the first click
+                // always emits a fresh ListSelectionEvent. Without this, when the directory
+                // has exactly one user, Swing auto-selects index 0 on render, and a click
+                // on that already-selected row is a no-op — addUser is never called.
+                list.clearSelection();
+                selecting = null;
 
                 createDialog.setVisible(true);
 


### PR DESCRIPTION
## Summary

Two related fixes that make the auth flow and the user-picker dialogs reliable for the in-class demo. No protocol or server-side changes; both commits are local to the client.

- **fix: polish login/register flow for demo readiness** — resolves 12 open `[Login/Register]` issues.
- **fix: allow single-user directory click in Select User dialog** — Select User dialog now responds to clicks when the directory has exactly one user.

## Manual test plan

Run the server and at least two clients (`java -cp out server.ServerController`, then `java -cp out client.ClientController` × 2).

### Login screen
- [ ] Bold "Login" heading visible at the top.
- [ ] Tooltip on Login ID clarifies it is the chosen username, not the Employee ID.
- [ ] Password field has a working Show/Hide toggle.
- [ ] Enter from any field submits.
- [ ] Wrong credentials: title reads "Login Error", password clears, Login ID stays.
- [ ] Stop the server, click Login: a "Connection Error" dialog appears within ~7 seconds and the button re-enables.
- [ ] Restart the server, click Login 5× rapidly: only one request is sent, button shows "Logging in..." and is disabled until response.

### Register screen
- [ ] Bold "Register / Create Account" heading.
- [ ] First label reads "Employee ID" (was "User ID"); tooltips on Employee ID and Login ID clarify each.
- [ ] Both password fields have Show/Hide toggles.
- [ ] Enter on any of the five fields submits.
- [ ] Fill the form, click Back, then click Create Account from login: register screen is blank again.
- [ ] Successful register opens login with the new Login ID pre-filled.
- [ ] Registration errors show "Registration Error" as the dialog title.
- [ ] If the Employee ID and User Name do not match the authorized list, the dialog asks the user to verify both fields (rather than blaming the ID alone).
- [ ] Create Account button shows "Creating..." while in flight.

### Duplicate session
- [ ] Logging in as the same user from a second client shows a coherent "Session Already Active" dialog (no longer contradicts itself with "Please log in again").

### Select User dialog
- [ ] Open Add User (or Create Conversation): the user list is focused immediately; Tab order starts there.
- [ ] With a user selected, Delete or Backspace removes them — same as clicking Remove.
- [ ] **Single-user case:** with exactly one other user in the directory, clicking that user inside Create Conversation (or Add) now adds them to the dialog. Previously a no-op.
- [ ] Regression: with three or more users in the directory, the existing picker flow still works.