### PR TITLE
fix(admin): resolve 9 open admin-flow issues

### DIFF
--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -243,44 +243,51 @@ public class ClientController {
 
     private void handleLoginResultResponse(Response response) {
         LoginResult lr = (LoginResult) response.getPayload();
-        authInFlight = false;
-        if (gui != null) gui.setLoginInFlight(false);
-        switch (lr.getLoginStatus()) {
-            case SUCCESS:
-                loggedIn = true;
-                currentUser = lr.getUserInfo();
-                conversations = Collections.synchronizedList(
-                        lr.getConversationList() != null ? lr.getConversationList() : new ArrayList<>());
-                currentDirectory = lr.getDirectoryUserInfoList() != null
-                        ? lr.getDirectoryUserInfoList() : new ArrayList<>();
-                if (gui != null) {
-                    gui.showMainView();
-                }
-                break;
-            case INVALID_CREDENTIALS:
-            case NO_ACCOUNT_EXISTS:
-            case DUPLICATE_SESSION:
-                if (gui != null) gui.showLoginError(lr.getLoginStatus());
-                break;
-        }
+        // #193: coalesce field reset + UI updates into a single EDT task so the in-flight
+        // flag and visible button state can never be observed out-of-order with each other.
+        SwingUtilities.invokeLater(() -> {
+            authInFlight = false;
+            if (gui != null) gui.setLoginInFlight(false);
+            switch (lr.getLoginStatus()) {
+                case SUCCESS:
+                    loggedIn = true;
+                    currentUser = lr.getUserInfo();
+                    conversations = Collections.synchronizedList(
+                            lr.getConversationList() != null ? lr.getConversationList() : new ArrayList<>());
+                    currentDirectory = lr.getDirectoryUserInfoList() != null
+                            ? lr.getDirectoryUserInfoList() : new ArrayList<>();
+                    if (gui != null) {
+                        gui.showMainView();
+                    }
+                    break;
+                case INVALID_CREDENTIALS:
+                case NO_ACCOUNT_EXISTS:
+                case DUPLICATE_SESSION:
+                    if (gui != null) gui.showLoginError(lr.getLoginStatus());
+                    break;
+            }
+        });
     }
 
     private void handleRegisterResultResponse(Response response) {
         RegisterResult rr = (RegisterResult) response.getPayload();
-        authInFlight = false;
-        if (gui != null) gui.setLoginInFlight(false);
-        switch (rr.getRegisterStatus()) {
-            case SUCCESS:
-                // #139B: pre-fill the just-registered loginName on the login screen.
-                if (gui != null) gui.showLoginView(lastRegisteredLoginName);
-                break;
-            case USER_ID_TAKEN:
-            case USER_ID_INVALID:
-            case LOGIN_NAME_TAKEN:
-            case LOGIN_NAME_INVALID:
-                if (gui != null) gui.showRegisterError(rr.getRegisterStatus());
-                break;
-        }
+        // #193: same EDT coalescing as handleLoginResultResponse.
+        SwingUtilities.invokeLater(() -> {
+            authInFlight = false;
+            if (gui != null) gui.setLoginInFlight(false);
+            switch (rr.getRegisterStatus()) {
+                case SUCCESS:
+                    // #139B: pre-fill the just-registered loginName on the login screen.
+                    if (gui != null) gui.showLoginView(lastRegisteredLoginName);
+                    break;
+                case USER_ID_TAKEN:
+                case USER_ID_INVALID:
+                case LOGIN_NAME_TAKEN:
+                case LOGIN_NAME_INVALID:
+                    if (gui != null) gui.showRegisterError(rr.getRegisterStatus());
+                    break;
+            }
+        });
     }
 
     private void handleMessageResponse(Response response) {
@@ -452,18 +459,22 @@ public class ClientController {
         if (gui != null) gui.showLoginView();
     }
 
+    /** #55/#124: read the cached admin search results so the dialog can seed itself on open
+     *  even if the response arrived before the dialog finished constructing. */
+    public ArrayList<ConversationMetadata> getCurrentAdminConversationSearch() {
+        return currentAdminConversationSearch;
+    }
+
+    /** #128: clear the cached admin search results so reopening the dialog starts fresh. */
+    public void clearAdminConversationSearch() {
+        currentAdminConversationSearch.clear();
+    }
+
     /** Matches DataManager.handleSendMessage — payload: RawMessage(text, conversationId). */
     public void sendMessage(long conversationId, String m) {
         if (!loggedIn || currentUser == null) return;
         enqueueRequest(new Request(RequestType.MESSAGE,
                 new RawMessage(m, conversationId), currentUser.getUserId()));
-    }
-
-    /** Matches DataManager.handleAdminConversationQuery — payload: AdminConversationQuery(userId). */
-    public void adminConversationSearch(String query) {
-        if (!loggedIn || currentUser == null || currentUser.getUserType() != UserType.ADMIN) return;
-        enqueueRequest(new Request(RequestType.ADMIN_CONVERSATION_QUERY,
-                new AdminConversationQuery(query), currentUser.getUserId()));
     }
 
     /** Matches DataManager.handleCreateConversation — payload: CreateConversationPayload(participants). */

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -1108,7 +1108,9 @@ public class ClientUI {
             createConversationButton.setEnabled(false);
 
             // construct admin button unconditionally and enable later if the user is admin
-            adminButton = new JButton("Admin");
+            // #127: clearer label + tooltip explaining the prerequisite (a user must be selected).
+            adminButton = new JButton("View Conversations");
+            adminButton.setToolTipText("Select a user in the directory, then click to view their conversations");
             adminButton.setEnabled(false);
             adminButton.setVisible(false);
 
@@ -1244,7 +1246,11 @@ public class ClientUI {
                 adminDialog.addWindowListener(new WindowAdapter() {
                     @Override
                     public void windowClosed(WindowEvent e) {
+                    	// #128: clear all admin-dialog state so reopening shows a fresh empty list.
                     	adminDialog = null;
+                    	adminConversationSearchWindow = null;
+                    	controller.clearAdminConversationSearch();
+                    	adminButton.setEnabled(false);
                     }
                 });
 
@@ -1275,17 +1281,6 @@ public class ClientUI {
                     createConversationUserWindow.addUser(selecting);
                 } else if(cards.main.conversationView.addDialog != null && cards.main.conversationView.addDialog.isVisible()) {
                     if(selecting != null) cards.main.conversationView.addUserWindow.addUser(selecting);
-                }
-            });
-
-            // Helpful debug signal when user clicks an already-selected row.
-            list.addMouseListener(new MouseAdapter() {
-                @Override
-                public void mouseClicked(MouseEvent e) {
-                    int clickedIndex = list.locationToIndex(e.getPoint());
-                    if (clickedIndex >= 0) {
-                        list.setSelectedIndex(clickedIndex);
-                    }
                 }
             });
 
@@ -1532,9 +1527,44 @@ public class ClientUI {
         JButton okButton;
         JButton cancelButton;
 
+        // #126: render each search result as "[ID: N] TYPE • K participant(s) • last active <ts>"
+        // (or "no messages yet"). Modeled on ConversationCellRenderer above.
+        private final class AdminConversationCellRenderer extends DefaultListCellRenderer {
+            @Override
+            public Component getListCellRendererComponent(
+                    JList<?> list, Object value, int index,
+                    boolean isSelected, boolean cellHasFocus) {
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                if (value instanceof ConversationMetadata) {
+                    ConversationMetadata m = (ConversationMetadata) value;
+                    int n = m.getParticipants() != null ? m.getParticipants().size() : 0;
+                    String activity;
+                    long ts = m.getLastMessageTimestampMillis();
+                    if (ts <= 0L) {
+                        activity = "no messages yet";
+                    } else {
+                        ZonedDateTime zdt = java.time.Instant.ofEpochMilli(ts)
+                                .atZone(ZoneId.systemDefault());
+                        DateTimeFormatter dtf = zdt.getYear() == ZonedDateTime.now().getYear()
+                                ? DateTimeFormatter.ofPattern("LLL dd, HH:mm", java.util.Locale.ENGLISH)
+                                : DateTimeFormatter.ofPattern("LLL dd yyyy, HH:mm", java.util.Locale.ENGLISH);
+                        activity = "last active " + zdt.format(dtf);
+                    }
+                    setText("[ID: " + m.getConversationId() + "]  "
+                            + m.getType() + "  •  "
+                            + n + " participant(s)  •  "
+                            + activity);
+                }
+                return this;
+            }
+        }
+
         AdminConversationSearchWindow() {
             searchField = makePlaceholderField("Search conversations...", 15);
-            okButton = new JButton("OK");
+            // #129: button label tells the user what clicking actually does, and starts disabled
+            // so it can't be clicked before a row is selected.
+            okButton = new JButton("Join Conversation");
+            okButton.setEnabled(false);
             okButton.setFocusTraversalKeysEnabled(false);
             cancelButton = new JButton("Cancel");
 
@@ -1543,6 +1573,9 @@ public class ClientUI {
 
             // searchField is located on the upper side of the window
             add(searchField, BorderLayout.NORTH);
+
+            // #126: install the custom cell renderer so each row shows ID, type, count, recency.
+            list.setCellRenderer(new AdminConversationCellRenderer());
 
             // the list is located on the center of the window
             add(new JScrollPane(list), BorderLayout.CENTER);
@@ -1553,6 +1586,14 @@ public class ClientUI {
         	buttonPane.add(cancelButton);
 
         	add(buttonPane, BorderLayout.SOUTH);
+
+            // #55/#124: seed from the controller's cache. If the ADMIN_CONVERSATION_RESULT
+            // response arrived before this window was constructed (race on fast loopback),
+            // the data is already in the cache and we render it immediately. The async
+            // updateAdminConversationSearchModel callback path stays for late responses.
+            for (ConversationMetadata m : controller.getCurrentAdminConversationSearch()) {
+                model.addElement(m);
+            }
 
         	// add action to searchField
         	searchField.getDocument().addDocumentListener(new DocumentListener() {
@@ -1579,12 +1620,23 @@ public class ClientUI {
 			    }
             });
 
-        	// add action to okButton
+        	// add action to okButton — #125: confirm before join, then optimistic feedback.
             okButton.addActionListener(e -> {
-                if(list.getSelectedValue() == null) {
-                    return;
-                }
-            	controller.joinConversation(list.getSelectedValue().getConversationId());
+                ConversationMetadata sel = list.getSelectedValue();
+                if (sel == null) return;
+                int n = sel.getParticipants() != null ? sel.getParticipants().size() : 0;
+                int confirm = JOptionPane.showConfirmDialog(
+                    AdminConversationSearchWindow.this,
+                    "Join conversation #" + sel.getConversationId()
+                        + " (" + n + " participant(s))?",
+                    "Confirm Join", JOptionPane.YES_NO_OPTION);
+                if (confirm != JOptionPane.YES_OPTION) return;
+
+                controller.joinConversation(sel.getConversationId());
+                JOptionPane.showMessageDialog(
+                    AdminConversationSearchWindow.this,
+                    "Join request sent for conversation #" + sel.getConversationId() + ".",
+                    "Joining...", JOptionPane.INFORMATION_MESSAGE);
                 Window window = SwingUtilities.getWindowAncestor(this);
                 window.dispose();
             });


### PR DESCRIPTION
## Summary

Stacks on top of #198 (login/register polish + picker fix). Resolves nine open `[Admin]`-related issues. All changes are client-side; no protocol or server changes. Five thematic groups in a single commit:

- **A — Admin dialog state/race + button affordance:** #55, #124, #127, #128
- **B — Search list rendering & OK button affordance:** #126, #129
- **C — Join confirmation/feedback:** #125
- **D — Dead code removal:** #130
- **E — Non-admin register freeze:** #193

> **Note:** this PR currently targets `fix/auth-and-picker-polish`. Once #198 merges, GitHub will auto-rebase the base to `main`.

## Manual test plan

Run the server and at least two clients (one admin, one non-admin):
```
java -cp out server.ServerController
java -cp out client.ClientController
```

### Theme A — Admin dialog (#55, #124, #127, #128)
- [ ] Log in as admin, select a user in the directory; hover **View Conversations** — tooltip appears explaining a user must be selected first.
- [ ] Click **View Conversations** — dialog opens and the user's conversations are populated immediately (no need to type to refresh).
- [ ] Close the dialog — the button is disabled until you re-select a user. Re-open — the list is fresh, no stale rows from the previous session.

### Theme B — Search list rendering (#126, #129)
- [ ] Each search result row shows `[ID: N] TYPE • K participant(s) • last active <timestamp>` (or "no messages yet" when no messages).
- [ ] The **Join Conversation** button is disabled on first render. Selecting a row enables it.

### Theme C — Join confirmation (#125)
- [ ] Select a row and click **Join Conversation**. A confirm dialog shows the conversation ID and participant count. Click **No** — nothing happens. Click **Yes** — an acknowledgement dialog appears, the picker closes, and the conversation appears in the admin's sidebar.

### Theme D — Dead code removal (#130)
- [ ] Smoke: full login + admin flow still works.
- [ ] `grep -rn "adminConversationSearch(" src/` returns no results.

### Theme E — Non-admin register freeze (#193)
- [ ] Register a brand-new **non-admin** account. The UI transitions to the login screen with the new Login ID pre-filled, no stuck "Creating..." state.
- [ ] Same flow for an admin account — no regression.

### Regression checks
- [ ] PR #198's picker single-user fix still works (Theme D's MouseAdapter removal is independent).
- [ ] PR #198's login/register flow still works (Theme E only changes EDT scheduling order, not behaviour).