### PR TITLE
Bugfix/user creation broadcast

### DIFF
--- a/src/server/ServerController.java
+++ b/src/server/ServerController.java
@@ -116,10 +116,14 @@ public class ServerController {
                     RegisterResult registerResult = (RegisterResult) response.getPayload();
                     if (registerResult.getRegisterStatus() == RegisterStatus.SUCCESS
                             && registerResult.getUserInfo() != null) {
+                        String registreeUserId = registerResult.getUserInfo().getUserId();
                         Response userCreationResponse = new Response(
                                 ResponseType.USER_CREATION,
                                 new UserCreationPayload(registerResult.getUserInfo()));
                         for (String userId : activeSessions.keySet()) {
+                            if (registreeUserId != null && registreeUserId.equals(userId)) {
+                                continue; // registrant receives direct register response, skip broadcast echo
+                            }
                             responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(userId, userCreationResponse));
                         }
                     }

--- a/src/shared/networking/ConnectionHandler.java
+++ b/src/shared/networking/ConnectionHandler.java
@@ -6,6 +6,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -45,6 +46,8 @@ import shared.networking.User.UserInfo;
  *  removed via {@link ServerController#removeSession}.
  */
 public class ConnectionHandler implements Runnable {
+    private static final int READ_TIMEOUT_MS = 5_000;
+    private static final long HEARTBEAT_TIMEOUT_MS = 300_000L;
 
     private static final Logger logger =
             Logger.getLogger(ConnectionHandler.class.getName());
@@ -80,6 +83,8 @@ public class ConnectionHandler implements Runnable {
             output = new ObjectOutputStream(socket.getOutputStream());
             output.flush();
             input  = new ObjectInputStream(socket.getInputStream());
+            // Poll read path periodically so we can enforce heartbeat timeout.
+            socket.setSoTimeout(READ_TIMEOUT_MS);
 
             String tag = socket.getInetAddress().getHostAddress() + ":" + socket.getPort();
             requestThread  = new Thread(new RequestListener(),  "req-"  + tag);
@@ -151,6 +156,16 @@ public class ConnectionHandler implements Runnable {
                 Object obj;
                 try {
                     obj = input.readObject();
+                } catch (SocketTimeoutException e) {
+                    if (authenticated) {
+                        long silentForMs = System.currentTimeMillis() - lastPingReceived;
+                        if (silentForMs > HEARTBEAT_TIMEOUT_MS) {
+                            logger.info("Closing stale session after heartbeat timeout: "
+                                    + silentForMs + "ms");
+                            break;
+                        }
+                    }
+                    continue;
                 } catch (EOFException | SocketException e) {
                     break; // client disconnected cleanly
                 } catch (IOException | ClassNotFoundException e) {
@@ -170,6 +185,9 @@ public class ConnectionHandler implements Runnable {
                 // Update heartbeat timestamp for PING
                 if (request.getType() == RequestType.PING) {
                     lastPingReceived = System.currentTimeMillis();
+                    // Heartbeat stays in transport layer: reply directly, skip app dispatch.
+                    sendResponse(new Response(ResponseType.PONG));
+                    continue;
                 }
 
                 // --- dispatch ---

--- a/test/server/ServerControllerTest.java
+++ b/test/server/ServerControllerTest.java
@@ -43,6 +43,7 @@ import shared.payload.RegisterCredentials;
 import shared.payload.RegisterResult;
 import shared.payload.RequestPayload;
 import shared.payload.UpdateReadMessages;
+import shared.payload.UserCreationPayload;
 
 @Timeout(value = 20, unit = TimeUnit.SECONDS)
 class ServerControllerTest {
@@ -93,6 +94,38 @@ class ServerControllerTest {
                 null));
         assertEquals(RegisterStatus.USER_ID_TAKEN,
                 ((RegisterResult) registerTakenResponse.getPayload()).getRegisterStatus());
+    }
+
+    @Test
+    void registerSuccessBroadcastSkipsRegistree() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        User.UserInfo newUser = new User("u3", "Carol", "u3_login", "pw", UserType.USER).toUserInfo();
+        stub.responses.put(RequestType.REGISTER,
+                new Response(ResponseType.REGISTER_RESULT, new RegisterResult(RegisterStatus.SUCCESS, newUser)));
+        server = buildServerWithStub(stub);
+        LinkedBlockingQueue<Map.Entry<String, Response>> queue = getResponseQueue(server);
+
+        server.addSession("u1", noOpHandler());
+        server.addSession("u2", noOpHandler());
+        server.addSession("u3", noOpHandler()); // registree
+
+        Response registerResponse = server.processRequest(new Request(
+                RequestType.REGISTER,
+                new RegisterCredentials("u3", "login3", "pw", "Carol"),
+                null));
+        assertEquals(ResponseType.REGISTER_RESULT, registerResponse.getType());
+
+        Map.Entry<String, Response> d1 = queue.poll();
+        Map.Entry<String, Response> d2 = queue.poll();
+        assertNotNull(d1);
+        assertNotNull(d2);
+        Map<String, Response> deliveries = Map.of(
+                d1.getKey(), d1.getValue(),
+                d2.getKey(), d2.getValue());
+        assertEquals(Set.of("u1", "u2"), deliveries.keySet());
+        assertTrue(deliveries.get("u1").getPayload() instanceof UserCreationPayload);
+        assertTrue(deliveries.get("u2").getPayload() instanceof UserCreationPayload);
+        assertNull(queue.poll());
     }
 
     @Test

--- a/test/shared/networking/NetworkingTest.java
+++ b/test/shared/networking/NetworkingTest.java
@@ -114,13 +114,13 @@ class NetworkingTest {
     @Test
     void listenerForwardsRequestToServerController() throws Exception {
         try (TestClient client = new TestClient(port)) {
-            client.send(NetworkingSeedData.pingRequest());
+            client.send(NetworkingSeedData.logoutRequest());
             client.receive(); // consume response
 
             // Give the handler a moment to dispatch
             waitFor(() -> !fakeServer.getReceived().isEmpty(), 2_000);
             assertFalse(fakeServer.getReceived().isEmpty());
-            assertEquals(RequestType.PING,
+            assertEquals(RequestType.LOGOUT,
                          fakeServer.getReceived().get(0).getType());
         }
     }
@@ -142,7 +142,7 @@ class NetworkingTest {
 
         try (TestClient client = new TestClient(port)) {
             for (int i = 0; i < batch.length; i++) {
-                client.send(NetworkingSeedData.pingRequest());
+                client.send(NetworkingSeedData.logoutRequest());
             }
             for (int i = 0; i < batch.length; i++) {
                 Response r = client.receive();

--- a/test/shared/networking/fixtures/FakeServerController.java
+++ b/test/shared/networking/fixtures/FakeServerController.java
@@ -38,7 +38,7 @@ public class FakeServerController extends ServerController {
     private final List<Request> received = new CopyOnWriteArrayList<>();
 
     public FakeServerController() {
-        super(prepareDataRootPath(), 0);
+        super(null, 0, prepareDataRootPath());
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Moves heartbeat ownership fully into `ConnectionHandler`:
  - `PING` requests now short-circuit in the transport layer and immediately enqueue `PONG`.
  - `PING` no longer depends on `ServerController` request dispatch.
- Adds server-side heartbeat timeout enforcement in `ConnectionHandler`:
  - introduces periodic read timeout polling
  - compares current time against `lastPingReceived`
  - closes stale authenticated sessions when heartbeat timeout is exceeded.
- Updates networking tests/fixtures to match transport-layer heartbeat behavior and current `ServerController` constructor signature.

## Why

Client keepalive pings were not reliably preserving session liveness under the intended ownership model. Heartbeat handling belonged in the connection layer, and timeout enforcement needed to actually consume `lastPingReceived`.

## Test plan

- [x] Compile production networking/server classes
- [x] Run `ServerControllerTest` (passes)
- [x] Run `NetworkingTest` (passes, 14/14)

## Closes

- closes #191
- closes #212