### PR TITLE
fix: new-message notifications (divider lifecycle + broadcast reliability)

### DIFF
--- a/docs/SRS.md
+++ b/docs/SRS.md
@@ -656,7 +656,6 @@ class ClientController
 + ClientController(hostIp: String, hostPort: int)
 ~ ClientController(hostIp: String, hostPort: int, guiOverride: ClientUI)   // package-private; tests/headless — optional null GUI, conditional thread start
 - close(): void   // shutdown hook; interrupts workers and disconnectSocket
-~ runRequestLoop(): void         // package-private; blocking drain in caller thread (tests / headless)
 ~ processResponse(response: Response): void   // package-private for tests without a socket
 ~ setCurrentDirectoryForTesting(dir: ArrayList<UserInfo>): void   // package-private test seam
 

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -227,8 +227,14 @@ public class ClientController {
             snapshot = new ArrayList<>(conversations);
             isCurrentConv = msg.getConversationId() == currentConversationId;
             if (isCurrentConv && currentUser != null) {
+                // Sending is itself a read-ack. Echoes of the user's own outbound message
+                // must advance lastRead unconditionally — focus may be on the Send button
+                // (not the input) by the time the echo arrives, which would otherwise defer
+                // the advance and let the user's own message inflate their own unread badge.
+                boolean fromSelf = msg.getSenderId() != null
+                        && msg.getSenderId().equals(currentUser.getUserId());
                 boolean userViewingBottom = (gui == null) || gui.userIsViewingBottom();
-                if (inputFocused.get() && userViewingBottom) {
+                if (fromSelf || (inputFocused.get() && userViewingBottom)) {
                     shouldAdvanceLastRead = true;
                 } else {
                     deferredReadAdvance.merge(msg.getConversationId(), msg.getSequenceNumber(), Math::max);

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -22,20 +22,20 @@ public class ClientController {
     // UI
     // -------------------------------------------------------------------------
 
-    private ClientUI gui;
+    private final ClientUI gui;
 
     // -------------------------------------------------------------------------
     // Server endpoint (fixed for this controller instance)
     // -------------------------------------------------------------------------
 
-    private String hostIp;
-    private int hostPort;
+    private final String hostIp;
+    private final int hostPort;
 
     // -------------------------------------------------------------------------
     // TCP connection + object streams
     // -------------------------------------------------------------------------
 
-    private ConnectionStatus connectionStatus;
+    private volatile ConnectionStatus connectionStatus = ConnectionStatus.NOT_CONNECTED;
     private Socket socket;
     private ObjectOutputStream outputStream;
     private ObjectInputStream inputStream;
@@ -44,7 +44,7 @@ public class ClientController {
     // Outbound requests + background workers
     // -------------------------------------------------------------------------
 
-    private LinkedBlockingDeque<Request> requestQueue;
+    private final LinkedBlockingDeque<Request> requestQueue = new LinkedBlockingDeque<>();
     private Thread requestDrainThread;
     private Thread responseListenerThread;
     private Thread inactivityDetectorThread;
@@ -53,13 +53,25 @@ public class ClientController {
     // Session (authenticated user)
     // -------------------------------------------------------------------------
 
-    private boolean loggedIn;
-    /** Reassigned off-EDT by the response listener thread (handleReadMessagesUpdatedResponse) and
-     *  read on EDT by the compose-focus listener and sidebar renderer. {@code volatile} ensures
-     *  the EDT observes the freshest reference. */
+    private volatile boolean loggedIn = false;
+    /**
+     * Reassigned off-EDT by the response listener ({@link #handleReadMessagesUpdatedResponse}
+     * builds a fresh {@link UserInfo}, populates its {@code lastRead} map pre-publication, then
+     * publishes the new reference). After publication, the {@code lastRead} map is mutated only
+     * on the EDT — see the {@link UserInfo} contract. The response thread reads the reference
+     * (e.g. to gate read-advance in {@link #handleMessageResponse}) and schedules a
+     * {@code SwingUtilities.invokeLater} for any actual mutation. {@code volatile} ensures
+     * readers observe the freshest reference.
+     */
     private volatile UserInfo currentUser;
-    /** #140/#142: true while a LOGIN or REGISTER request is enqueued and unresolved. */
-    private volatile boolean authInFlight = false;
+    /** True while a LOGIN or REGISTER request is enqueued and unresolved. Atomic so rapid
+     *  duplicate clicks lose the {@code compareAndSet} race instead of both passing a
+     *  non-atomic {@code if (!flag) flag = true}. */
+    private final AtomicBoolean authInFlight = new AtomicBoolean(false);
+    /** EDT-only Swing timer that resets {@link #authInFlight} and surfaces a network error if
+     *  the server never replies (crash-after-receive, hung handler). Cancelled on auth resolve. */
+    private javax.swing.Timer authWatchdogTimer;
+    private static final int AUTH_WATCHDOG_MS = 15_000;
     /** #139: cached on register() so handleRegisterResultResponse can pre-fill the login screen. */
     private volatile String lastRegisteredLoginName = null;
 
@@ -67,11 +79,11 @@ public class ClientController {
     // Client-side caches backing list views / filters
     // -------------------------------------------------------------------------
 
-    private List<Conversation> conversations;
+    private final List<Conversation> conversations = Collections.synchronizedList(new ArrayList<>());
     /** -1 means no conversation selected. */
-    private long currentConversationId = -1;
-    private ArrayList<UserInfo> currentDirectory;
-    private ArrayList<ConversationMetadata> currentAdminConversationSearch;
+    private volatile long currentConversationId = -1;
+    private ArrayList<UserInfo> currentDirectory = new ArrayList<>();
+    private ArrayList<ConversationMetadata> currentAdminConversationSearch = new ArrayList<>();
 
     // -------------------------------------------------------------------------
     // Window-focus gate (Fix A): inbound messages while the OS window is inactive
@@ -84,9 +96,16 @@ public class ClientController {
      *  tests (no window-activation events) and pre-window-event states do not
      *  suppress reads. */
     private final AtomicBoolean windowActive = new AtomicBoolean(true);
-    /** Conversation id → highest seq of an inbound message that arrived while
-     *  windowActive=false. Drained by {@link #replayReadAdvanceIfNeeded()} on
-     *  window activation. EDT-only access. */
+    /**
+     * Conversation id → highest seq of an inbound message that arrived while
+     * {@code windowActive=false}. Drained by {@link #replayReadAdvanceIfNeeded()}
+     * on window activation.
+     * <p>Concurrency: writes serialize via the {@code conversations} monitor (the
+     * response listener writes inside {@link #handleMessageResponse}'s monitor;
+     * {@link #tryAdvanceReadOnInbound} writes under the same monitor; the EDT
+     * {@link #replayReadAdvanceIfNeeded} drain re-acquires that monitor for the
+     * atomic drain-and-clear). Reads outside the monitor are unsafe.
+     */
     private final HashMap<Long, Long> deferredReadAdvance = new HashMap<>();
 
     // -------------------------------------------------------------------------
@@ -94,6 +113,23 @@ public class ClientController {
     // -------------------------------------------------------------------------
 
     private volatile long lastServerActivityMillis = System.currentTimeMillis();
+
+    // -------------------------------------------------------------------------
+    // Tunables
+    // -------------------------------------------------------------------------
+
+    /** #138: bounded TCP connect timeout — unreachable server fails fast (~7s) instead of
+     *  the OS default (~75s on most platforms). */
+    private static final int CONNECT_TIMEOUT_MS = 7000;
+    /** Send a PING this often while connected to keep NAT/firewall paths warm. */
+    private static final long PING_INTERVAL_MS = 30_000L;
+    /** No server activity for this long → assume the server is gone and force-logout. */
+    private static final long INACTIVITY_LIMIT_MS = 300_000L;
+    /** Polling interval the listener and inactivity threads use while waiting for the next
+     *  successful reconnect. */
+    private static final long RECONNECT_POLL_MS = 500L;
+    /** Backoff after a failed connect/send in the drain thread before retrying. */
+    private static final long RETRY_BACKOFF_MS = 300L;
 
     /*
      * Entry point for the client application.
@@ -121,12 +157,6 @@ public class ClientController {
     public ClientController(String hostIp, int hostPort) {
         this.hostIp = hostIp;
         this.hostPort = hostPort;
-        this.connectionStatus = ConnectionStatus.NOT_CONNECTED;
-        this.requestQueue = new LinkedBlockingDeque<>();
-        this.loggedIn = false;
-        this.conversations = Collections.synchronizedList(new ArrayList<>());
-        this.currentDirectory = new ArrayList<>();
-        this.currentAdminConversationSearch = new ArrayList<>();
         this.gui = new ClientUI(this);
         gui.showLoginView();
         startRequestDrainThread();
@@ -134,35 +164,10 @@ public class ClientController {
         startInactivityDetectorThread();
     }
 
-    /** Runs the request loop in the current thread (blocking). For tests / headless use. */
-    void runRequestLoop() {
-        try {
-            ensureConnected();
-        } catch (IOException e) {
-            connectionStatus = ConnectionStatus.NOT_CONNECTED;
-            e.printStackTrace();
-            return;
-        }
-        try {
-            while (!Thread.currentThread().isInterrupted()) {
-                Request r = requestQueue.take();
-                sendRequest(r);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
     /** Package-private test seam: accepts a pre-built (or null) GUI; no Swing window opened. */
     ClientController(String hostIp, int hostPort, ClientUI guiOverride) {
         this.hostIp = hostIp;
         this.hostPort = hostPort;
-        this.connectionStatus = ConnectionStatus.NOT_CONNECTED;
-        this.requestQueue = new LinkedBlockingDeque<>();
-        this.loggedIn = false;
-        this.conversations = Collections.synchronizedList(new ArrayList<>());
-        this.currentDirectory = new ArrayList<>();
-        this.currentAdminConversationSearch = new ArrayList<>();
         this.gui = guiOverride;
         // Integration tests pass a real port (>0) and need request processing
         if (hostPort > 0) {
@@ -180,53 +185,31 @@ public class ClientController {
 
     /**
      * Closes object streams and the TCP socket and sets {@link #connectionStatus} to
-     * {@link ConnectionStatus#NOT_CONNECTED}. Does <b>not</b> interrupt the request drain, response listener,
-     * or inactivity threads — they keep running and can wait for the next lazy reconnect (e.g. after
-     * manual logout while the UI stays up). For full shutdown use {@link #close()}.
+     * {@link ConnectionStatus#NOT_CONNECTED}. Does <b>not</b> interrupt the request drain,
+     * response listener, or inactivity threads — they keep running and can wait for the next
+     * lazy reconnect. For full shutdown use {@link #close()}; for logout, use
+     * {@link #logout()} which sends LOGOUT off-thread before tearing down the streams.
+     * Field swaps happen under {@code synchronized(this)} so concurrent {@link #ensureConnected}
+     * / {@link #sendRequest} calls observe a consistent (out, in, socket) triple.
      */
-    private synchronized void disconnectSocket() {
-        String logoutUserId = (loggedIn && currentUser != null) ? currentUser.getUserId() : null;
-        if (logoutUserId != null && outputStream != null
-                && connectionStatus == ConnectionStatus.CONNECTED) {
-            try {
-                outputStream.writeObject(new Request(RequestType.LOGOUT, logoutUserId));
-                outputStream.flush();
-                outputStream.reset();
-            } catch (IOException e) {
-                connectionStatus = ConnectionStatus.NOT_CONNECTED;
-                e.printStackTrace();
-            }
+    private void disconnectSocket() {
+        final ObjectOutputStream out;
+        final ObjectInputStream in;
+        final Socket sock;
+        synchronized (this) {
+            out = outputStream; outputStream = null;
+            in = inputStream;   inputStream = null;
+            sock = socket;      socket = null;
+            connectionStatus = ConnectionStatus.NOT_CONNECTED;
         }
-        connectionStatus = ConnectionStatus.NOT_CONNECTED;
-        try {
-            if (inputStream != null) {
-                inputStream.close();
-            }
-        } catch (IOException ignored) {
-        }
-        inputStream = null;
-        try {
-            if (outputStream != null) {
-                outputStream.close();
-            }
-        } catch (IOException ignored) {
-        }
-        outputStream = null;
-        try {
-            if (socket != null && !socket.isClosed()) {
-                socket.close();
-            }
-        } catch (IOException ignored) {
-        }
-        socket = null;
+        try { if (in != null) in.close(); } catch (IOException ignored) {}
+        try { if (out != null) out.close(); } catch (IOException ignored) {}
+        try { if (sock != null && !sock.isClosed()) sock.close(); } catch (IOException ignored) {}
     }
 
     /** Package-private so tests can drive response handling directly without a live socket. */
     void processResponse(Response response) {
         if (response == null) return;
-        if (response.getType() != ResponseType.PONG) {
-            System.out.println("Processing response: " + response.getType());
-        }
         lastServerActivityMillis = System.currentTimeMillis();
         switch (response.getType()) {
             case LOGIN_RESULT:
@@ -263,7 +246,7 @@ public class ClientController {
                 connectionStatus = ConnectionStatus.CONNECTED;
                 break;
             case PONG:
-                lastServerActivityMillis = System.currentTimeMillis();
+                // lastServerActivityMillis is already updated for every response above.
                 break;
             default:
                 break;
@@ -272,10 +255,11 @@ public class ClientController {
 
     private void handleLoginResultResponse(Response response) {
         LoginResult lr = (LoginResult) response.getPayload();
-        // #193: coalesce field reset + UI updates into a single EDT task so the in-flight
-        // flag and visible button state can never be observed out-of-order with each other.
+        // Coalesce field reset + UI updates into a single EDT task so the in-flight flag and
+        // visible button state can never be observed out-of-order with each other.
         SwingUtilities.invokeLater(() -> {
-            authInFlight = false;
+            authInFlight.set(false);
+            cancelAuthWatchdog();
             if (gui != null) gui.setLoginInFlight(false);
             switch (lr.getLoginStatus()) {
                 case SUCCESS:
@@ -287,7 +271,10 @@ public class ClientController {
                     ArrayList<Conversation> sorted = lr.getConversationList() != null
                             ? new ArrayList<>(lr.getConversationList()) : new ArrayList<>();
                     sorted.sort((a, b) -> Long.compare(latestSequenceNumber(b), latestSequenceNumber(a)));
-                    conversations = Collections.synchronizedList(sorted);
+                    synchronized (conversations) {
+                        conversations.clear();
+                        conversations.addAll(sorted);
+                    }
                     currentDirectory = lr.getDirectoryUserInfoList() != null
                             ? lr.getDirectoryUserInfoList() : new ArrayList<>();
                     if (gui != null) {
@@ -305,13 +292,12 @@ public class ClientController {
 
     private void handleRegisterResultResponse(Response response) {
         RegisterResult rr = (RegisterResult) response.getPayload();
-        // #193: same EDT coalescing as handleLoginResultResponse.
         SwingUtilities.invokeLater(() -> {
-            authInFlight = false;
+            authInFlight.set(false);
+            cancelAuthWatchdog();
             if (gui != null) gui.setLoginInFlight(false);
             switch (rr.getRegisterStatus()) {
                 case SUCCESS:
-                    // #139B: pre-fill the just-registered loginName on the login screen.
                     if (gui != null) gui.showLoginView(lastRegisteredLoginName);
                     break;
                 case USER_ID_TAKEN:
@@ -332,7 +318,10 @@ public class ClientController {
         boolean shouldAdvanceLastRead = false;
         // The lastRead-advance decision must happen under the same monitor that
         // openConversationAtomically uses, so a click-to-open never captures a lastRead
-        // that an in-flight inbound has just bumped past the new message.
+        // that an in-flight inbound has just bumped past the new message. The actual
+        // setLastRead mutation is deferred to the EDT to honour the UserInfo contract;
+        // EDT preserves submission order, and openConversationAtomically also runs on
+        // the EDT, so the per-conversation pointer remains monotonic.
         synchronized (conversations) {
             for (int i = 0; i < conversations.size(); i++) {
                 if (conversations.get(i).getConversationId() == msg.getConversationId()) {
@@ -347,12 +336,19 @@ public class ClientController {
             if (isCurrentConv && currentUser != null) {
                 boolean userViewingBottom = (gui == null) || gui.userIsViewingBottom();
                 if (windowActive.get() && userViewingBottom) {
-                    currentUser.setLastRead(msg.getConversationId(), msg.getSequenceNumber());
                     shouldAdvanceLastRead = true;
                 } else {
                     deferredReadAdvance.merge(msg.getConversationId(), msg.getSequenceNumber(), Math::max);
                 }
             }
+        }
+        if (shouldAdvanceLastRead) {
+            final long convId = msg.getConversationId();
+            final long seq = msg.getSequenceNumber();
+            SwingUtilities.invokeLater(() -> {
+                UserInfo me = currentUser;
+                if (me != null) me.setLastRead(convId, seq);
+            });
         }
         if (gui != null) {
             gui.updateConversationListModel(snapshot);
@@ -387,7 +383,9 @@ public class ClientController {
             me.setLastRead(convId, seq);
             updateReadMessages(convId, seq);
         } else {
-            deferredReadAdvance.merge(convId, seq, Math::max);
+            synchronized (conversations) {
+                deferredReadAdvance.merge(convId, seq, Math::max);
+            }
         }
     }
 
@@ -407,12 +405,21 @@ public class ClientController {
      * UPDATE_READ_MESSAGES at the highest deferred seq, advance local lastRead,
      * and re-sync the open conversation's per-message snapshot. Called on window
      * activation. Idempotent on an empty buffer.
+     * <p>The drain-and-clear runs under {@code synchronized(conversations)} so it
+     * cannot race with a concurrent inbound that {@code merge}s into the same map
+     * inside {@link #handleMessageResponse}'s monitor.
      */
     public void replayReadAdvanceIfNeeded() {
         UserInfo me = currentUser;
-        if (me == null || deferredReadAdvance.isEmpty()) return;
-        HashMap<Long, Long> drained = new HashMap<>(deferredReadAdvance);
-        deferredReadAdvance.clear();
+        if (me == null) return;
+        HashMap<Long, Long> drained;
+        long openId;
+        synchronized (conversations) {
+            if (deferredReadAdvance.isEmpty()) return;
+            drained = new HashMap<>(deferredReadAdvance);
+            deferredReadAdvance.clear();
+            openId = currentConversationId;
+        }
         for (Map.Entry<Long, Long> e : drained.entrySet()) {
             long convId = e.getKey();
             long maxSeq = e.getValue();
@@ -421,14 +428,11 @@ public class ClientController {
                 updateReadMessages(convId, maxSeq);
             }
         }
-        if (gui != null) {
-            long openId = currentConversationId;
-            if (openId != -1L) {
-                Long openMax = drained.get(openId);
-                if (openMax != null) gui.markDisplayedReadUpTo(openMax);
-                gui.repaintMessageList();
-                gui.repaintConversationList();
-            }
+        if (gui != null && openId != -1L) {
+            Long openMax = drained.get(openId);
+            if (openMax != null) gui.markDisplayedReadUpTo(openMax);
+            gui.repaintMessageList();
+            gui.repaintConversationList();
         }
     }
 
@@ -456,6 +460,9 @@ public class ClientController {
 
     private void handleConversationMetadataResponse(Response response) {
         ConversationMetadata meta = (ConversationMetadata) response.getPayload();
+        // TODO(meta-merge): meta is currently never merged into the matching Conversation —
+        // either fold participant updates from `meta` into the in-cache Conversation, or
+        // delete this handler if the server-side emitter has been removed.
         ArrayList<Conversation> snapshot;
         synchronized (conversations) {
             boolean found = false;
@@ -481,17 +488,17 @@ public class ClientController {
         UserCreationPayload payload = (UserCreationPayload) response.getPayload();
         if (payload == null || payload.getUserInfo() == null) return;
         UserInfo created = payload.getUserInfo();
-        boolean exists = false;
-        for (UserInfo u : currentDirectory) {
-            if (u != null && Objects.equals(u.getUserId(), created.getUserId())) {
-                exists = true;
-                break;
+        // EDT-marshal: currentDirectory is read on EDT (search filter, directory render);
+        // mutating it on the response thread would race with EDT iteration.
+        SwingUtilities.invokeLater(() -> {
+            for (UserInfo u : currentDirectory) {
+                if (u != null && Objects.equals(u.getUserId(), created.getUserId())) {
+                    return;
+                }
             }
-        }
-        if (!exists) {
             currentDirectory.add(created);
             if (gui != null) gui.updateDirectoryModel(getFilteredDirectory(""));
-        }
+        });
     }
 
     private void handleLeaveResultResponse(Response response) {
@@ -545,10 +552,15 @@ public class ClientController {
     private void handleAdminConversationResultResponse(Response response) {
         // AdminConversationResult carries ConversationMetadata — store it directly.
         AdminConversationResult acr = (AdminConversationResult) response.getPayload();
-        currentAdminConversationSearch = new ArrayList<>(acr.getConversations());
-        if (gui != null) {
-            gui.updateAdminConversationSearchModel(currentAdminConversationSearch);
-        }
+        // EDT-marshal: currentAdminConversationSearch is read on the EDT (admin dialog
+        // filter, model update). Reassigning the reference on the response thread races
+        // EDT iteration in getFilteredAdminConversationSearch.
+        SwingUtilities.invokeLater(() -> {
+            currentAdminConversationSearch = new ArrayList<>(acr.getConversations());
+            if (gui != null) {
+                gui.updateAdminConversationSearchModel(currentAdminConversationSearch);
+            }
+        });
     }
 
     /** Routes the admin's silent read into the open admin viewer panel. Does not touch
@@ -561,11 +573,11 @@ public class ClientController {
         }
     }
 
-    /** Lazily opens a TCP connection to the server and initializes the input and output streams*/
+    /** Lazily opens a TCP connection to the server and initializes the input and output streams.
+     *  Synchronized so the state field flip and stream creation happen as one block — concurrent
+     *  callers either skip out at the CONNECTED check or wait their turn. */
     private synchronized void ensureConnected() throws IOException {
         if (connectionStatus == ConnectionStatus.CONNECTED) return;
-        connectionStatus = ConnectionStatus.CONNECTING;
-        // #138: bounded connect timeout so unreachable server fails fast instead of hanging ~75s.
         socket = new Socket();
         socket.connect(new InetSocketAddress(hostIp, hostPort), CONNECT_TIMEOUT_MS);
         // OOS must be created and flushed BEFORE OIS on both sides to avoid header deadlock
@@ -577,7 +589,19 @@ public class ClientController {
         lastServerActivityMillis = System.currentTimeMillis();
     }
 
-    private static final int CONNECT_TIMEOUT_MS = 7000;
+    /** Captures {@link #currentUser} once and returns it iff a session is active. Any caller
+     *  that derefs {@code currentUser} more than once should go through this helper to avoid
+     *  the volatile reference flipping to null mid-method. */
+    private UserInfo requireSession() {
+        UserInfo me = currentUser;
+        return (loggedIn && me != null) ? me : null;
+    }
+
+    /** Same contract as {@link #requireSession()} but additionally requires admin privileges. */
+    private UserInfo requireAdminSession() {
+        UserInfo me = requireSession();
+        return (me != null && me.getUserType() == UserType.ADMIN) ? me : null;
+    }
 
     // -------------------------------------------------------------------------
     // Public action methods — each maps 1-to-1 with a DataManager handler.
@@ -585,45 +609,109 @@ public class ClientController {
 
     /** Matches DataManager.handleRegister — payload: RegisterCredentials(userId, loginName, password, name). */
     public void register(String userId, String realName, String loginName, char[] password) {
-        if (authInFlight) return; // #140: drop rapid duplicate clicks
-        authInFlight = true;
+        if (!authInFlight.compareAndSet(false, true)) return; // drop rapid duplicate clicks
         lastRegisteredLoginName = loginName;
         if (gui != null) gui.setLoginInFlight(true);
+        startAuthWatchdog();
         RegisterCredentials creds = new RegisterCredentials(userId, loginName, new String(password), realName);
         enqueueRequest(new Request(RequestType.REGISTER, creds, null));
     }
 
     /** Matches DataManager.handleLogin — payload: LoginCredentials(loginName, password). */
     public void login(String loginName, char[] password) {
-        if (authInFlight) return; // #140: drop rapid duplicate clicks
-        authInFlight = true;
+        if (!authInFlight.compareAndSet(false, true)) return; // drop rapid duplicate clicks
         if (gui != null) gui.setLoginInFlight(true);
+        startAuthWatchdog();
         LoginCredentials creds = new LoginCredentials(loginName, new String(password));
         enqueueRequest(new Request(RequestType.LOGIN, creds, null));
     }
 
+    /** EDT-only. Replaces any prior watchdog with a single-shot timer that fires after
+     *  {@link #AUTH_WATCHDOG_MS} if the server never responds, freeing the login button. */
+    private void startAuthWatchdog() {
+        if (authWatchdogTimer != null) authWatchdogTimer.stop();
+        authWatchdogTimer = new javax.swing.Timer(AUTH_WATCHDOG_MS, e -> {
+            if (authInFlight.compareAndSet(true, false)) {
+                if (gui != null) {
+                    gui.setLoginInFlight(false);
+                    gui.showNetworkError();
+                }
+            }
+        });
+        authWatchdogTimer.setRepeats(false);
+        authWatchdogTimer.start();
+    }
+
+    /** EDT-only. Stops the watchdog if running. */
+    private void cancelAuthWatchdog() {
+        if (authWatchdogTimer != null) {
+            authWatchdogTimer.stop();
+            authWatchdogTimer = null;
+        }
+    }
+
     /**
-     * Clears local session (lists, queue, flags), shows login UI, sends {@link RequestType#LOGOUT} on the
-     * wire (if connected), then {@link #disconnectSocket()}. Session tracking lives outside
-     * {@code DataManager}.
+     * Clears local session synchronously (lists, queue, flags) and switches to the login view.
+     * The wire LOGOUT and stream teardown run on a daemon helper so the EDT does not block on
+     * socket I/O. Session tracking lives outside {@code DataManager}.
+     * <p>
+     * Ordering: we clear {@link #requestQueue} <i>before</i> capturing/nulling the streams so any
+     * request the drain thread already pulled with {@code take()} will, on its next
+     * {@link #sendRequest(Request)} call, observe {@code outputStream == null} and drop silently.
+     * The captured stream refs are local to the helper, so a subsequent re-login can rebuild a
+     * fresh connection via {@link #ensureConnected()} without racing the in-flight LOGOUT write.
      */
     public void logout() {
-        if (!loggedIn || currentUser == null) return;
-        disconnectSocket();
+        UserInfo me = requireSession();
+        if (me == null) return;
+        String userId = me.getUserId();
+        // Clear queue first; drained-but-not-yet-sent requests will observe NOT_CONNECTED below.
+        requestQueue.clear();
+        // Capture-and-null the streams under `this` so concurrent ensureConnected/sendRequest
+        // see a consistent (out, in, socket) triple. The captured triple is handed to the helper.
+        final ObjectOutputStream out;
+        final ObjectInputStream in;
+        final Socket sock;
+        final boolean wasConnected;
+        synchronized (this) {
+            out = outputStream; outputStream = null;
+            in = inputStream;   inputStream = null;
+            sock = socket;      socket = null;
+            wasConnected = connectionStatus == ConnectionStatus.CONNECTED;
+            connectionStatus = ConnectionStatus.NOT_CONNECTED;
+        }
         loggedIn = false;
         currentUser = null;
         conversations.clear();
         currentConversationId = -1;
         currentAdminConversationSearch.clear();
         currentDirectory.clear();
-        requestQueue.clear();
         if (gui != null) gui.showLoginView();
+        Thread t = new Thread(() -> closeWithLogout(userId, wasConnected, out, in, sock),
+                              "client-logout");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    /** Off-EDT helper: best-effort LOGOUT write on the captured stream, then close all three. */
+    private static void closeWithLogout(String userId, boolean wasConnected,
+                                        ObjectOutputStream out, ObjectInputStream in, Socket sock) {
+        if (wasConnected && out != null) {
+            try {
+                out.writeObject(new Request(RequestType.LOGOUT, null, userId));
+                out.flush();
+            } catch (IOException ignored) { /* socket already gone — close path below handles it */ }
+        }
+        try { if (in != null) in.close(); } catch (IOException ignored) {}
+        try { if (out != null) out.close(); } catch (IOException ignored) {}
+        try { if (sock != null && !sock.isClosed()) sock.close(); } catch (IOException ignored) {}
     }
 
     /** #55/#124: read the cached admin search results so the dialog can seed itself on open
-     *  even if the response arrived before the dialog finished constructing. */
+     *  even if the response arrived before the dialog finished constructing. Defensive copy:
+     *  the live list is reassigned + cleared on the EDT, so callers must not retain a reference. */
     public ArrayList<ConversationMetadata> getCurrentAdminConversationSearch() {
-        return currentAdminConversationSearch;
+        return new ArrayList<>(currentAdminConversationSearch);
     }
 
     /** #128: clear the cached admin search results so reopening the dialog starts fresh. */
@@ -633,61 +721,68 @@ public class ClientController {
 
     /** Matches DataManager.handleSendMessage — payload: RawMessage(text, conversationId). */
     public void sendMessage(long conversationId, String m) {
-        if (!loggedIn || currentUser == null) return;
+        UserInfo me = requireSession();
+        if (me == null) return;
         enqueueRequest(new Request(RequestType.MESSAGE,
-                new RawMessage(m, conversationId), currentUser.getUserId()));
+                new RawMessage(m, conversationId), me.getUserId()));
     }
 
     /** Matches DataManager.handleCreateConversation — payload: CreateConversationPayload(participants). */
     public void createConversation(ArrayList<UserInfo> p) {
-        if (!loggedIn || currentUser == null) return;
+        UserInfo me = requireSession();
+        if (me == null) return;
         ArrayList<UserInfo> participants = new ArrayList<>(p);
         boolean creatorPresent = false;
         for (UserInfo u : participants) {
-            if (currentUser.getUserId().equals(u.getUserId())) { creatorPresent = true; break; }
+            if (me.getUserId().equals(u.getUserId())) { creatorPresent = true; break; }
         }
-        if (!creatorPresent) participants.add(0, currentUser);
+        if (!creatorPresent) participants.add(0, me);
         enqueueRequest(new Request(RequestType.CREATE_CONVERSATION,
-                new CreateConversationPayload(participants), currentUser.getUserId()));
+                new CreateConversationPayload(participants), me.getUserId()));
     }
 
     /** Matches DataManager.handleAddToConversation — payload: AddToConversationPayload(participants, conversationId). */
     public void addToConversation(ArrayList<UserInfo> p, long conversationId) {
-        if (!loggedIn || currentUser == null) return;
+        UserInfo me = requireSession();
+        if (me == null) return;
         enqueueRequest(new Request(RequestType.ADD_PARTICIPANT,
-                new AddToConversationPayload(p, conversationId), currentUser.getUserId()));
+                new AddToConversationPayload(p, conversationId), me.getUserId()));
     }
 
     /** Matches DataManager.handleLeaveConversation — payload: LeaveConversationPayload(conversationId). */
     public void leaveConversation(long conversationId) {
-        if (!loggedIn || currentUser == null) return;
+        UserInfo me = requireSession();
+        if (me == null) return;
         enqueueRequest(new Request(RequestType.LEAVE_CONVERSATION,
-                new LeaveConversationPayload(conversationId), currentUser.getUserId()));
+                new LeaveConversationPayload(conversationId), me.getUserId()));
     }
 
     /** Matches DataManager.handleUpdateReadMessages — payload: UpdateReadMessages(conversationId, lastSeenSequenceNumber). */
     public void updateReadMessages(long conversationId, long lastSeenSequenceNumber) {
-        if (!loggedIn || currentUser == null) return;
+        UserInfo me = requireSession();
+        if (me == null) return;
         enqueueRequest(new Request(
                 RequestType.UPDATE_READ_MESSAGES,
                 new UpdateReadMessages(conversationId, lastSeenSequenceNumber),
-                currentUser.getUserId()));
+                me.getUserId()));
     }
 
     /** Matches DataManager.handleAdminConversationQuery — payload: AdminConversationQuery(userID). */
     public void adminGetUserConversations(String userID) {
-        if (!loggedIn || currentUser == null || currentUser.getUserType() != UserType.ADMIN) return;
+        UserInfo me = requireAdminSession();
+        if (me == null) return;
         enqueueRequest(new Request(RequestType.ADMIN_CONVERSATION_QUERY,
-                new AdminConversationQuery(userID), currentUser.getUserId()));
+                new AdminConversationQuery(userID), me.getUserId()));
     }
 
     /** Matches DataManager.handleAdminViewConversation — payload: AdminViewConversationQuery(conversationId).
      *  Pulls a full read-only snapshot for the admin viewer; server does NOT mutate the
      *  participant list, so other clients are unaware of the lookup. */
     public void adminViewConversation(long conversationId) {
-        if (!loggedIn || currentUser == null || currentUser.getUserType() != UserType.ADMIN) return;
+        UserInfo me = requireAdminSession();
+        if (me == null) return;
         enqueueRequest(new Request(RequestType.ADMIN_VIEW_CONVERSATION,
-                new AdminViewConversationQuery(conversationId), currentUser.getUserId()));
+                new AdminViewConversationQuery(conversationId), me.getUserId()));
     }
 
     /** Matches DataManager.handleJoinConversation — payload: JoinConversationPayload(conversationId). */
@@ -739,9 +834,7 @@ public class ClientController {
         ArrayList<UserInfo> filtered = new ArrayList<>();
         String q = query.toLowerCase();
         for (UserInfo u : currentDirectory) {
-            if (u.getUserId().toLowerCase().contains(q) || u.getName().toLowerCase().contains(q)) {
-                filtered.add(u);
-            }
+            if (userMatches(u, q)) filtered.add(u);
         }
         return filtered;
     }
@@ -757,19 +850,14 @@ public class ClientController {
             ArrayList<Conversation> filtered = new ArrayList<>();
             String q = query.toLowerCase();
             for (Conversation c : conversations) {
-                for (UserInfo p : c.getParticipants()) {
-                    if (p.getName().toLowerCase().contains(q) || p.getUserId().toLowerCase().contains(q)) {
-                        filtered.add(c);
-                        break;
-                    }
-                }
+                if (anyUserMatches(c.getParticipants(), q)) filtered.add(c);
             }
             filtered.sort((a, b) -> Long.compare(latestSequenceNumber(b), latestSequenceNumber(a)));
             return filtered;
         }
     }
 
-    private long latestSequenceNumber(Conversation c) {
+    private static long latestSequenceNumber(Conversation c) {
         if (c == null) return 0L;
         if (c.getMessages().isEmpty()) {
             // Empty conversations have no message sequence yet; use conversationId as a
@@ -787,20 +875,27 @@ public class ClientController {
         ArrayList<ConversationMetadata> filtered = new ArrayList<>();
         String query = q.toLowerCase();
         for (ConversationMetadata m : currentAdminConversationSearch) {
-            if (matchesParticipant(m.getParticipants(), query)
-                    || matchesParticipant(m.getHistoricalParticipants(), query)) {
+            if (anyUserMatches(m.getParticipants(), query)
+                    || anyUserMatches(m.getHistoricalParticipants(), query)) {
                 filtered.add(m);
             }
         }
         return filtered;
     }
 
-    private static boolean matchesParticipant(ArrayList<UserInfo> people, String query) {
+    /** Case-insensitive substring match on userId OR name. {@code lowerQuery} is assumed
+     *  pre-lowercased — do this once at the call site, not per-element. */
+    private static boolean userMatches(UserInfo u, String lowerQuery) {
+        if (u == null) return false;
+        return u.getUserId().toLowerCase().contains(lowerQuery)
+                || u.getName().toLowerCase().contains(lowerQuery);
+    }
+
+    /** True iff any user in {@code people} matches {@code lowerQuery} per {@link #userMatches}. */
+    private static boolean anyUserMatches(Collection<UserInfo> people, String lowerQuery) {
         if (people == null) return false;
-        for (UserInfo p : people) {
-            if (p.getName().toLowerCase().contains(query) || p.getUserId().toLowerCase().contains(query)) {
-                return true;
-            }
+        for (UserInfo u : people) {
+            if (userMatches(u, lowerQuery)) return true;
         }
         return false;
     }
@@ -821,37 +916,16 @@ public class ClientController {
 
     /**
      * Fix E2: atomically capture the triple (conversation reference, viewer's lastRead at open
-     * time, defensive message-list snapshot) under the {@code conversations} monitor. Closes
-     * the race between the click-to-open handler reading {@code lastRead} and {@code Conversation.append}
-     * adding a new message before {@link ConversationView#setListModel} consumes the message list:
-     * without atomic capture, the freshly-arrived message could land in the wrong half of the
+     * time, defensive message-list snapshot) under the {@code conversations} monitor AND publish
+     * {@code currentConversationId} in the same critical section. Closes the race between the
+     * click-to-open handler reading {@code lastRead} and {@code Conversation.append} adding a
+     * new message before {@link ConversationView#setListModel} consumes the message list: without
+     * atomic capture, the freshly-arrived message could land in the wrong half of the
      * "New messages" divider boundary.
      * <p>Returns null if no user is logged in or the conversation is unknown.
      * <p>Lock order: {@code conversations} → {@code Conversation.this} (via {@link Conversation#getMessages()}).
      * This matches {@link #handleMessageResponse} which acquires {@code conversations} then {@code Conversation.append}
      * in the same order, so deadlock is impossible.
-     */
-    public ConversationOpenSnapshot getConversationSnapshotForOpen(long id) {
-        UserInfo me = currentUser;
-        if (me == null) return null;
-        synchronized (conversations) {
-            for (Conversation c : conversations) {
-                if (c.getConversationId() == id) {
-                    long lastRead = me.getLastRead(id);
-                    ArrayList<Message> snap = c.getMessages();
-                    return new ConversationOpenSnapshot(c, lastRead, snap);
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Atomic open: captures the (lastRead, messages) pair AND publishes
-     * {@code currentConversationId} under the same {@code conversations} monitor that
-     * {@link #handleMessageResponse} uses to append inbound messages and decide whether
-     * to advance lastRead. Without serialization the EDT could snapshot lastRead AFTER
-     * a concurrent inbound advanced it past the new message, erasing the divider.
      */
     public ConversationOpenSnapshot openConversationAtomically(long id) {
         UserInfo me = currentUser;
@@ -884,46 +958,63 @@ public class ClientController {
         }
     }
 
-    /**
-     * True iff {@code viewer}'s last-read pointer trails the latest message sequence in {@code conv}.
-     * Returns false if either argument is null. Used by the conversation-list cell renderer to
-     * decide whether to bold a row and prepend the unread glyph.
-     */
-    public static boolean isUnread(Conversation conv, UserInfo viewer) {
-        if (conv == null || viewer == null) return false;
-        long lastReadSeq = viewer.getLastRead(conv.getConversationId());
-        ArrayList<Message> msgs = conv.getMessages();
-        long latestSeq = msgs.isEmpty() ? 0L : msgs.get(msgs.size() - 1).getSequenceNumber();
-        return latestSeq > lastReadSeq;
-    }
+    // -------------------------------------------------------------------------
+    // Read/unread math — pure functions, grouped under ReadCalc to signal intent.
+    // The public statics on ClientController are one-line delegates so existing
+    // call sites (UI renderers, tests pinning ClientController.isUnread / etc.)
+    // continue to compile.
+    // -------------------------------------------------------------------------
 
-    /**
-     * True iff {@code msg}'s sequence number is strictly above the snapshot pointer
-     * {@code displayedLastReadSeq}. Mirrors the per-message dot predicate used by
-     * the conversation panel renderer; exposed for unit tests.
-     */
-    public static boolean isMessageUnread(Message msg, long displayedLastReadSeq) {
-        if (msg == null) return false;
-        return msg.getSequenceNumber() > displayedLastReadSeq;
-    }
+    /** Pure read-state calculations. Stateless; no instance fields. */
+    private static final class ReadCalc {
+        private ReadCalc() {}
 
-    /**
-     * Number of messages in {@code conv} with sequence above {@code viewer}'s last-read pointer.
-     * Returns 0 if either argument is null, the conversation is empty, or the viewer is already
-     * caught up. Used by the sidebar cell renderer to populate the unread-count badge.
-     * <p>Implementation is an O(unread) backward scan that stops at the first read message,
-     * relying on Conversation.append being the only mutator and appending in monotonic seq order.
-     */
-    public static int unreadCount(Conversation conv, UserInfo viewer) {
-        if (conv == null || viewer == null) return 0;
-        long lastReadSeq = viewer.getLastRead(conv.getConversationId());
-        ArrayList<Message> msgs = conv.getMessages();
-        int count = 0;
-        for (int i = msgs.size() - 1; i >= 0; i--) {
-            if (msgs.get(i).getSequenceNumber() > lastReadSeq) count++;
-            else break;
+        /** True iff {@code viewer}'s last-read pointer trails the latest message sequence in {@code conv}. */
+        static boolean isUnread(Conversation conv, UserInfo viewer) {
+            if (conv == null || viewer == null) return false;
+            long lastReadSeq = viewer.getLastRead(conv.getConversationId());
+            ArrayList<Message> msgs = conv.getMessages();
+            long latestSeq = msgs.isEmpty() ? 0L : msgs.get(msgs.size() - 1).getSequenceNumber();
+            return latestSeq > lastReadSeq;
         }
-        return count;
+
+        /** True iff {@code msg}'s sequence number is strictly above {@code displayedLastReadSeq}. */
+        static boolean isMessageUnread(Message msg, long displayedLastReadSeq) {
+            if (msg == null) return false;
+            return msg.getSequenceNumber() > displayedLastReadSeq;
+        }
+
+        /** O(unread) backward scan; stops at the first read message. Relies on
+         *  {@link Conversation#append} being the only mutator and appending in monotonic seq order. */
+        static int unreadCount(Conversation conv, UserInfo viewer) {
+            if (conv == null || viewer == null) return 0;
+            long lastReadSeq = viewer.getLastRead(conv.getConversationId());
+            ArrayList<Message> msgs = conv.getMessages();
+            int count = 0;
+            for (int i = msgs.size() - 1; i >= 0; i--) {
+                if (msgs.get(i).getSequenceNumber() > lastReadSeq) count++;
+                else break;
+            }
+            return count;
+        }
+    }
+
+    /** Used by the conversation-list cell renderer to decide whether to bold a row and prepend
+     *  the unread glyph. Returns false if either argument is null. */
+    public static boolean isUnread(Conversation conv, UserInfo viewer) {
+        return ReadCalc.isUnread(conv, viewer);
+    }
+
+    /** Per-message dot predicate paired with the open-conversation snapshot so the renderer
+     *  and sidebar stay aligned. Returns false if {@code msg} is null. */
+    public static boolean isMessageUnread(Message msg, long displayedLastReadSeq) {
+        return ReadCalc.isMessageUnread(msg, displayedLastReadSeq);
+    }
+
+    /** Count of messages in {@code conv} with sequence above {@code viewer}'s last-read pointer.
+     *  Returns 0 if either argument is null, the conversation is empty, or already caught up. */
+    public static int unreadCount(Conversation conv, UserInfo viewer) {
+        return ReadCalc.unreadCount(conv, viewer);
     }
 
     /** Writes a {@link Request} to the socket stream. Synchronized to prevent interleaved writes. */
@@ -964,20 +1055,23 @@ public class ClientController {
                     sendRequest(r);
                 } catch (IOException e) {
                     connectionStatus = ConnectionStatus.NOT_CONNECTED;
-                    if (authInFlight) {
+                    if (authInFlight.compareAndSet(true, false)) {
                         // #138: drop the queued auth request and notify the user instead of
-                        // silently retrying the unreachable server forever.
-                        authInFlight = false;
-                        if (gui != null) {
-                            gui.setLoginInFlight(false);
-                            gui.showNetworkError();
-                        }
+                        // silently retrying the unreachable server forever. EDT-marshal the
+                        // GUI updates and watchdog-cancel since this is the drain thread.
+                        SwingUtilities.invokeLater(() -> {
+                            cancelAuthWatchdog();
+                            if (gui != null) {
+                                gui.setLoginInFlight(false);
+                                gui.showNetworkError();
+                            }
+                        });
                     } else {
                         requestQueue.addFirst(r);
                     }
                     e.printStackTrace();
                     try {
-                        Thread.sleep(300L);
+                        Thread.sleep(RETRY_BACKOFF_MS);
                     } catch (InterruptedException ie) {
                         Thread.currentThread().interrupt();
                         break;
@@ -996,7 +1090,7 @@ public class ClientController {
                 while (!Thread.currentThread().isInterrupted()
                         && connectionStatus != ConnectionStatus.CONNECTED) {
                     try {
-                        Thread.sleep(500L);
+                        Thread.sleep(RECONNECT_POLL_MS);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         break;
@@ -1028,15 +1122,12 @@ public class ClientController {
     }
 
     private void startInactivityDetectorThread() {
-        final long pingIntervalMs = 30_000L;
-        final long inactivityLimitMs = 300_000L;
-        final long waitForConnectPollMs = 500L;
         inactivityDetectorThread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
                 while (!Thread.currentThread().isInterrupted()
                         && connectionStatus != ConnectionStatus.CONNECTED) {
                     try {
-                        Thread.sleep(waitForConnectPollMs);
+                        Thread.sleep(RECONNECT_POLL_MS);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         break;
@@ -1047,13 +1138,13 @@ public class ClientController {
                 while (!Thread.currentThread().isInterrupted()
                         && connectionStatus == ConnectionStatus.CONNECTED) {
                     try {
-                        Thread.sleep(pingIntervalMs);
+                        Thread.sleep(PING_INTERVAL_MS);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         break;
                     }
                     long idle = System.currentTimeMillis() - lastServerActivityMillis;
-                    if (idle >= inactivityLimitMs) {
+                    if (idle >= INACTIVITY_LIMIT_MS) {
                         logout();
                         break;
                     }

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -1,5 +1,6 @@
 package client;
 
+import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -18,46 +19,25 @@ import shared.payload.*;
 
 public class ClientController {
 
-    // -------------------------------------------------------------------------
-    // UI
-    // -------------------------------------------------------------------------
-
     private final ClientUI gui;
-
-    // -------------------------------------------------------------------------
-    // Server endpoint (fixed for this controller instance)
-    // -------------------------------------------------------------------------
-
     private final String hostIp;
     private final int hostPort;
-
-    // -------------------------------------------------------------------------
-    // TCP connection + object streams
-    // -------------------------------------------------------------------------
 
     private volatile ConnectionStatus connectionStatus = ConnectionStatus.NOT_CONNECTED;
     private Socket socket;
     private ObjectOutputStream outputStream;
     private ObjectInputStream inputStream;
 
-    // -------------------------------------------------------------------------
-    // Outbound requests + background workers
-    // -------------------------------------------------------------------------
-
     private final LinkedBlockingDeque<Request> requestQueue = new LinkedBlockingDeque<>();
     private Thread requestDrainThread;
     private Thread responseListenerThread;
     private Thread inactivityDetectorThread;
 
-    // -------------------------------------------------------------------------
-    // Session (authenticated user)
-    // -------------------------------------------------------------------------
-
     private volatile boolean loggedIn = false;
     /**
-     * The reference is reassigned off-EDT (response listener publishes a fresh instance with
-     * lastRead pre-populated); after publication, the lastRead map is mutated only on the EDT.
-     * volatile ensures readers observe the freshest reference.
+     * Reassigned off-EDT (response listener publishes a fresh instance with lastRead pre-populated);
+     * after publication, the lastRead map is mutated only on the EDT. volatile ensures readers
+     * observe the freshest reference.
      */
     private volatile UserInfo currentUser;
     /** Atomic so rapid duplicate clicks lose the compareAndSet race rather than both passing
@@ -68,21 +48,11 @@ public class ClientController {
     private static final int AUTH_WATCHDOG_MS = 15_000;
     private volatile String lastRegisteredLoginName = null;
 
-    // -------------------------------------------------------------------------
-    // Client-side caches backing list views / filters
-    // -------------------------------------------------------------------------
-
     private final List<Conversation> conversations = Collections.synchronizedList(new ArrayList<>());
     /** -1 means no conversation selected. */
     private volatile long currentConversationId = -1;
     private ArrayList<UserInfo> currentDirectory = new ArrayList<>();
     private ArrayList<ConversationMetadata> currentAdminConversationSearch = new ArrayList<>();
-
-    // -------------------------------------------------------------------------
-    // Window-focus gate: inbound messages while the OS window is inactive must
-    // NOT advance the read pointer. Buffer the per-conversation max sequence
-    // and replay on activation, coalescing a burst into one UPDATE_READ_MESSAGES.
-    // -------------------------------------------------------------------------
 
     /** Defaults true so headless tests and pre-window-event states do not suppress reads. */
     private final AtomicBoolean windowActive = new AtomicBoolean(true);
@@ -93,15 +63,7 @@ public class ClientController {
      */
     private final HashMap<Long, Long> deferredReadAdvance = new HashMap<>();
 
-    // -------------------------------------------------------------------------
-    // Server path liveness (updated on inbound server-driven signals, e.g. PONG)
-    // -------------------------------------------------------------------------
-
     private volatile long lastServerActivityMillis = System.currentTimeMillis();
-
-    // -------------------------------------------------------------------------
-    // Tunables
-    // -------------------------------------------------------------------------
 
     /** Bounded so an unreachable server fails fast (~7s) rather than the ~75s OS default. */
     private static final int CONNECT_TIMEOUT_MS = 7000;
@@ -146,11 +108,8 @@ public class ClientController {
         disconnectSocket();
     }
 
-    /**
-     * Closes streams and socket without stopping background threads, so they can wait for the
-     * next lazy reconnect. Field swaps happen under {@code synchronized(this)} so concurrent
-     * {@link #ensureConnected} / {@link #sendRequest} calls observe a consistent (out, in, socket) triple.
-     */
+    /** Field swaps under {@code synchronized(this)} so concurrent ensureConnected/sendRequest
+     *  observe a consistent (out, in, socket) triple. Threads stay alive for lazy reconnect. */
     private void disconnectSocket() {
         final ObjectOutputStream out;
         final ObjectInputStream in;
@@ -161,9 +120,13 @@ public class ClientController {
             sock = socket;      socket = null;
             connectionStatus = ConnectionStatus.NOT_CONNECTED;
         }
-        try { if (in != null) in.close(); } catch (IOException ignored) {}
-        try { if (out != null) out.close(); } catch (IOException ignored) {}
-        try { if (sock != null && !sock.isClosed()) sock.close(); } catch (IOException ignored) {}
+        closeQuietly(in, out, sock);
+    }
+
+    private static void closeQuietly(Closeable... streams) {
+        for (Closeable s : streams) {
+            if (s != null) try { s.close(); } catch (IOException ignored) {}
+        }
     }
 
     /** Test seam: drive response handling directly without a live socket. */
@@ -171,51 +134,23 @@ public class ClientController {
         if (response == null) return;
         lastServerActivityMillis = System.currentTimeMillis();
         switch (response.getType()) {
-            case LOGIN_RESULT:
-                handleLoginResultResponse(response);
-                break;
-            case REGISTER_RESULT:
-                handleRegisterResultResponse(response);
-                break;
-            case MESSAGE:
-                handleMessageResponse(response);
-                break;
-            case CONVERSATION:
-                handleConversationResponse(response);
-                break;
-            case LEAVE_RESULT:
-                handleLeaveResultResponse(response);
-                break;
-            case READ_MESSAGES_UPDATED:
-                handleReadMessagesUpdatedResponse(response);
-                break;
-            case ADMIN_CONVERSATION_RESULT:
-                handleAdminConversationResultResponse(response);
-                break;
-            case ADMIN_VIEW_CONVERSATION_RESULT:
-                handleAdminViewConversationResultResponse(response);
-                break;
-            case CONVERSATION_METADATA:
-                handleConversationMetadataResponse(response);
-                break;
-            case USER_CREATION:
-                handleUserCreationResponse(response);
-                break;
-            case CONNECTED:
-                connectionStatus = ConnectionStatus.CONNECTED;
-                break;
-            case PONG:
-                // lastServerActivityMillis already updated above; nothing else to do.
-                break;
-            default:
-                break;
+            case LOGIN_RESULT:                   handleLoginResultResponse(response); break;
+            case REGISTER_RESULT:                handleRegisterResultResponse(response); break;
+            case MESSAGE:                        handleMessageResponse(response); break;
+            case CONVERSATION:                   handleConversationResponse(response); break;
+            case LEAVE_RESULT:                   handleLeaveResultResponse(response); break;
+            case READ_MESSAGES_UPDATED:          handleReadMessagesUpdatedResponse(response); break;
+            case ADMIN_CONVERSATION_RESULT:      handleAdminConversationResultResponse(response); break;
+            case ADMIN_VIEW_CONVERSATION_RESULT: handleAdminViewConversationResultResponse(response); break;
+            case USER_CREATION:                  handleUserCreationResponse(response); break;
+            case CONNECTED:                      connectionStatus = ConnectionStatus.CONNECTED; break;
+            case PONG:                           break;
+            default:                             break;
         }
     }
 
     private void handleLoginResultResponse(Response response) {
         LoginResult lr = (LoginResult) response.getPayload();
-        // Coalesce field reset + UI updates into one EDT task so the in-flight flag and
-        // button state cannot be observed out-of-order.
         SwingUtilities.invokeLater(() -> {
             authInFlight.set(false);
             cancelAuthWatchdog();
@@ -224,20 +159,15 @@ public class ClientController {
                 case SUCCESS:
                     loggedIn = true;
                     currentUser = lr.getUserInfo();
-                    // Defense-in-depth: server already sorts the wire payload, but re-sort
-                    // here so the controller's recency invariant holds for any direct consumer.
-                    ArrayList<Conversation> sorted = lr.getConversationList() != null
-                            ? new ArrayList<>(lr.getConversationList()) : new ArrayList<>();
-                    sorted.sort((a, b) -> Long.compare(latestSequenceNumber(b), latestSequenceNumber(a)));
                     synchronized (conversations) {
                         conversations.clear();
-                        conversations.addAll(sorted);
+                        if (lr.getConversationList() != null) {
+                            conversations.addAll(lr.getConversationList());
+                        }
                     }
                     currentDirectory = lr.getDirectoryUserInfoList() != null
                             ? lr.getDirectoryUserInfoList() : new ArrayList<>();
-                    if (gui != null) {
-                        gui.showMainView();
-                    }
+                    if (gui != null) gui.showMainView();
                     break;
                 case INVALID_CREDENTIALS:
                 case NO_ACCOUNT_EXISTS:
@@ -275,8 +205,8 @@ public class ClientController {
         boolean shouldAdvanceLastRead = false;
         // The lastRead-advance decision must happen under the same monitor that
         // openConversationAtomically uses, so a click-to-open cannot capture a stale lastRead.
-        // The setLastRead mutation is deferred to the EDT (per UserInfo's contract); EDT
-        // preserves submission order, so the per-conversation pointer stays monotonic.
+        // setLastRead is deferred to the EDT (per UserInfo's contract); EDT preserves submission
+        // order, so the per-conversation pointer stays monotonic.
         synchronized (conversations) {
             for (int i = 0; i < conversations.size(); i++) {
                 if (conversations.get(i).getConversationId() == msg.getConversationId()) {
@@ -316,28 +246,6 @@ public class ClientController {
         }
     }
 
-    /**
-     * Gate is {@code windowActive && userIsViewingBottom}: optimistically advance
-     * {@code currentUser.lastRead} and ask the server to persist; otherwise buffer the
-     * per-conversation max seq for replay on the next window activation.
-     * <p>Test seam: {@link #handleMessageResponse} inlines the same decision on the live
-     * path under the {@code conversations} monitor — keep the two implementations in sync.
-     * Headless callers (gui == null) implicitly satisfy the bottom-viewing predicate.
-     */
-    void tryAdvanceReadOnInbound(long convId, long seq) {
-        UserInfo me = currentUser;
-        if (me == null) return;
-        boolean userViewingBottom = (gui == null) || gui.userIsViewingBottom();
-        if (windowActive.get() && userViewingBottom) {
-            me.setLastRead(convId, seq);
-            updateReadMessages(convId, seq);
-        } else {
-            synchronized (conversations) {
-                deferredReadAdvance.merge(convId, seq, Math::max);
-            }
-        }
-    }
-
     public void setWindowActive(boolean active) {
         windowActive.set(active);
     }
@@ -346,12 +254,8 @@ public class ClientController {
         return windowActive.get();
     }
 
-    /**
-     * Drain {@link #deferredReadAdvance}: send one UPDATE_READ_MESSAGES per conversation at the
-     * highest deferred seq, advance local lastRead, and re-sync the open conversation. Idempotent
-     * on an empty buffer. Drain-and-clear runs under {@code synchronized(conversations)} so it
-     * cannot race a concurrent inbound merging into the same map.
-     */
+    /** Drain-and-clear runs under {@code synchronized(conversations)} so it cannot race a
+     *  concurrent inbound merging into the same map. Idempotent on an empty buffer. */
     public void replayReadAdvanceIfNeeded() {
         UserInfo me = currentUser;
         if (me == null) return;
@@ -393,33 +297,7 @@ public class ClientController {
             if (isNew) {
                 setCurrentConversationId(conv.getConversationId());
                 SwingUtilities.invokeLater(() -> gui.updateMessageListModel(conv));
-                // TODO: call gui.selectConversationInList(conv) once that method exists on ClientUI
             }
-        }
-    }
-
-    private void handleConversationMetadataResponse(Response response) {
-        ConversationMetadata meta = (ConversationMetadata) response.getPayload();
-        // TODO(meta-merge): meta is currently never merged into the matching Conversation —
-        // fold participant updates in, or delete this handler if the emitter has been removed.
-        ArrayList<Conversation> snapshot;
-        synchronized (conversations) {
-            boolean found = false;
-            for (Conversation c : conversations) {
-                if (c.getConversationId() == meta.getConversationId()) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                System.err.println("CONVERSATION_METADATA: no matching conversation for id=" + meta.getConversationId());
-                return;
-            }
-            snapshot = new ArrayList<>(conversations);
-        }
-        if (gui != null) {
-            final ArrayList<Conversation> snap = snapshot;
-            SwingUtilities.invokeLater(() -> gui.updateConversationListModel(snap));
         }
     }
 
@@ -463,9 +341,9 @@ public class ClientController {
         UserInfo fresh = updated.getUpdatedUserInfo();
         UserInfo old = currentUser;
         if (old != null) {
-            // Preserve any local optimistic advance the server has not yet acked.
-            // The defensive copy is load-bearing: getLastReadMap() returns an unmodifiable
-            // view of the live HashMap, so iterating it raw races a concurrent EDT writer.
+            // Preserve any local optimistic advance the server has not yet acked. Defensive copy
+            // is load-bearing: getLastReadMap() returns an unmodifiable view of the live HashMap,
+            // so iterating it raw races a concurrent EDT writer.
             Map<Long, Long> oldEntries = new HashMap<>(old.getLastReadMap());
             for (Map.Entry<Long, Long> e : oldEntries.entrySet()) {
                 long convId = e.getKey();
@@ -503,8 +381,7 @@ public class ClientController {
         }
     }
 
-    /** Synchronized so the state flip and stream creation happen atomically — concurrent
-     *  callers either skip at the CONNECTED check or wait their turn. */
+    /** Synchronized so the state flip and stream creation happen atomically. */
     private synchronized void ensureConnected() throws IOException {
         if (connectionStatus == ConnectionStatus.CONNECTED) return;
         socket = new Socket();
@@ -527,10 +404,6 @@ public class ClientController {
         UserInfo me = requireSession();
         return (me != null && me.getUserType() == UserType.ADMIN) ? me : null;
     }
-
-    // -------------------------------------------------------------------------
-    // Public action methods — each maps 1-to-1 with a DataManager handler.
-    // -------------------------------------------------------------------------
 
     public void register(String userId, String realName, String loginName, char[] password) {
         if (!authInFlight.compareAndSet(false, true)) return;
@@ -572,22 +445,15 @@ public class ClientController {
         }
     }
 
-    /**
-     * Clears local session synchronously and switches to the login view. The wire LOGOUT and
-     * stream teardown run on a daemon helper so the EDT never blocks on socket I/O.
-     * <p>Ordering: clear {@link #requestQueue} BEFORE nulling the streams, so any request the
-     * drain thread already took will, on its next {@link #sendRequest(Request)} call, observe
-     * {@code outputStream == null} and drop silently. The captured stream refs are local to the
-     * helper, letting a subsequent re-login rebuild a fresh connection without racing the
-     * in-flight LOGOUT write.
-     */
+    /** Clears local session synchronously and switches to the login view. The wire LOGOUT and
+     *  stream teardown run on a daemon helper so the EDT never blocks on socket I/O. The queue
+     *  is cleared BEFORE nulling streams so any request the drain thread already took observes
+     *  outputStream==null on its next sendRequest and drops silently. */
     public void logout() {
         UserInfo me = requireSession();
         if (me == null) return;
         String userId = me.getUserId();
         requestQueue.clear();
-        // Capture-and-null under `this` so concurrent ensureConnected/sendRequest see a
-        // consistent (out, in, socket) triple.
         final ObjectOutputStream out;
         final ObjectInputStream in;
         final Socket sock;
@@ -620,9 +486,7 @@ public class ClientController {
                 out.flush();
             } catch (IOException ignored) { /* socket already gone */ }
         }
-        try { if (in != null) in.close(); } catch (IOException ignored) {}
-        try { if (out != null) out.close(); } catch (IOException ignored) {}
-        try { if (sock != null && !sock.isClosed()) sock.close(); } catch (IOException ignored) {}
+        closeQuietly(in, out, sock);
     }
 
     /** Defensive copy: the live list is reassigned + cleared on the EDT. */
@@ -699,10 +563,6 @@ public class ClientController {
                 new JoinConversationPayload(conversationId), currentUser.getUserId()));
     }
 
-    // -------------------------------------------------------------------------
-    // UI/local filtering + read-only accessors.
-    // -------------------------------------------------------------------------
-
     public void searchDirectory(String query) {
         if (gui == null) return;
         gui.updateDirectoryModel(getFilteredDirectory(query));
@@ -760,7 +620,7 @@ public class ClientController {
     private static long latestSequenceNumber(Conversation c) {
         if (c == null) return 0L;
         if (c.getMessages().isEmpty()) {
-            // No messages yet; fall back to conversationId for creation-recency ordering.
+            // Fall back to conversationId for creation-recency ordering.
             return c.getConversationId();
         }
         return c.getMessages().get(c.getMessages().size() - 1).getSequenceNumber();
@@ -809,15 +669,10 @@ public class ClientController {
         return null;
     }
 
-    /**
-     * Atomically capture (conversation, viewer's lastRead at open time, message-list snapshot)
-     * AND publish {@code currentConversationId} in one critical section. Without atomic capture,
-     * a message arriving between the lastRead read and the snapshot could land on the wrong side
-     * of the "New messages" divider.
-     * <p>Lock order: {@code conversations} → {@code Conversation.this} — matches
-     * {@link #handleMessageResponse}, so deadlock is impossible.
-     * <p>Returns null if no user is logged in or the conversation is unknown.
-     */
+    /** Atomically capture (conversation, viewer's lastRead at open time, message-list snapshot)
+     *  AND publish currentConversationId in one critical section, so a message arriving between
+     *  the lastRead read and the snapshot cannot land on the wrong side of the divider.
+     *  Lock order: conversations → Conversation.this — matches handleMessageResponse. */
     public ConversationOpenSnapshot openConversationAtomically(long id) {
         UserInfo me = currentUser;
         if (me == null) return null;
@@ -846,52 +701,31 @@ public class ClientController {
         }
     }
 
-    // -------------------------------------------------------------------------
-    // Read/unread math — public statics delegate so existing call sites (UI
-    // renderers, tests pinning ClientController.isUnread / etc.) keep compiling.
-    // -------------------------------------------------------------------------
-
-    private static final class ReadCalc {
-        private ReadCalc() {}
-
-        static boolean isUnread(Conversation conv, UserInfo viewer) {
-            if (conv == null || viewer == null) return false;
-            long lastReadSeq = viewer.getLastRead(conv.getConversationId());
-            ArrayList<Message> msgs = conv.getMessages();
-            long latestSeq = msgs.isEmpty() ? 0L : msgs.get(msgs.size() - 1).getSequenceNumber();
-            return latestSeq > lastReadSeq;
-        }
-
-        static boolean isMessageUnread(Message msg, long displayedLastReadSeq) {
-            if (msg == null) return false;
-            return msg.getSequenceNumber() > displayedLastReadSeq;
-        }
-
-        /** O(unread) backward scan: relies on {@link Conversation#append} being the only
-         *  mutator and appending in monotonic seq order. */
-        static int unreadCount(Conversation conv, UserInfo viewer) {
-            if (conv == null || viewer == null) return 0;
-            long lastReadSeq = viewer.getLastRead(conv.getConversationId());
-            ArrayList<Message> msgs = conv.getMessages();
-            int count = 0;
-            for (int i = msgs.size() - 1; i >= 0; i--) {
-                if (msgs.get(i).getSequenceNumber() > lastReadSeq) count++;
-                else break;
-            }
-            return count;
-        }
-    }
-
     public static boolean isUnread(Conversation conv, UserInfo viewer) {
-        return ReadCalc.isUnread(conv, viewer);
+        if (conv == null || viewer == null) return false;
+        long lastReadSeq = viewer.getLastRead(conv.getConversationId());
+        ArrayList<Message> msgs = conv.getMessages();
+        long latestSeq = msgs.isEmpty() ? 0L : msgs.get(msgs.size() - 1).getSequenceNumber();
+        return latestSeq > lastReadSeq;
     }
 
     public static boolean isMessageUnread(Message msg, long displayedLastReadSeq) {
-        return ReadCalc.isMessageUnread(msg, displayedLastReadSeq);
+        if (msg == null) return false;
+        return msg.getSequenceNumber() > displayedLastReadSeq;
     }
 
+    /** O(unread) backward scan: relies on Conversation#append being the only mutator and
+     *  appending in monotonic seq order. */
     public static int unreadCount(Conversation conv, UserInfo viewer) {
-        return ReadCalc.unreadCount(conv, viewer);
+        if (conv == null || viewer == null) return 0;
+        long lastReadSeq = viewer.getLastRead(conv.getConversationId());
+        ArrayList<Message> msgs = conv.getMessages();
+        int count = 0;
+        for (int i = msgs.size() - 1; i >= 0; i--) {
+            if (msgs.get(i).getSequenceNumber() > lastReadSeq) count++;
+            else break;
+        }
+        return count;
     }
 
     /** Synchronized to prevent interleaved writes on the shared output stream. */
@@ -911,47 +745,57 @@ public class ClientController {
         requestQueue.add(r);
     }
 
-    // -------------------------------------------------------------------------
-    // Background thread starters (daemon workers for queue drain, responses,
-    // and connection / ping keepalive).
-    // -------------------------------------------------------------------------
+    private void awaitConnected() {
+        while (!Thread.currentThread().isInterrupted()
+                && connectionStatus != ConnectionStatus.CONNECTED) {
+            try {
+                Thread.sleep(RECONNECT_POLL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    private void attemptSendOrBackoff(Request r) {
+        try {
+            ensureConnected();
+            sendRequest(r);
+        } catch (IOException e) {
+            connectionStatus = ConnectionStatus.NOT_CONNECTED;
+            if (authInFlight.compareAndSet(true, false)) {
+                // Drop the queued auth and notify rather than silently retrying an unreachable
+                // server forever. EDT-marshal the GUI work.
+                SwingUtilities.invokeLater(() -> {
+                    cancelAuthWatchdog();
+                    if (gui != null) {
+                        gui.setLoginInFlight(false);
+                        gui.showNetworkError();
+                    }
+                });
+            } else {
+                requestQueue.addFirst(r);
+            }
+            e.printStackTrace();
+            try {
+                Thread.sleep(RETRY_BACKOFF_MS);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
 
     private void startRequestDrainThread() {
         requestDrainThread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
-                Request r = null;
+                Request r;
                 try {
                     r = requestQueue.take();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     break;
                 }
-                try {
-                    ensureConnected();
-                    sendRequest(r);
-                } catch (IOException e) {
-                    connectionStatus = ConnectionStatus.NOT_CONNECTED;
-                    if (authInFlight.compareAndSet(true, false)) {
-                        // Drop the queued auth and notify, rather than silently retrying an
-                        // unreachable server forever. EDT-marshal the GUI work.
-                        SwingUtilities.invokeLater(() -> {
-                            cancelAuthWatchdog();
-                            if (gui != null) {
-                                gui.setLoginInFlight(false);
-                                gui.showNetworkError();
-                            }
-                        });
-                    } else {
-                        requestQueue.addFirst(r);
-                    }
-                    e.printStackTrace();
-                    try {
-                        Thread.sleep(RETRY_BACKOFF_MS);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        break;
-                    }
-                }
+                attemptSendOrBackoff(r);
             }
         }, "request-drain");
         requestDrainThread.setDaemon(true);
@@ -961,18 +805,9 @@ public class ClientController {
     private void startResponseListenerThread() {
         responseListenerThread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
-                while (!Thread.currentThread().isInterrupted()
-                        && connectionStatus != ConnectionStatus.CONNECTED) {
-                    try {
-                        Thread.sleep(RECONNECT_POLL_MS);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        break;
-                    }
-                }
+                awaitConnected();
                 if (Thread.currentThread().isInterrupted()) break;
 
-                readLoop:
                 while (!Thread.currentThread().isInterrupted()
                         && connectionStatus == ConnectionStatus.CONNECTED && inputStream != null) {
                     try {
@@ -982,11 +817,11 @@ public class ClientController {
                         }
                     } catch (EOFException | SocketException e) {
                         connectionStatus = ConnectionStatus.NOT_CONNECTED;
-                        break readLoop;
+                        break;
                     } catch (IOException | ClassNotFoundException e) {
                         connectionStatus = ConnectionStatus.NOT_CONNECTED;
                         e.printStackTrace();
-                        break readLoop;
+                        break;
                     }
                 }
             }
@@ -998,15 +833,7 @@ public class ClientController {
     private void startInactivityDetectorThread() {
         inactivityDetectorThread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
-                while (!Thread.currentThread().isInterrupted()
-                        && connectionStatus != ConnectionStatus.CONNECTED) {
-                    try {
-                        Thread.sleep(RECONNECT_POLL_MS);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        break;
-                    }
-                }
+                awaitConnected();
                 if (Thread.currentThread().isInterrupted()) break;
 
                 while (!Thread.currentThread().isInterrupted()

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -57,7 +57,15 @@ public class ClientController {
     /** Defaults true so headless tests and pre-window-event states do not suppress reads. */
     private final AtomicBoolean windowActive = new AtomicBoolean(true);
     /**
-     * Conversation id → highest seq of an inbound message that arrived while windowActive=false.
+     * Mirrors whether {@code messageInputField} owns the focus. Drives the read-ack predicate
+     * (replaces {@code windowActive} for that purpose). Defaults true for headless tests and
+     * pre-attach states. Written from the EDT inside {@link ClientUI}'s FocusListener; read
+     * off-EDT in {@link #handleMessageResponse}.
+     */
+    private final AtomicBoolean inputFocused = new AtomicBoolean(true);
+    /**
+     * Conversation id → highest seq of an inbound message that arrived while the input was
+     * unfocused (or the user was scrolled up).
      * <p>Concurrency: writes and the drain-and-clear all serialize via the {@code conversations}
      * monitor. Reads outside that monitor are unsafe.
      */
@@ -220,7 +228,7 @@ public class ClientController {
             isCurrentConv = msg.getConversationId() == currentConversationId;
             if (isCurrentConv && currentUser != null) {
                 boolean userViewingBottom = (gui == null) || gui.userIsViewingBottom();
-                if (windowActive.get() && userViewingBottom) {
+                if (inputFocused.get() && userViewingBottom) {
                     shouldAdvanceLastRead = true;
                 } else {
                     deferredReadAdvance.merge(msg.getConversationId(), msg.getSequenceNumber(), Math::max);
@@ -252,6 +260,14 @@ public class ClientController {
 
     public boolean isWindowActive() {
         return windowActive.get();
+    }
+
+    public void setInputFocused(boolean focused) {
+        inputFocused.set(focused);
+    }
+
+    public boolean isInputFocused() {
+        return inputFocused.get();
     }
 
     /** Drain-and-clear runs under {@code synchronized(conversations)} so it cannot race a
@@ -471,6 +487,7 @@ public class ClientController {
         currentConversationId = -1;
         currentAdminConversationSearch.clear();
         currentDirectory.clear();
+        inputFocused.set(true);
         if (gui != null) gui.showLoginView();
         Thread t = new Thread(() -> closeWithLogout(userId, wasConnected, out, in, sock),
                               "client-logout");

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -55,24 +55,17 @@ public class ClientController {
 
     private volatile boolean loggedIn = false;
     /**
-     * Reassigned off-EDT by the response listener ({@link #handleReadMessagesUpdatedResponse}
-     * builds a fresh {@link UserInfo}, populates its {@code lastRead} map pre-publication, then
-     * publishes the new reference). After publication, the {@code lastRead} map is mutated only
-     * on the EDT — see the {@link UserInfo} contract. The response thread reads the reference
-     * (e.g. to gate read-advance in {@link #handleMessageResponse}) and schedules a
-     * {@code SwingUtilities.invokeLater} for any actual mutation. {@code volatile} ensures
-     * readers observe the freshest reference.
+     * The reference is reassigned off-EDT (response listener publishes a fresh instance with
+     * lastRead pre-populated); after publication, the lastRead map is mutated only on the EDT.
+     * volatile ensures readers observe the freshest reference.
      */
     private volatile UserInfo currentUser;
-    /** True while a LOGIN or REGISTER request is enqueued and unresolved. Atomic so rapid
-     *  duplicate clicks lose the {@code compareAndSet} race instead of both passing a
-     *  non-atomic {@code if (!flag) flag = true}. */
+    /** Atomic so rapid duplicate clicks lose the compareAndSet race rather than both passing
+     *  a non-atomic {@code if (!flag) flag = true}. */
     private final AtomicBoolean authInFlight = new AtomicBoolean(false);
-    /** EDT-only Swing timer that resets {@link #authInFlight} and surfaces a network error if
-     *  the server never replies (crash-after-receive, hung handler). Cancelled on auth resolve. */
+    /** EDT-only single-shot timer that surfaces a network error if the server never replies. */
     private javax.swing.Timer authWatchdogTimer;
     private static final int AUTH_WATCHDOG_MS = 15_000;
-    /** #139: cached on register() so handleRegisterResultResponse can pre-fill the login screen. */
     private volatile String lastRegisteredLoginName = null;
 
     // -------------------------------------------------------------------------
@@ -86,25 +79,17 @@ public class ClientController {
     private ArrayList<ConversationMetadata> currentAdminConversationSearch = new ArrayList<>();
 
     // -------------------------------------------------------------------------
-    // Window-focus gate (Fix A): inbound messages while the OS window is inactive
-    // must NOT advance the read pointer — the user hasn't actually seen them.
-    // We buffer the per-conversation max sequence and replay on activation,
-    // coalescing a burst of N messages into a single UPDATE_READ_MESSAGES.
+    // Window-focus gate: inbound messages while the OS window is inactive must
+    // NOT advance the read pointer. Buffer the per-conversation max sequence
+    // and replay on activation, coalescing a burst into one UPDATE_READ_MESSAGES.
     // -------------------------------------------------------------------------
 
-    /** True while the JFrame is the active OS window. Defaults true so headless
-     *  tests (no window-activation events) and pre-window-event states do not
-     *  suppress reads. */
+    /** Defaults true so headless tests and pre-window-event states do not suppress reads. */
     private final AtomicBoolean windowActive = new AtomicBoolean(true);
     /**
-     * Conversation id → highest seq of an inbound message that arrived while
-     * {@code windowActive=false}. Drained by {@link #replayReadAdvanceIfNeeded()}
-     * on window activation.
-     * <p>Concurrency: writes serialize via the {@code conversations} monitor (the
-     * response listener writes inside {@link #handleMessageResponse}'s monitor;
-     * {@link #tryAdvanceReadOnInbound} writes under the same monitor; the EDT
-     * {@link #replayReadAdvanceIfNeeded} drain re-acquires that monitor for the
-     * atomic drain-and-clear). Reads outside the monitor are unsafe.
+     * Conversation id → highest seq of an inbound message that arrived while windowActive=false.
+     * <p>Concurrency: writes and the drain-and-clear all serialize via the {@code conversations}
+     * monitor. Reads outside that monitor are unsafe.
      */
     private final HashMap<Long, Long> deferredReadAdvance = new HashMap<>();
 
@@ -118,35 +103,15 @@ public class ClientController {
     // Tunables
     // -------------------------------------------------------------------------
 
-    /** #138: bounded TCP connect timeout — unreachable server fails fast (~7s) instead of
-     *  the OS default (~75s on most platforms). */
+    /** Bounded so an unreachable server fails fast (~7s) rather than the ~75s OS default. */
     private static final int CONNECT_TIMEOUT_MS = 7000;
     /** Send a PING this often while connected to keep NAT/firewall paths warm. */
     private static final long PING_INTERVAL_MS = 30_000L;
     /** No server activity for this long → assume the server is gone and force-logout. */
     private static final long INACTIVITY_LIMIT_MS = 300_000L;
-    /** Polling interval the listener and inactivity threads use while waiting for the next
-     *  successful reconnect. */
     private static final long RECONNECT_POLL_MS = 500L;
-    /** Backoff after a failed connect/send in the drain thread before retrying. */
     private static final long RETRY_BACKOFF_MS = 300L;
 
-    /*
-     * Entry point for the client application.
-     *
-     * Usage: java ClientController [host] [port]
-     *
-     *   host - IP address or hostname of the server to connect to.
-     *          Defaults to "localhost" if not provided.
-     *   port - TCP port the server is listening on.
-     *          Defaults to 8080 if not provided.
-     *          Must match the port the server was started with.
-     *          Configurable so clients can reach servers on different ports
-     *          across environments (dev, staging, prod).
-     *
-     * Example:
-     *   java ClientController 192.168.1.10 8080
-     */
     public static void main(String[] args) {
         String host = args.length > 0 ? args[0] : "localhost";
         int port = args.length > 1 ? Integer.parseInt(args[1]) : 8080;
@@ -164,18 +129,16 @@ public class ClientController {
         startInactivityDetectorThread();
     }
 
-    /** Package-private test seam: accepts a pre-built (or null) GUI; no Swing window opened. */
+    /** Test seam: accepts a pre-built (or null) GUI; no Swing window opened. */
     ClientController(String hostIp, int hostPort, ClientUI guiOverride) {
         this.hostIp = hostIp;
         this.hostPort = hostPort;
         this.gui = guiOverride;
-        // Integration tests pass a real port (>0) and need request processing
         if (hostPort > 0) {
             startRequestDrainThread();
         }
     }
 
-    /** Interrupts workers and tears down the TCP connection. Use for application shutdown. */
     private void close() {
         if (requestDrainThread != null) requestDrainThread.interrupt();
         if (responseListenerThread != null) responseListenerThread.interrupt();
@@ -184,13 +147,9 @@ public class ClientController {
     }
 
     /**
-     * Closes object streams and the TCP socket and sets {@link #connectionStatus} to
-     * {@link ConnectionStatus#NOT_CONNECTED}. Does <b>not</b> interrupt the request drain,
-     * response listener, or inactivity threads — they keep running and can wait for the next
-     * lazy reconnect. For full shutdown use {@link #close()}; for logout, use
-     * {@link #logout()} which sends LOGOUT off-thread before tearing down the streams.
-     * Field swaps happen under {@code synchronized(this)} so concurrent {@link #ensureConnected}
-     * / {@link #sendRequest} calls observe a consistent (out, in, socket) triple.
+     * Closes streams and socket without stopping background threads, so they can wait for the
+     * next lazy reconnect. Field swaps happen under {@code synchronized(this)} so concurrent
+     * {@link #ensureConnected} / {@link #sendRequest} calls observe a consistent (out, in, socket) triple.
      */
     private void disconnectSocket() {
         final ObjectOutputStream out;
@@ -207,7 +166,7 @@ public class ClientController {
         try { if (sock != null && !sock.isClosed()) sock.close(); } catch (IOException ignored) {}
     }
 
-    /** Package-private so tests can drive response handling directly without a live socket. */
+    /** Test seam: drive response handling directly without a live socket. */
     void processResponse(Response response) {
         if (response == null) return;
         lastServerActivityMillis = System.currentTimeMillis();
@@ -246,7 +205,7 @@ public class ClientController {
                 connectionStatus = ConnectionStatus.CONNECTED;
                 break;
             case PONG:
-                // lastServerActivityMillis is already updated for every response above.
+                // lastServerActivityMillis already updated above; nothing else to do.
                 break;
             default:
                 break;
@@ -255,8 +214,8 @@ public class ClientController {
 
     private void handleLoginResultResponse(Response response) {
         LoginResult lr = (LoginResult) response.getPayload();
-        // Coalesce field reset + UI updates into a single EDT task so the in-flight flag and
-        // visible button state can never be observed out-of-order with each other.
+        // Coalesce field reset + UI updates into one EDT task so the in-flight flag and
+        // button state cannot be observed out-of-order.
         SwingUtilities.invokeLater(() -> {
             authInFlight.set(false);
             cancelAuthWatchdog();
@@ -265,9 +224,8 @@ public class ClientController {
                 case SUCCESS:
                     loggedIn = true;
                     currentUser = lr.getUserInfo();
-                    // #214: defense-in-depth — server now sorts the wire payload, but
-                    // copy + re-sort here so the controller's invariant holds for any
-                    // direct consumer of `conversations` (tests, future callers).
+                    // Defense-in-depth: server already sorts the wire payload, but re-sort
+                    // here so the controller's recency invariant holds for any direct consumer.
                     ArrayList<Conversation> sorted = lr.getConversationList() != null
                             ? new ArrayList<>(lr.getConversationList()) : new ArrayList<>();
                     sorted.sort((a, b) -> Long.compare(latestSequenceNumber(b), latestSequenceNumber(a)));
@@ -311,17 +269,14 @@ public class ClientController {
     }
 
     private void handleMessageResponse(Response response) {
-        // Move the matching conversation to front (most recent), then refresh the list view.
         Message msg = (Message) response.getPayload();
         ArrayList<Conversation> snapshot;
         boolean isCurrentConv;
         boolean shouldAdvanceLastRead = false;
         // The lastRead-advance decision must happen under the same monitor that
-        // openConversationAtomically uses, so a click-to-open never captures a lastRead
-        // that an in-flight inbound has just bumped past the new message. The actual
-        // setLastRead mutation is deferred to the EDT to honour the UserInfo contract;
-        // EDT preserves submission order, and openConversationAtomically also runs on
-        // the EDT, so the per-conversation pointer remains monotonic.
+        // openConversationAtomically uses, so a click-to-open cannot capture a stale lastRead.
+        // The setLastRead mutation is deferred to the EDT (per UserInfo's contract); EDT
+        // preserves submission order, so the per-conversation pointer stays monotonic.
         synchronized (conversations) {
             for (int i = 0; i < conversations.size(); i++) {
                 if (conversations.get(i).getConversationId() == msg.getConversationId()) {
@@ -362,18 +317,12 @@ public class ClientController {
     }
 
     /**
-     * Inbound message arrived in the open conversation. The composed gate is
-     * {@code windowActive && userIsViewingBottom}: if the OS window is active AND the user
-     * is parked at the bottom of the message list (Fix E1), optimistically advance
-     * {@code currentUser.lastRead} and ask the server to persist. Otherwise buffer the
-     * per-conversation max seq for replay on the next window activation OR scroll-to-bottom
-     * transition (whichever comes first).
-     * <p>Package-private seam so unit tests (with {@code gui == null}) can exercise the
-     * read-advance contract directly. Headless callers (gui == null) implicitly satisfy
-     * the bottom-viewing predicate so existing tests need not stage a scroll position.
-     * <p>NOT on the live path: {@link #handleMessageResponse} inlines the same decision
-     * under the {@code conversations} monitor to serialize with
-     * {@link #openConversationAtomically}. Keep the two implementations in sync.
+     * Gate is {@code windowActive && userIsViewingBottom}: optimistically advance
+     * {@code currentUser.lastRead} and ask the server to persist; otherwise buffer the
+     * per-conversation max seq for replay on the next window activation.
+     * <p>Test seam: {@link #handleMessageResponse} inlines the same decision on the live
+     * path under the {@code conversations} monitor — keep the two implementations in sync.
+     * Headless callers (gui == null) implicitly satisfy the bottom-viewing predicate.
      */
     void tryAdvanceReadOnInbound(long convId, long seq) {
         UserInfo me = currentUser;
@@ -389,25 +338,19 @@ public class ClientController {
         }
     }
 
-    /** Called by {@link ClientUI}'s WindowAdapter on activate/deactivate. */
     public void setWindowActive(boolean active) {
         windowActive.set(active);
     }
 
-    /** True iff the OS window is currently active. Exposed for tests and gating callers
-     *  (e.g. {@link ClientUI#appendMessageToConversationView}). */
     public boolean isWindowActive() {
         return windowActive.get();
     }
 
     /**
-     * Drain {@link #deferredReadAdvance}: for each conversation, send one
-     * UPDATE_READ_MESSAGES at the highest deferred seq, advance local lastRead,
-     * and re-sync the open conversation's per-message snapshot. Called on window
-     * activation. Idempotent on an empty buffer.
-     * <p>The drain-and-clear runs under {@code synchronized(conversations)} so it
-     * cannot race with a concurrent inbound that {@code merge}s into the same map
-     * inside {@link #handleMessageResponse}'s monitor.
+     * Drain {@link #deferredReadAdvance}: send one UPDATE_READ_MESSAGES per conversation at the
+     * highest deferred seq, advance local lastRead, and re-sync the open conversation. Idempotent
+     * on an empty buffer. Drain-and-clear runs under {@code synchronized(conversations)} so it
+     * cannot race a concurrent inbound merging into the same map.
      */
     public void replayReadAdvanceIfNeeded() {
         UserInfo me = currentUser;
@@ -437,8 +380,6 @@ public class ClientController {
     }
 
     private void handleConversationResponse(Response response) {
-        // Move to front regardless of whether it is new or an update (recency sort).
-        // Track whether this conversation was already known so we can auto-open new ones.
         Conversation conv = (Conversation) response.getPayload();
         boolean isNew;
         ArrayList<Conversation> snapshot;
@@ -450,7 +391,6 @@ public class ClientController {
         if (gui != null) {
             gui.updateConversationListModel(snapshot);
             if (isNew) {
-                // Auto-open the newly created conversation in the center panel.
                 setCurrentConversationId(conv.getConversationId());
                 SwingUtilities.invokeLater(() -> gui.updateMessageListModel(conv));
                 // TODO: call gui.selectConversationInList(conv) once that method exists on ClientUI
@@ -461,8 +401,7 @@ public class ClientController {
     private void handleConversationMetadataResponse(Response response) {
         ConversationMetadata meta = (ConversationMetadata) response.getPayload();
         // TODO(meta-merge): meta is currently never merged into the matching Conversation —
-        // either fold participant updates from `meta` into the in-cache Conversation, or
-        // delete this handler if the server-side emitter has been removed.
+        // fold participant updates in, or delete this handler if the emitter has been removed.
         ArrayList<Conversation> snapshot;
         synchronized (conversations) {
             boolean found = false;
@@ -488,8 +427,7 @@ public class ClientController {
         UserCreationPayload payload = (UserCreationPayload) response.getPayload();
         if (payload == null || payload.getUserInfo() == null) return;
         UserInfo created = payload.getUserInfo();
-        // EDT-marshal: currentDirectory is read on EDT (search filter, directory render);
-        // mutating it on the response thread would race with EDT iteration.
+        // EDT-marshal: currentDirectory is read on EDT; mutating it off-EDT would race iteration.
         SwingUtilities.invokeLater(() -> {
             for (UserInfo u : currentDirectory) {
                 if (u != null && Objects.equals(u.getUserId(), created.getUserId())) {
@@ -507,8 +445,6 @@ public class ClientController {
         ArrayList<Conversation> snapshot;
         synchronized (conversations) {
             conversations.removeIf(c -> c.getConversationId() == leftId);
-
-            // If we just left the current conversation, switch to the most recent one
             if (currentConversationId == leftId) {
                 currentConversationId = conversations.isEmpty() ? -1 : conversations.get(0).getConversationId();
             }
@@ -516,9 +452,7 @@ public class ClientController {
         }
         if (gui != null) {
             Conversation current = getCurrentConversation();
-            // Update conversation list (sidebar)
             gui.updateConversationListModel(snapshot);
-            // Update conversation view (message panel) to show the new current conversation
             gui.updateMessageListModel(current);
         }
     }
@@ -529,10 +463,9 @@ public class ClientController {
         UserInfo fresh = updated.getUpdatedUserInfo();
         UserInfo old = currentUser;
         if (old != null) {
-            // #209: preserve any local optimistic advance the server has not yet acked.
-            // getLastReadMap() returns an unmodifiableMap view of the live HashMap; the
-            // defensive copy below is load-bearing — without it, a concurrent EDT writer
-            // can throw ConcurrentModificationException during iteration.
+            // Preserve any local optimistic advance the server has not yet acked.
+            // The defensive copy is load-bearing: getLastReadMap() returns an unmodifiable
+            // view of the live HashMap, so iterating it raw races a concurrent EDT writer.
             Map<Long, Long> oldEntries = new HashMap<>(old.getLastReadMap());
             for (Map.Entry<Long, Long> e : oldEntries.entrySet()) {
                 long convId = e.getKey();
@@ -550,11 +483,9 @@ public class ClientController {
     }
 
     private void handleAdminConversationResultResponse(Response response) {
-        // AdminConversationResult carries ConversationMetadata — store it directly.
         AdminConversationResult acr = (AdminConversationResult) response.getPayload();
-        // EDT-marshal: currentAdminConversationSearch is read on the EDT (admin dialog
-        // filter, model update). Reassigning the reference on the response thread races
-        // EDT iteration in getFilteredAdminConversationSearch.
+        // EDT-marshal: currentAdminConversationSearch is read on the EDT; reassigning off-EDT
+        // races iteration in getFilteredAdminConversationSearch.
         SwingUtilities.invokeLater(() -> {
             currentAdminConversationSearch = new ArrayList<>(acr.getConversations());
             if (gui != null) {
@@ -563,9 +494,8 @@ public class ClientController {
         });
     }
 
-    /** Routes the admin's silent read into the open admin viewer panel. Does not touch
-     *  {@code conversations} or {@code currentConversationId}, so the viewed conversation
-     *  never enters the admin's own sidebar. */
+    /** Silent read: does not touch {@code conversations} or {@code currentConversationId},
+     *  so the viewed conversation never enters the admin's own sidebar. */
     private void handleAdminViewConversationResultResponse(Response response) {
         Object payload = response.getPayload();
         if (gui != null && payload instanceof Conversation) {
@@ -573,15 +503,13 @@ public class ClientController {
         }
     }
 
-    /** Lazily opens a TCP connection to the server and initializes the input and output streams.
-     *  Synchronized so the state field flip and stream creation happen as one block — concurrent
-     *  callers either skip out at the CONNECTED check or wait their turn. */
+    /** Synchronized so the state flip and stream creation happen atomically — concurrent
+     *  callers either skip at the CONNECTED check or wait their turn. */
     private synchronized void ensureConnected() throws IOException {
         if (connectionStatus == ConnectionStatus.CONNECTED) return;
         socket = new Socket();
         socket.connect(new InetSocketAddress(hostIp, hostPort), CONNECT_TIMEOUT_MS);
-        // OOS must be created and flushed BEFORE OIS on both sides to avoid header deadlock
-        // (mirrors the convention in ConnectionHandler on the server).
+        // OOS must be created and flushed BEFORE OIS on both sides to avoid header deadlock.
         outputStream = new ObjectOutputStream(socket.getOutputStream());
         outputStream.flush();
         inputStream = new ObjectInputStream(socket.getInputStream());
@@ -589,15 +517,12 @@ public class ClientController {
         lastServerActivityMillis = System.currentTimeMillis();
     }
 
-    /** Captures {@link #currentUser} once and returns it iff a session is active. Any caller
-     *  that derefs {@code currentUser} more than once should go through this helper to avoid
-     *  the volatile reference flipping to null mid-method. */
+    /** Snapshot the volatile reference once so callers cannot observe it flipping to null mid-method. */
     private UserInfo requireSession() {
         UserInfo me = currentUser;
         return (loggedIn && me != null) ? me : null;
     }
 
-    /** Same contract as {@link #requireSession()} but additionally requires admin privileges. */
     private UserInfo requireAdminSession() {
         UserInfo me = requireSession();
         return (me != null && me.getUserType() == UserType.ADMIN) ? me : null;
@@ -607,9 +532,8 @@ public class ClientController {
     // Public action methods — each maps 1-to-1 with a DataManager handler.
     // -------------------------------------------------------------------------
 
-    /** Matches DataManager.handleRegister — payload: RegisterCredentials(userId, loginName, password, name). */
     public void register(String userId, String realName, String loginName, char[] password) {
-        if (!authInFlight.compareAndSet(false, true)) return; // drop rapid duplicate clicks
+        if (!authInFlight.compareAndSet(false, true)) return;
         lastRegisteredLoginName = loginName;
         if (gui != null) gui.setLoginInFlight(true);
         startAuthWatchdog();
@@ -617,17 +541,16 @@ public class ClientController {
         enqueueRequest(new Request(RequestType.REGISTER, creds, null));
     }
 
-    /** Matches DataManager.handleLogin — payload: LoginCredentials(loginName, password). */
     public void login(String loginName, char[] password) {
-        if (!authInFlight.compareAndSet(false, true)) return; // drop rapid duplicate clicks
+        if (!authInFlight.compareAndSet(false, true)) return;
         if (gui != null) gui.setLoginInFlight(true);
         startAuthWatchdog();
         LoginCredentials creds = new LoginCredentials(loginName, new String(password));
         enqueueRequest(new Request(RequestType.LOGIN, creds, null));
     }
 
-    /** EDT-only. Replaces any prior watchdog with a single-shot timer that fires after
-     *  {@link #AUTH_WATCHDOG_MS} if the server never responds, freeing the login button. */
+    /** EDT-only. Replaces any prior watchdog so a stalled server cannot leave the login
+     *  button in the in-flight state forever. */
     private void startAuthWatchdog() {
         if (authWatchdogTimer != null) authWatchdogTimer.stop();
         authWatchdogTimer = new javax.swing.Timer(AUTH_WATCHDOG_MS, e -> {
@@ -642,7 +565,6 @@ public class ClientController {
         authWatchdogTimer.start();
     }
 
-    /** EDT-only. Stops the watchdog if running. */
     private void cancelAuthWatchdog() {
         if (authWatchdogTimer != null) {
             authWatchdogTimer.stop();
@@ -651,24 +573,21 @@ public class ClientController {
     }
 
     /**
-     * Clears local session synchronously (lists, queue, flags) and switches to the login view.
-     * The wire LOGOUT and stream teardown run on a daemon helper so the EDT does not block on
-     * socket I/O. Session tracking lives outside {@code DataManager}.
-     * <p>
-     * Ordering: we clear {@link #requestQueue} <i>before</i> capturing/nulling the streams so any
-     * request the drain thread already pulled with {@code take()} will, on its next
-     * {@link #sendRequest(Request)} call, observe {@code outputStream == null} and drop silently.
-     * The captured stream refs are local to the helper, so a subsequent re-login can rebuild a
-     * fresh connection via {@link #ensureConnected()} without racing the in-flight LOGOUT write.
+     * Clears local session synchronously and switches to the login view. The wire LOGOUT and
+     * stream teardown run on a daemon helper so the EDT never blocks on socket I/O.
+     * <p>Ordering: clear {@link #requestQueue} BEFORE nulling the streams, so any request the
+     * drain thread already took will, on its next {@link #sendRequest(Request)} call, observe
+     * {@code outputStream == null} and drop silently. The captured stream refs are local to the
+     * helper, letting a subsequent re-login rebuild a fresh connection without racing the
+     * in-flight LOGOUT write.
      */
     public void logout() {
         UserInfo me = requireSession();
         if (me == null) return;
         String userId = me.getUserId();
-        // Clear queue first; drained-but-not-yet-sent requests will observe NOT_CONNECTED below.
         requestQueue.clear();
-        // Capture-and-null the streams under `this` so concurrent ensureConnected/sendRequest
-        // see a consistent (out, in, socket) triple. The captured triple is handed to the helper.
+        // Capture-and-null under `this` so concurrent ensureConnected/sendRequest see a
+        // consistent (out, in, socket) triple.
         final ObjectOutputStream out;
         final ObjectInputStream in;
         final Socket sock;
@@ -693,33 +612,28 @@ public class ClientController {
         t.start();
     }
 
-    /** Off-EDT helper: best-effort LOGOUT write on the captured stream, then close all three. */
     private static void closeWithLogout(String userId, boolean wasConnected,
                                         ObjectOutputStream out, ObjectInputStream in, Socket sock) {
         if (wasConnected && out != null) {
             try {
                 out.writeObject(new Request(RequestType.LOGOUT, null, userId));
                 out.flush();
-            } catch (IOException ignored) { /* socket already gone — close path below handles it */ }
+            } catch (IOException ignored) { /* socket already gone */ }
         }
         try { if (in != null) in.close(); } catch (IOException ignored) {}
         try { if (out != null) out.close(); } catch (IOException ignored) {}
         try { if (sock != null && !sock.isClosed()) sock.close(); } catch (IOException ignored) {}
     }
 
-    /** #55/#124: read the cached admin search results so the dialog can seed itself on open
-     *  even if the response arrived before the dialog finished constructing. Defensive copy:
-     *  the live list is reassigned + cleared on the EDT, so callers must not retain a reference. */
+    /** Defensive copy: the live list is reassigned + cleared on the EDT. */
     public ArrayList<ConversationMetadata> getCurrentAdminConversationSearch() {
         return new ArrayList<>(currentAdminConversationSearch);
     }
 
-    /** #128: clear the cached admin search results so reopening the dialog starts fresh. */
     public void clearAdminConversationSearch() {
         currentAdminConversationSearch.clear();
     }
 
-    /** Matches DataManager.handleSendMessage — payload: RawMessage(text, conversationId). */
     public void sendMessage(long conversationId, String m) {
         UserInfo me = requireSession();
         if (me == null) return;
@@ -727,7 +641,6 @@ public class ClientController {
                 new RawMessage(m, conversationId), me.getUserId()));
     }
 
-    /** Matches DataManager.handleCreateConversation — payload: CreateConversationPayload(participants). */
     public void createConversation(ArrayList<UserInfo> p) {
         UserInfo me = requireSession();
         if (me == null) return;
@@ -741,7 +654,6 @@ public class ClientController {
                 new CreateConversationPayload(participants), me.getUserId()));
     }
 
-    /** Matches DataManager.handleAddToConversation — payload: AddToConversationPayload(participants, conversationId). */
     public void addToConversation(ArrayList<UserInfo> p, long conversationId) {
         UserInfo me = requireSession();
         if (me == null) return;
@@ -749,7 +661,6 @@ public class ClientController {
                 new AddToConversationPayload(p, conversationId), me.getUserId()));
     }
 
-    /** Matches DataManager.handleLeaveConversation — payload: LeaveConversationPayload(conversationId). */
     public void leaveConversation(long conversationId) {
         UserInfo me = requireSession();
         if (me == null) return;
@@ -757,7 +668,6 @@ public class ClientController {
                 new LeaveConversationPayload(conversationId), me.getUserId()));
     }
 
-    /** Matches DataManager.handleUpdateReadMessages — payload: UpdateReadMessages(conversationId, lastSeenSequenceNumber). */
     public void updateReadMessages(long conversationId, long lastSeenSequenceNumber) {
         UserInfo me = requireSession();
         if (me == null) return;
@@ -767,7 +677,6 @@ public class ClientController {
                 me.getUserId()));
     }
 
-    /** Matches DataManager.handleAdminConversationQuery — payload: AdminConversationQuery(userID). */
     public void adminGetUserConversations(String userID) {
         UserInfo me = requireAdminSession();
         if (me == null) return;
@@ -775,9 +684,8 @@ public class ClientController {
                 new AdminConversationQuery(userID), me.getUserId()));
     }
 
-    /** Matches DataManager.handleAdminViewConversation — payload: AdminViewConversationQuery(conversationId).
-     *  Pulls a full read-only snapshot for the admin viewer; server does NOT mutate the
-     *  participant list, so other clients are unaware of the lookup. */
+    /** Read-only snapshot for the admin viewer; server does NOT mutate the participant list,
+     *  so other clients are unaware of the lookup. */
     public void adminViewConversation(long conversationId) {
         UserInfo me = requireAdminSession();
         if (me == null) return;
@@ -785,7 +693,6 @@ public class ClientController {
                 new AdminViewConversationQuery(conversationId), me.getUserId()));
     }
 
-    /** Matches DataManager.handleJoinConversation — payload: JoinConversationPayload(conversationId). */
     public void joinConversation(long conversationId) {
         if (!loggedIn || currentUser == null || currentUser.getUserType() != UserType.ADMIN) return;
         enqueueRequest(new Request(RequestType.JOIN_CONVERSATION,
@@ -796,13 +703,11 @@ public class ClientController {
     // UI/local filtering + read-only accessors.
     // -------------------------------------------------------------------------
 
-    /** Filters local directory and refreshes the directory list model in the GUI. */
     public void searchDirectory(String query) {
         if (gui == null) return;
         gui.updateDirectoryModel(getFilteredDirectory(query));
     }
 
-    /** Filters local conversation list and refreshes the conversation list model in the GUI. */
     public void searchConversationList(String query) {
         if (gui == null) return;
         gui.updateConversationListModel(getFilteredConversationList(query));
@@ -811,24 +716,20 @@ public class ClientController {
     public UserInfo getCurrentUserInfo() { return currentUser; }
     public boolean isLoggedIn()           { return loggedIn; }
 
-    /** Package-private: seeds the directory list for unit tests without a live server. */
+    /** Test seam: seed the directory list without a live server. */
     void setCurrentDirectoryForTesting(ArrayList<UserInfo> dir) {
         this.currentDirectory = new ArrayList<>(dir);
     }
 
-    /** Package-private: outbound request queue depth — used by unit tests to verify whether
-     *  optimization paths (e.g. {@link #replayReadAdvanceIfNeeded()} and
-     *  {@link #handleMessageResponse(shared.networking.Response)}) did or did not enqueue a request. */
+    /** Test seam: verify whether optimization paths did or did not enqueue a request. */
     int requestQueueDepthForTesting() {
         return requestQueue.size();
     }
 
-    /** Package-private: most recently enqueued request, or {@code null} if empty. */
     Request peekLastRequestForTesting() {
         return requestQueue.peekLast();
     }
 
-    /** Returns all users whose id or name contains {@code query} (case-insensitive). */
     public ArrayList<UserInfo> getFilteredDirectory(String query) {
         if (query == null || query.isBlank()) return new ArrayList<>(currentDirectory);
         ArrayList<UserInfo> filtered = new ArrayList<>();
@@ -839,7 +740,6 @@ public class ClientController {
         return filtered;
     }
 
-    /** Returns conversations where any participant's id or name matches {@code query}. */
     public ArrayList<Conversation> getFilteredConversationList(String query) {
         synchronized (conversations) {
             if (query == null || query.isBlank()) {
@@ -860,16 +760,14 @@ public class ClientController {
     private static long latestSequenceNumber(Conversation c) {
         if (c == null) return 0L;
         if (c.getMessages().isEmpty()) {
-            // Empty conversations have no message sequence yet; use conversationId as a
-            // creation-recency fallback.
+            // No messages yet; fall back to conversationId for creation-recency ordering.
             return c.getConversationId();
         }
         return c.getMessages().get(c.getMessages().size() - 1).getSequenceNumber();
     }
 
-    /** Returns admin search results filtered by participant id or name,
-     *  matching both active and historical participants so orphaned
-     *  conversations (everyone has left) remain searchable. */
+    /** Matches both active and historical participants so orphaned conversations
+     *  (everyone has left) remain searchable. */
     public ArrayList<ConversationMetadata> getFilteredAdminConversationSearch(String q) {
         if (q == null || q.isBlank()) return new ArrayList<>(currentAdminConversationSearch);
         ArrayList<ConversationMetadata> filtered = new ArrayList<>();
@@ -883,15 +781,13 @@ public class ClientController {
         return filtered;
     }
 
-    /** Case-insensitive substring match on userId OR name. {@code lowerQuery} is assumed
-     *  pre-lowercased — do this once at the call site, not per-element. */
+    /** {@code lowerQuery} must be pre-lowercased — done once at the call site, not per element. */
     private static boolean userMatches(UserInfo u, String lowerQuery) {
         if (u == null) return false;
         return u.getUserId().toLowerCase().contains(lowerQuery)
                 || u.getName().toLowerCase().contains(lowerQuery);
     }
 
-    /** True iff any user in {@code people} matches {@code lowerQuery} per {@link #userMatches}. */
     private static boolean anyUserMatches(Collection<UserInfo> people, String lowerQuery) {
         if (people == null) return false;
         for (UserInfo u : people) {
@@ -903,7 +799,6 @@ public class ClientController {
     public void setCurrentConversationId(long conversationId) { this.currentConversationId = conversationId; }
     public long getCurrentConversationId() { return currentConversationId; }
 
-    /** Returns the full {@link Conversation} object for the currently selected conversation, or null. */
     public Conversation getCurrentConversation() {
         if (currentConversationId == -1) return null;
         synchronized (conversations) {
@@ -915,17 +810,13 @@ public class ClientController {
     }
 
     /**
-     * Fix E2: atomically capture the triple (conversation reference, viewer's lastRead at open
-     * time, defensive message-list snapshot) under the {@code conversations} monitor AND publish
-     * {@code currentConversationId} in the same critical section. Closes the race between the
-     * click-to-open handler reading {@code lastRead} and {@code Conversation.append} adding a
-     * new message before {@link ConversationView#setListModel} consumes the message list: without
-     * atomic capture, the freshly-arrived message could land in the wrong half of the
-     * "New messages" divider boundary.
+     * Atomically capture (conversation, viewer's lastRead at open time, message-list snapshot)
+     * AND publish {@code currentConversationId} in one critical section. Without atomic capture,
+     * a message arriving between the lastRead read and the snapshot could land on the wrong side
+     * of the "New messages" divider.
+     * <p>Lock order: {@code conversations} → {@code Conversation.this} — matches
+     * {@link #handleMessageResponse}, so deadlock is impossible.
      * <p>Returns null if no user is logged in or the conversation is unknown.
-     * <p>Lock order: {@code conversations} → {@code Conversation.this} (via {@link Conversation#getMessages()}).
-     * This matches {@link #handleMessageResponse} which acquires {@code conversations} then {@code Conversation.append}
-     * in the same order, so deadlock is impossible.
      */
     public ConversationOpenSnapshot openConversationAtomically(long id) {
         UserInfo me = currentUser;
@@ -943,10 +834,7 @@ public class ClientController {
         return null;
     }
 
-    /**
-     * Atomically-captured triple used by the click-to-open path. Immutable; callers must not
-     * mutate {@link #messages} (it's a defensive copy from {@link Conversation#getMessages()}).
-     */
+    /** Immutable open-time snapshot. {@link #messages} is a defensive copy — do not mutate. */
     public static final class ConversationOpenSnapshot {
         public final Conversation conversation;
         public final long lastReadAtOpen;
@@ -959,17 +847,13 @@ public class ClientController {
     }
 
     // -------------------------------------------------------------------------
-    // Read/unread math — pure functions, grouped under ReadCalc to signal intent.
-    // The public statics on ClientController are one-line delegates so existing
-    // call sites (UI renderers, tests pinning ClientController.isUnread / etc.)
-    // continue to compile.
+    // Read/unread math — public statics delegate so existing call sites (UI
+    // renderers, tests pinning ClientController.isUnread / etc.) keep compiling.
     // -------------------------------------------------------------------------
 
-    /** Pure read-state calculations. Stateless; no instance fields. */
     private static final class ReadCalc {
         private ReadCalc() {}
 
-        /** True iff {@code viewer}'s last-read pointer trails the latest message sequence in {@code conv}. */
         static boolean isUnread(Conversation conv, UserInfo viewer) {
             if (conv == null || viewer == null) return false;
             long lastReadSeq = viewer.getLastRead(conv.getConversationId());
@@ -978,14 +862,13 @@ public class ClientController {
             return latestSeq > lastReadSeq;
         }
 
-        /** True iff {@code msg}'s sequence number is strictly above {@code displayedLastReadSeq}. */
         static boolean isMessageUnread(Message msg, long displayedLastReadSeq) {
             if (msg == null) return false;
             return msg.getSequenceNumber() > displayedLastReadSeq;
         }
 
-        /** O(unread) backward scan; stops at the first read message. Relies on
-         *  {@link Conversation#append} being the only mutator and appending in monotonic seq order. */
+        /** O(unread) backward scan: relies on {@link Conversation#append} being the only
+         *  mutator and appending in monotonic seq order. */
         static int unreadCount(Conversation conv, UserInfo viewer) {
             if (conv == null || viewer == null) return 0;
             long lastReadSeq = viewer.getLastRead(conv.getConversationId());
@@ -999,31 +882,25 @@ public class ClientController {
         }
     }
 
-    /** Used by the conversation-list cell renderer to decide whether to bold a row and prepend
-     *  the unread glyph. Returns false if either argument is null. */
     public static boolean isUnread(Conversation conv, UserInfo viewer) {
         return ReadCalc.isUnread(conv, viewer);
     }
 
-    /** Per-message dot predicate paired with the open-conversation snapshot so the renderer
-     *  and sidebar stay aligned. Returns false if {@code msg} is null. */
     public static boolean isMessageUnread(Message msg, long displayedLastReadSeq) {
         return ReadCalc.isMessageUnread(msg, displayedLastReadSeq);
     }
 
-    /** Count of messages in {@code conv} with sequence above {@code viewer}'s last-read pointer.
-     *  Returns 0 if either argument is null, the conversation is empty, or already caught up. */
     public static int unreadCount(Conversation conv, UserInfo viewer) {
         return ReadCalc.unreadCount(conv, viewer);
     }
 
-    /** Writes a {@link Request} to the socket stream. Synchronized to prevent interleaved writes. */
+    /** Synchronized to prevent interleaved writes on the shared output stream. */
     private synchronized void sendRequest(Request r) {
         if (outputStream == null || connectionStatus != ConnectionStatus.CONNECTED) return;
         try {
             outputStream.writeObject(r);
             outputStream.flush();
-            outputStream.reset(); // prevent object-reference cache memory leak
+            outputStream.reset(); // prevents the object-reference cache from leaking memory
         } catch (IOException e) {
             connectionStatus = ConnectionStatus.NOT_CONNECTED;
             e.printStackTrace();
@@ -1039,7 +916,6 @@ public class ClientController {
     // and connection / ping keepalive).
     // -------------------------------------------------------------------------
 
-    /** Drains {@link #requestQueue}: connect if needed, then {@link #sendRequest(Request)}. */
     private void startRequestDrainThread() {
         requestDrainThread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
@@ -1056,9 +932,8 @@ public class ClientController {
                 } catch (IOException e) {
                     connectionStatus = ConnectionStatus.NOT_CONNECTED;
                     if (authInFlight.compareAndSet(true, false)) {
-                        // #138: drop the queued auth request and notify the user instead of
-                        // silently retrying the unreachable server forever. EDT-marshal the
-                        // GUI updates and watchdog-cancel since this is the drain thread.
+                        // Drop the queued auth and notify, rather than silently retrying an
+                        // unreachable server forever. EDT-marshal the GUI work.
                         SwingUtilities.invokeLater(() -> {
                             cancelAuthWatchdog();
                             if (gui != null) {
@@ -1083,7 +958,6 @@ public class ClientController {
         requestDrainThread.start();
     }
 
-    /** Waits for TCP, then reads {@link Response} objects and dispatches them. */
     private void startResponseListenerThread() {
         responseListenerThread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -146,6 +146,7 @@ public class ClientController {
             case REGISTER_RESULT:                handleRegisterResultResponse(response); break;
             case MESSAGE:                        handleMessageResponse(response); break;
             case CONVERSATION:                   handleConversationResponse(response); break;
+            case CONVERSATION_METADATA:          handleConversationMetadataResponse(response); break;
             case LEAVE_RESULT:                   handleLeaveResultResponse(response); break;
             case READ_MESSAGES_UPDATED:          handleReadMessagesUpdatedResponse(response); break;
             case ADMIN_CONVERSATION_RESULT:      handleAdminConversationResultResponse(response); break;
@@ -320,6 +321,55 @@ public class ClientController {
                 setCurrentConversationId(conv.getConversationId());
                 SwingUtilities.invokeLater(() -> gui.updateMessageListModel(conv));
             }
+        }
+    }
+
+    /** Roster-only update for a conversation already in the local cache. First delivery of a
+     *  conversation is owned by the LOGIN response and the full CONVERSATION broadcast — if the
+     *  metadata arrives for an unknown id, drop it rather than synthesize a history-less stub. */
+    private void handleConversationMetadataResponse(Response response) {
+        ConversationMetadata meta = (ConversationMetadata) response.getPayload();
+        if (meta == null) return;
+        ArrayList<Conversation> snapshot;
+        boolean changed = false;
+        synchronized (conversations) {
+            Conversation local = null;
+            for (Conversation c : conversations) {
+                if (c.getConversationId() == meta.getConversationId()) { local = c; break; }
+            }
+            if (local == null) return;
+            ArrayList<UserInfo> incoming = meta.getParticipants();
+            ArrayList<UserInfo> current = local.getParticipants();
+            ArrayList<UserInfo> toAdd = new ArrayList<>();
+            for (UserInfo u : incoming) {
+                if (u == null || u.getUserId() == null) continue;
+                boolean present = false;
+                for (UserInfo existing : current) {
+                    if (u.getUserId().equals(existing.getUserId())) { present = true; break; }
+                }
+                if (!present) toAdd.add(u);
+            }
+            if (!toAdd.isEmpty()) {
+                local.addParticipants(toAdd);
+                changed = true;
+            }
+            for (UserInfo existing : current) {
+                if (existing == null || existing.getUserId() == null) continue;
+                boolean stillThere = false;
+                for (UserInfo u : incoming) {
+                    if (u != null && existing.getUserId().equals(u.getUserId())) {
+                        stillThere = true; break;
+                    }
+                }
+                if (!stillThere) {
+                    local.removeParticipant(existing.getUserId());
+                    changed = true;
+                }
+            }
+            snapshot = new ArrayList<>(conversations);
+        }
+        if (changed && gui != null) {
+            gui.updateConversationListModel(snapshot);
         }
     }
 
@@ -626,27 +676,15 @@ public class ClientController {
     public ArrayList<Conversation> getFilteredConversationList(String query) {
         synchronized (conversations) {
             if (query == null || query.isBlank()) {
-                ArrayList<Conversation> all = new ArrayList<>(conversations);
-                all.sort((a, b) -> Long.compare(latestSequenceNumber(b), latestSequenceNumber(a)));
-                return all;
+                return new ArrayList<>(conversations);
             }
             ArrayList<Conversation> filtered = new ArrayList<>();
             String q = query.toLowerCase();
             for (Conversation c : conversations) {
                 if (anyUserMatches(c.getParticipants(), q)) filtered.add(c);
             }
-            filtered.sort((a, b) -> Long.compare(latestSequenceNumber(b), latestSequenceNumber(a)));
             return filtered;
         }
-    }
-
-    private static long latestSequenceNumber(Conversation c) {
-        if (c == null) return 0L;
-        if (c.getMessages().isEmpty()) {
-            // Fall back to conversationId for creation-recency ordering.
-            return c.getConversationId();
-        }
-        return c.getMessages().get(c.getMessages().size() - 1).getSequenceNumber();
     }
 
     /** Matches both active and historical participants so orphaned conversations

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -9,6 +9,7 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.util.*;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.SwingUtilities;
 import shared.enums.*;
 import shared.networking.*;
@@ -53,7 +54,10 @@ public class ClientController {
     // -------------------------------------------------------------------------
 
     private boolean loggedIn;
-    private UserInfo currentUser;
+    /** Reassigned off-EDT by the response listener thread (handleReadMessagesUpdatedResponse) and
+     *  read on EDT by the compose-focus listener and sidebar renderer. {@code volatile} ensures
+     *  the EDT observes the freshest reference. */
+    private volatile UserInfo currentUser;
     /** #140/#142: true while a LOGIN or REGISTER request is enqueued and unresolved. */
     private volatile boolean authInFlight = false;
     /** #139: cached on register() so handleRegisterResultResponse can pre-fill the login screen. */
@@ -68,6 +72,22 @@ public class ClientController {
     private long currentConversationId = -1;
     private ArrayList<UserInfo> currentDirectory;
     private ArrayList<ConversationMetadata> currentAdminConversationSearch;
+
+    // -------------------------------------------------------------------------
+    // Window-focus gate (Fix A): inbound messages while the OS window is inactive
+    // must NOT advance the read pointer — the user hasn't actually seen them.
+    // We buffer the per-conversation max sequence and replay on activation,
+    // coalescing a burst of N messages into a single UPDATE_READ_MESSAGES.
+    // -------------------------------------------------------------------------
+
+    /** True while the JFrame is the active OS window. Defaults true so headless
+     *  tests (no window-activation events) and pre-window-event states do not
+     *  suppress reads. */
+    private final AtomicBoolean windowActive = new AtomicBoolean(true);
+    /** Conversation id → highest seq of an inbound message that arrived while
+     *  windowActive=false. Drained by {@link #replayReadAdvanceIfNeeded()} on
+     *  window activation. EDT-only access. */
+    private final HashMap<Long, Long> deferredReadAdvance = new HashMap<>();
 
     // -------------------------------------------------------------------------
     // Server path liveness (updated on inbound server-driven signals, e.g. PONG)
@@ -304,6 +324,10 @@ public class ClientController {
         Message msg = (Message) response.getPayload();
         ArrayList<Conversation> snapshot;
         boolean isCurrentConv;
+        boolean shouldAdvanceLastRead = false;
+        // The lastRead-advance decision must happen under the same monitor that
+        // openConversationAtomically uses, so a click-to-open never captures a lastRead
+        // that an in-flight inbound has just bumped past the new message.
         synchronized (conversations) {
             for (int i = 0; i < conversations.size(); i++) {
                 if (conversations.get(i).getConversationId() == msg.getConversationId()) {
@@ -315,12 +339,90 @@ public class ClientController {
             }
             snapshot = new ArrayList<>(conversations);
             isCurrentConv = msg.getConversationId() == currentConversationId;
+            if (isCurrentConv && currentUser != null) {
+                boolean userViewingBottom = (gui == null) || gui.userIsViewingBottom();
+                if (windowActive.get() && userViewingBottom) {
+                    currentUser.setLastRead(msg.getConversationId(), msg.getSequenceNumber());
+                    shouldAdvanceLastRead = true;
+                } else {
+                    deferredReadAdvance.merge(msg.getConversationId(), msg.getSequenceNumber(), Math::max);
+                }
+            }
         }
         if (gui != null) {
             gui.updateConversationListModel(snapshot);
             if (isCurrentConv) {
                 gui.appendMessageToConversationView(msg);
-                updateReadMessages(currentConversationId, msg.getSequenceNumber());
+            }
+        }
+        if (shouldAdvanceLastRead) {
+            updateReadMessages(msg.getConversationId(), msg.getSequenceNumber());
+        }
+    }
+
+    /**
+     * Inbound message arrived in the open conversation. The composed gate is
+     * {@code windowActive && userIsViewingBottom}: if the OS window is active AND the user
+     * is parked at the bottom of the message list (Fix E1), optimistically advance
+     * {@code currentUser.lastRead} and ask the server to persist. Otherwise buffer the
+     * per-conversation max seq for replay on the next window activation OR scroll-to-bottom
+     * transition (whichever comes first).
+     * <p>Package-private seam so unit tests (with {@code gui == null}) can exercise the
+     * read-advance contract directly. Headless callers (gui == null) implicitly satisfy
+     * the bottom-viewing predicate so existing tests need not stage a scroll position.
+     * <p>NOT on the live path: {@link #handleMessageResponse} inlines the same decision
+     * under the {@code conversations} monitor to serialize with
+     * {@link #openConversationAtomically}. Keep the two implementations in sync.
+     */
+    void tryAdvanceReadOnInbound(long convId, long seq) {
+        UserInfo me = currentUser;
+        if (me == null) return;
+        boolean userViewingBottom = (gui == null) || gui.userIsViewingBottom();
+        if (windowActive.get() && userViewingBottom) {
+            me.setLastRead(convId, seq);
+            updateReadMessages(convId, seq);
+        } else {
+            deferredReadAdvance.merge(convId, seq, Math::max);
+        }
+    }
+
+    /** Called by {@link ClientUI}'s WindowAdapter on activate/deactivate. */
+    public void setWindowActive(boolean active) {
+        windowActive.set(active);
+    }
+
+    /** True iff the OS window is currently active. Exposed for tests and gating callers
+     *  (e.g. {@link ClientUI#appendMessageToConversationView}). */
+    public boolean isWindowActive() {
+        return windowActive.get();
+    }
+
+    /**
+     * Drain {@link #deferredReadAdvance}: for each conversation, send one
+     * UPDATE_READ_MESSAGES at the highest deferred seq, advance local lastRead,
+     * and re-sync the open conversation's per-message snapshot. Called on window
+     * activation. Idempotent on an empty buffer.
+     */
+    public void replayReadAdvanceIfNeeded() {
+        UserInfo me = currentUser;
+        if (me == null || deferredReadAdvance.isEmpty()) return;
+        HashMap<Long, Long> drained = new HashMap<>(deferredReadAdvance);
+        deferredReadAdvance.clear();
+        for (Map.Entry<Long, Long> e : drained.entrySet()) {
+            long convId = e.getKey();
+            long maxSeq = e.getValue();
+            if (me.getLastRead(convId) < maxSeq) {
+                me.setLastRead(convId, maxSeq);
+                updateReadMessages(convId, maxSeq);
+            }
+        }
+        if (gui != null) {
+            long openId = currentConversationId;
+            if (openId != -1L) {
+                Long openMax = drained.get(openId);
+                if (openMax != null) gui.markDisplayedReadUpTo(openMax);
+                gui.repaintMessageList();
+                gui.repaintConversationList();
             }
         }
     }
@@ -413,7 +515,10 @@ public class ClientController {
         ReadMessagesUpdated updated = (ReadMessagesUpdated) response.getPayload();
         if (updated != null && updated.getUpdatedUserInfo() != null) {
             currentUser = updated.getUpdatedUserInfo();
-            if (gui != null) gui.repaintMessageList();
+            if (gui != null) {
+                gui.repaintMessageList();
+                gui.repaintConversationList();
+            }
         }
     }
 
@@ -596,6 +701,18 @@ public class ClientController {
         this.currentDirectory = new ArrayList<>(dir);
     }
 
+    /** Package-private: outbound request queue depth — used by unit tests to verify whether
+     *  optimization paths (e.g. {@link #replayReadAdvanceIfNeeded()} and
+     *  {@link #handleMessageResponse(shared.networking.Response)}) did or did not enqueue a request. */
+    int requestQueueDepthForTesting() {
+        return requestQueue.size();
+    }
+
+    /** Package-private: most recently enqueued request, or {@code null} if empty. */
+    Request peekLastRequestForTesting() {
+        return requestQueue.peekLast();
+    }
+
     /** Returns all users whose id or name contains {@code query} (case-insensitive). */
     public ArrayList<UserInfo> getFilteredDirectory(String query) {
         if (query == null || query.isBlank()) return new ArrayList<>(currentDirectory);
@@ -680,6 +797,113 @@ public class ClientController {
             }
         }
         return null;
+    }
+
+    /**
+     * Fix E2: atomically capture the triple (conversation reference, viewer's lastRead at open
+     * time, defensive message-list snapshot) under the {@code conversations} monitor. Closes
+     * the race between the click-to-open handler reading {@code lastRead} and {@code Conversation.append}
+     * adding a new message before {@link ConversationView#setListModel} consumes the message list:
+     * without atomic capture, the freshly-arrived message could land in the wrong half of the
+     * "New messages" divider boundary.
+     * <p>Returns null if no user is logged in or the conversation is unknown.
+     * <p>Lock order: {@code conversations} → {@code Conversation.this} (via {@link Conversation#getMessages()}).
+     * This matches {@link #handleMessageResponse} which acquires {@code conversations} then {@code Conversation.append}
+     * in the same order, so deadlock is impossible.
+     */
+    public ConversationOpenSnapshot getConversationSnapshotForOpen(long id) {
+        UserInfo me = currentUser;
+        if (me == null) return null;
+        synchronized (conversations) {
+            for (Conversation c : conversations) {
+                if (c.getConversationId() == id) {
+                    long lastRead = me.getLastRead(id);
+                    ArrayList<Message> snap = c.getMessages();
+                    return new ConversationOpenSnapshot(c, lastRead, snap);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Atomic open: captures the (lastRead, messages) pair AND publishes
+     * {@code currentConversationId} under the same {@code conversations} monitor that
+     * {@link #handleMessageResponse} uses to append inbound messages and decide whether
+     * to advance lastRead. Without serialization the EDT could snapshot lastRead AFTER
+     * a concurrent inbound advanced it past the new message, erasing the divider.
+     */
+    public ConversationOpenSnapshot openConversationAtomically(long id) {
+        UserInfo me = currentUser;
+        if (me == null) return null;
+        synchronized (conversations) {
+            for (Conversation c : conversations) {
+                if (c.getConversationId() == id) {
+                    long lastRead = me.getLastRead(id);
+                    ArrayList<Message> snap = c.getMessages();
+                    this.currentConversationId = id;
+                    return new ConversationOpenSnapshot(c, lastRead, snap);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Atomically-captured triple used by the click-to-open path. Immutable; callers must not
+     * mutate {@link #messages} (it's a defensive copy from {@link Conversation#getMessages()}).
+     */
+    public static final class ConversationOpenSnapshot {
+        public final Conversation conversation;
+        public final long lastReadAtOpen;
+        public final ArrayList<Message> messages;
+        ConversationOpenSnapshot(Conversation conversation, long lastReadAtOpen, ArrayList<Message> messages) {
+            this.conversation = conversation;
+            this.lastReadAtOpen = lastReadAtOpen;
+            this.messages = messages;
+        }
+    }
+
+    /**
+     * True iff {@code viewer}'s last-read pointer trails the latest message sequence in {@code conv}.
+     * Returns false if either argument is null. Used by the conversation-list cell renderer to
+     * decide whether to bold a row and prepend the unread glyph.
+     */
+    public static boolean isUnread(Conversation conv, UserInfo viewer) {
+        if (conv == null || viewer == null) return false;
+        long lastReadSeq = viewer.getLastRead(conv.getConversationId());
+        ArrayList<Message> msgs = conv.getMessages();
+        long latestSeq = msgs.isEmpty() ? 0L : msgs.get(msgs.size() - 1).getSequenceNumber();
+        return latestSeq > lastReadSeq;
+    }
+
+    /**
+     * True iff {@code msg}'s sequence number is strictly above the snapshot pointer
+     * {@code displayedLastReadSeq}. Mirrors the per-message dot predicate used by
+     * the conversation panel renderer; exposed for unit tests.
+     */
+    public static boolean isMessageUnread(Message msg, long displayedLastReadSeq) {
+        if (msg == null) return false;
+        return msg.getSequenceNumber() > displayedLastReadSeq;
+    }
+
+    /**
+     * Number of messages in {@code conv} with sequence above {@code viewer}'s last-read pointer.
+     * Returns 0 if either argument is null, the conversation is empty, or the viewer is already
+     * caught up. Used by the sidebar cell renderer to populate the unread-count badge.
+     * <p>Implementation is an O(unread) backward scan that stops at the first read message,
+     * relying on Conversation.append being the only mutator and appending in monotonic seq order.
+     */
+    public static int unreadCount(Conversation conv, UserInfo viewer) {
+        if (conv == null || viewer == null) return 0;
+        long lastReadSeq = viewer.getLastRead(conv.getConversationId());
+        ArrayList<Message> msgs = conv.getMessages();
+        int count = 0;
+        for (int i = msgs.size() - 1; i >= 0; i--) {
+            if (msgs.get(i).getSequenceNumber() > lastReadSeq) count++;
+            else break;
+        }
+        return count;
     }
 
     /** Writes a {@link Request} to the socket stream. Synchronized to prevent interleaved writes. */

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -281,8 +281,13 @@ public class ClientController {
                 case SUCCESS:
                     loggedIn = true;
                     currentUser = lr.getUserInfo();
-                    conversations = Collections.synchronizedList(
-                            lr.getConversationList() != null ? lr.getConversationList() : new ArrayList<>());
+                    // #214: defense-in-depth — server now sorts the wire payload, but
+                    // copy + re-sort here so the controller's invariant holds for any
+                    // direct consumer of `conversations` (tests, future callers).
+                    ArrayList<Conversation> sorted = lr.getConversationList() != null
+                            ? new ArrayList<>(lr.getConversationList()) : new ArrayList<>();
+                    sorted.sort((a, b) -> Long.compare(latestSequenceNumber(b), latestSequenceNumber(a)));
+                    conversations = Collections.synchronizedList(sorted);
                     currentDirectory = lr.getDirectoryUserInfoList() != null
                             ? lr.getDirectoryUserInfoList() : new ArrayList<>();
                     if (gui != null) {
@@ -513,12 +518,27 @@ public class ClientController {
 
     private void handleReadMessagesUpdatedResponse(Response response) {
         ReadMessagesUpdated updated = (ReadMessagesUpdated) response.getPayload();
-        if (updated != null && updated.getUpdatedUserInfo() != null) {
-            currentUser = updated.getUpdatedUserInfo();
-            if (gui != null) {
-                gui.repaintMessageList();
-                gui.repaintConversationList();
+        if (updated == null || updated.getUpdatedUserInfo() == null) return;
+        UserInfo fresh = updated.getUpdatedUserInfo();
+        UserInfo old = currentUser;
+        if (old != null) {
+            // #209: preserve any local optimistic advance the server has not yet acked.
+            // getLastReadMap() returns an unmodifiableMap view of the live HashMap; the
+            // defensive copy below is load-bearing — without it, a concurrent EDT writer
+            // can throw ConcurrentModificationException during iteration.
+            Map<Long, Long> oldEntries = new HashMap<>(old.getLastReadMap());
+            for (Map.Entry<Long, Long> e : oldEntries.entrySet()) {
+                long convId = e.getKey();
+                long localSeq = e.getValue();
+                if (localSeq > fresh.getLastRead(convId)) {
+                    fresh.setLastRead(convId, localSeq);
+                }
             }
+        }
+        currentUser = fresh;
+        if (gui != null) {
+            gui.repaintMessageList();
+            gui.repaintConversationList();
         }
     }
 

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -1700,9 +1700,9 @@ public class ClientUI {
                     createConversationButton.setEnabled(true);
                     adminButton.setEnabled(true);
                 } else if(createDialog != null && createDialog.isVisible()) { // if selectUser window is open
-                    if (selecting != null) createConversationUserWindow.addUser(selecting);
+                    if (selectedValue != null) createConversationUserWindow.addUser(selectedValue);
                 } else if(cards.main.conversationView.addDialog != null && cards.main.conversationView.addDialog.isVisible()) {
-                    if(selecting != null) cards.main.conversationView.addUserWindow.addUser(selecting);
+                    if(selectedValue != null) cards.main.conversationView.addUserWindow.addUser(selectedValue);
                 }
             });
         }

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -1374,6 +1374,9 @@ public class ClientUI {
             messageInputField.setText("");
             // Sending a reply is an unambiguous read-acknowledgement.
             removeDividerNow();
+            // Flush any deferred advance from earlier incoming messages — sending is a
+            // strong "I am here" signal, equivalent to a focus regain for read-ack purposes.
+            controller.replayReadAdvanceIfNeeded();
         }
 
         public void setListModel(Conversation currConv) {

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -514,12 +514,10 @@ public class ClientUI {
                 });
             }
             // Slide the per-message read snapshot forward only when the OS window is
-            // active AND the user is parked at the bottom — i.e. they can actually see
-            // the message. Otherwise leave the snapshot frozen; the deferred read-advance
-            // buffer on the controller will replay on the next window activation or
-            // scroll-to-bottom transition, which calls back into markDisplayedReadUpTo to
-            // re-sync. Do NOT call updateReadMessages here — the controller owns that
-            // wire concern via tryAdvanceReadOnInbound.
+            // active AND the user is parked at the bottom. Otherwise leave the snapshot
+            // frozen; the controller's deferred read-advance buffer replays on the next
+            // window activation or scroll-to-bottom, calling back into markDisplayedReadUpTo.
+            // Do NOT call updateReadMessages here — the controller owns the wire concern.
             if (frame.isActive() && cv.userIsAtBottom) {
                 cv.markDisplayedReadUpTo(message.getSequenceNumber());
             }
@@ -544,10 +542,8 @@ public class ClientUI {
                 cards.main.conversationView.markDisplayedReadUpTo(sequenceNumber));
     }
 
-    /** Fix E1: composed-gate input for {@link ClientController#tryAdvanceReadOnInbound}.
-     *  Returns true when the user is parked at (or near) the bottom of the open conversation,
-     *  i.e. they can actually see freshly-arrived messages. Read from the network reader
-     *  thread, so the underlying field is volatile. */
+    /** True when user is parked at the bottom of the open conversation.
+     *  Read from the network reader thread; underlying field is volatile. */
     public boolean userIsViewingBottom() {
         if (cards == null || cards.main == null || cards.main.conversationView == null) {
             return true;

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -152,9 +152,10 @@ public class ClientUI {
     private void installWindowListener() {
         frame.addWindowListener(new WindowAdapter() {
             @Override public void windowActivated(WindowEvent e) {
-                // drain reads deferred while window inactive
                 controller.setWindowActive(true);
-                controller.replayReadAdvanceIfNeeded();
+                // Read-ack drain is now keyed on input focus, not window focus. If focus
+                // restoration lands on the input, the FocusListener fires focusGained
+                // and drives the drain.
                 if (suppressActivationReset) {
                     suppressActivationReset = false;
                     return;
@@ -489,34 +490,21 @@ public class ClientUI {
             // leave-to-next conversation, etc.) also enable input and action buttons.
             cards.main.conversationView.setListModel(conversation);
             // Auto-switch should hand focus to message input, not leave it on a stale
-            // directory selection.
+            // directory selection. The FocusListener on the input drives the read-ack.
             cards.main.directoryView.clearSelecting();
             cards.main.conversationView.focusInput();
-
-            ArrayList<Message> msgs = conversation.getMessages();
-            if (!msgs.isEmpty()) {
-                markConversationRead(conversation, msgs.get(msgs.size() - 1).getSequenceNumber());
-            }
         });
-    }
-
-    /** Marks {@code conversation} read up to {@code sequenceNumber} both locally and on the server. */
-    private void markConversationRead(Conversation conversation, long sequenceNumber) {
-        UserInfo me = controller.getCurrentUserInfo();
-        if (me != null) {
-            me.setLastRead(conversation.getConversationId(), sequenceNumber);
-        }
-        controller.updateReadMessages(conversation.getConversationId(), sequenceNumber);
     }
 
     public void appendMessageToConversationView(Message message) {
         SwingUtilities.invokeLater(() -> {
             ConversationView cv = cards.main.conversationView;
-            // "Actively viewing" requires BOTH window focused AND parked at bottom; userIsAtBottom
-            // defaults to true, so checking it alone would suppress the divider in the alt-tab case.
+            // "Actively viewing" requires input focus AND parked at bottom; either alone
+            // is insufficient (typing without scroll-to-bottom = reading history; scroll-to-
+            // bottom without focus = clicked elsewhere e.g. sidebar or modal).
             UserInfo me = controller.getCurrentUserInfo();
             boolean fromOther = me != null && !message.getSenderId().equals(me.getUserId());
-            boolean userActivelyViewing = frame.isActive() && cv.userIsAtBottom;
+            boolean userActivelyViewing = controller.isInputFocused() && cv.userIsAtBottom;
             if (fromOther && !userActivelyViewing && !cv.modelHasDivider) {
                 cards.main.conversationView.conversationMessageListModel.addElement(ConversationView.NewMessagesDivider.INSTANCE);
                 cv.modelHasDivider = true;
@@ -532,8 +520,8 @@ public class ClientUI {
                     if (last >= 0) cv.list.ensureIndexIsVisible(last);
                 });
             }
-            // deferred replay: window was inactive when message arrived
-            if (frame.isActive() && cv.userIsAtBottom) {
+            // deferred replay: input was unfocused when message arrived
+            if (controller.isInputFocused() && cv.userIsAtBottom) {
                 cv.markDisplayedReadUpTo(message.getSequenceNumber());
             }
             if (fromOther && !frame.isActive()) {
@@ -1345,6 +1333,37 @@ public class ClientUI {
 
             messageInputField.addActionListener(e -> doSend());
 
+            messageInputField.addFocusListener(new java.awt.event.FocusAdapter() {
+                @Override public void focusGained(java.awt.event.FocusEvent e) {
+                    // Activation-restored focus is not a "user is reading" signal: when
+                    // frame.toFront() reactivates the window after an inbound peer message
+                    // (or the user alt-tabs back), Swing auto-restores focus to the last-
+                    // focused component. Treating that as a user-driven focus would silently
+                    // ack the message and defeat the divider/badge rule.
+                    if (e.getCause() == java.awt.event.FocusEvent.Cause.ACTIVATION) {
+                        return;
+                    }
+                    controller.setInputFocused(true);
+                    controller.replayReadAdvanceIfNeeded();
+                    Conversation c = controller.getCurrentConversation();
+                    if (c != null && userIsAtBottom) {
+                        ArrayList<Message> msgs = c.getMessages();
+                        if (!msgs.isEmpty()) {
+                            long latest = msgs.get(msgs.size() - 1).getSequenceNumber();
+                            UserInfo me = controller.getCurrentUserInfo();
+                            if (me != null && me.getLastRead(c.getConversationId()) < latest) {
+                                me.setLastRead(c.getConversationId(), latest);
+                                controller.updateReadMessages(c.getConversationId(), latest);
+                                markDisplayedReadUpTo(latest);
+                            }
+                        }
+                    }
+                }
+                @Override public void focusLost(java.awt.event.FocusEvent e) {
+                    controller.setInputFocused(false);
+                }
+            });
+
         }
 
         private void doSend() {
@@ -1384,6 +1403,7 @@ public class ClientUI {
                 // doesn't suppress the read-advance for the freshly-opened one.
                 userIsAtBottom = true;
                 participantsLabel.setText(finalMember);
+                messageInputField.setText("");
                 conversationMessageListModel.clear();
                 // Insert the "New messages" divider between read and unread.
                 // Suppress when finalLastReadAtOpen == 0 (nothing has ever been read; a
@@ -1420,6 +1440,7 @@ public class ClientUI {
                 modelHasDivider = false;
                 userIsAtBottom = true;
                 participantsLabel.setText("");
+                messageInputField.setText("");
                 conversationMessageListModel.clear();
                 refreshWrapLayout();
                 messageInputField.setEnabled(false);
@@ -1455,7 +1476,14 @@ public class ClientUI {
         }
 
         private void onScrollReachedBottom() {
-            controller.replayReadAdvanceIfNeeded();
+            // Match the unified rule: scroll-to-bottom alone is not "actively viewing".
+            // Without this gate, the auto-scroll on inbound message arrival fires this
+            // transition and silently drains the deferred buffer that handleMessageResponse
+            // just wrote, removing the divider and clearing the badge before the user
+            // can see them.
+            if (controller.isInputFocused()) {
+                controller.replayReadAdvanceIfNeeded();
+            }
         }
 
         public void markDisplayedReadUpTo(long sequenceNumber) {
@@ -1851,13 +1879,10 @@ public class ClientUI {
                         ClientController.ConversationOpenSnapshot snap =
                                 controller.openConversationAtomically(selected.getConversationId());
                         if (snap == null) return;
-                        if (!snap.messages.isEmpty()) {
-                            Message last = snap.messages.get(snap.messages.size() - 1);
-                            controller.getCurrentUserInfo().setLastRead(
-                                    selected.getConversationId(), last.getSequenceNumber());
-                            controller.updateReadMessages(selected.getConversationId(), last.getSequenceNumber());
-                        }
                         cards.main.conversationView.setListModel(snap);
+                        // Single source of truth: FocusListener on the input acks the open
+                        // only if focus successfully lands on the input field.
+                        cards.main.conversationView.focusInput();
                     }
                 }
             });

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -1326,7 +1326,7 @@ public class ClientUI {
 
         /**
          * Fix E2: race-free overload. Uses the message list captured atomically with
-         * {@code lastReadAtOpen} by {@link ClientController#getConversationSnapshotForOpen(long)}
+         * {@code lastReadAtOpen} by {@link ClientController#openConversationAtomically(long)}
          * so the divider boundary always matches the consistent (lastRead, messages) pair —
          * even if {@link Conversation#append} fires between capture and render.
          */

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -17,141 +17,191 @@ import java.util.ArrayList;
 
 public class ClientUI {
 
-    /** Last time a global key/mouse AWT event was observed (UI "user active"). */
-    private volatile long lastUserActivityMillis = System.currentTimeMillis();
-
     private final ClientController controller;
     private JFrame frame;
     private ScreenCards cards;
     private DefaultListModel<UserInfo> directoryModel;
     private DefaultListModel<Object> conversationMessageModel;
     private DefaultListModel<Conversation> conversationListModel;
-    /** Fires on the EDT every 5s to compare wall clock to {@link #lastUserActivityMillis}. */
-    private final Timer userIdlePollTimer;
-
-    private static final int USER_IDLE_POLL_MS = 5_000;
-    /** Optional: end session after this much in-app UI idle time (0 disables). Default 30 minutes. */
-    private static final long USER_IDLE_LOGOUT_AFTER_MS = 30L * 60L * 1000L;
+    private final IdleWatcher idleWatcher;
 
     private int unreadWhileAway = 0;
     private volatile boolean suppressActivationReset = false;
     private static final String BASE_TITLE = "Communication Application";
 
-    public ClientUI(ClientController controller) {
-        this.controller = controller;
+    private static final Dimension MAIN_FRAME_MIN_SIZE       = new Dimension(900, 600);
+    private static final Dimension SELECT_USER_DIALOG_SIZE   = new Dimension(300, 400);
+    private static final Dimension ADMIN_SEARCH_DIALOG_SIZE  = new Dimension(900, 600);
+    private static final double    BUBBLE_WRAP_FRACTION      = 0.70;
 
-        // Fix 3: wrap ALL frame setup in invokeLater so it runs on the EDT.
-        SwingUtilities.invokeLater(() -> {
-            try {
-                UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
-            } catch (Exception ignored) {
-                // If Nimbus is unavailable, keep current LAF and continue.
-            }
-
-            // Temporary dark-mode test theme (global UI defaults).
-            UIManager.put("control", new Color(43, 43, 43));
-            UIManager.put("info", new Color(60, 63, 65));
-            UIManager.put("nimbusBase", new Color(60, 63, 65));
-            UIManager.put("nimbusAlertYellow", new Color(248, 187, 0));
-            UIManager.put("nimbusDisabledText", new Color(128, 128, 128));
-            UIManager.put("nimbusFocus", new Color(115, 164, 209));
-            UIManager.put("nimbusGreen", new Color(176, 179, 50));
-            UIManager.put("nimbusInfoBlue", new Color(66, 139, 221));
-            UIManager.put("nimbusLightBackground", new Color(43, 43, 43));
-            UIManager.put("nimbusOrange", new Color(191, 98, 4));
-            UIManager.put("nimbusRed", new Color(169, 46, 34));
-            UIManager.put("nimbusSelectedText", new Color(255, 255, 255));
-            UIManager.put("nimbusSelectionBackground", new Color(75, 110, 175));
-            UIManager.put("text", new Color(220, 220, 220));
-            UIManager.put("Panel.background", new Color(43, 43, 43));
-            UIManager.put("Label.foreground", new Color(220, 220, 220));
-            UIManager.put("TextField.background", new Color(60, 63, 65));
-            UIManager.put("TextField.foreground", new Color(220, 220, 220));
-            UIManager.put("TextField.caretForeground", new Color(220, 220, 220));
-            UIManager.put("TextArea.background", new Color(60, 63, 65));
-            UIManager.put("TextArea.foreground", new Color(220, 220, 220));
-            UIManager.put("TextArea.caretForeground", new Color(220, 220, 220));
-            UIManager.put("Button.background", new Color(60, 63, 65));
-            UIManager.put("Button.foreground", new Color(220, 220, 220));
-            UIManager.put("List.background", new Color(43, 43, 43));
-            UIManager.put("List.foreground", new Color(220, 220, 220));
-            UIManager.put("List.selectionBackground", new Color(75, 110, 175));
-            UIManager.put("List.selectionForeground", new Color(255, 255, 255));
-            UIManager.put("OptionPane.background", new Color(43, 43, 43));
-            UIManager.put("OptionPane.messageForeground", new Color(220, 220, 220));
-
-            frame = new JFrame();
-            frame.setTitle(BASE_TITLE);
-            frame.setIconImage(createAppIcon());
-            // Fix 2a: enforce minimum window size
-            frame.setMinimumSize(new java.awt.Dimension(900, 600));
-            cards = new ScreenCards();
-            directoryModel = cards.main.directoryView.getListModel();
-            conversationMessageModel = cards.main.conversationView.getListModel();
-            conversationListModel = cards.main.conversationListView.getListModel();
-            frame.add(cards);
-            frame.pack();
-            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-            frame.setLocationRelativeTo(null);
-            frame.setVisible(true);
-
-            frame.addWindowListener(new WindowAdapter() {
-                @Override public void windowActivated(WindowEvent e) {
-                    // Fix A: tell the controller the window is active and drain any
-                    // deferred read-advances that piled up while we were inactive.
-                    controller.setWindowActive(true);
-                    controller.replayReadAdvanceIfNeeded();
-                    if (suppressActivationReset) {
-                        suppressActivationReset = false;
-                        return;
-                    }
-                    unreadWhileAway = 0;
-                    frame.setTitle(BASE_TITLE);
-                }
-                @Override public void windowDeactivated(WindowEvent e) {
-                    controller.setWindowActive(false);
-                }
-            });
-
-            JRootPane rp = frame.getRootPane();
-            InputMap im = rp.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-            ActionMap am = rp.getActionMap();
-            im.put(KeyStroke.getKeyStroke(KeyEvent.VK_L, InputEvent.CTRL_DOWN_MASK), "shortcutLogout");
-            im.put(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.CTRL_DOWN_MASK), "shortcutNewConv");
-            am.put("shortcutLogout", new AbstractAction() {
-                @Override public void actionPerformed(ActionEvent e) {
-                    if (controller.isLoggedIn()) controller.logout();
-                }
-            });
-            am.put("shortcutNewConv", new AbstractAction() {
-                @Override public void actionPerformed(ActionEvent e) {
-                    if (controller.isLoggedIn()
-                            && cards.main.directoryView.createConversationButton.isEnabled()) {
-                        cards.main.directoryView.createConversationButton.doClick();
-                    }
-                }
-            });
-
-            Toolkit.getDefaultToolkit().addAWTEventListener(
-                e -> {
-                    lastUserActivityMillis = System.currentTimeMillis();
-                },
-                AWTEvent.KEY_EVENT_MASK | AWTEvent.MOUSE_EVENT_MASK
-            );
-        });
-
-        userIdlePollTimer = new Timer(USER_IDLE_POLL_MS, e -> onUserIdlePollTick());
-        userIdlePollTimer.setRepeats(true);
-        userIdlePollTimer.start();
+    /** Named RGB constants for the dark-mode theme. Values are unchanged from the
+     *  original inline literals — this class only gives them readable names. */
+    private static final class Theme {
+        // Surfaces
+        static final Color SURFACE_BG          = new Color(43, 43, 43);
+        static final Color FIELD_BG            = new Color(60, 63, 65);
+        // Text
+        static final Color TEXT_PRIMARY        = new Color(220, 220, 220);
+        static final Color TEXT_ON_OWN_BUBBLE  = new Color(235, 235, 235);
+        static final Color WHITE               = new Color(255, 255, 255);
+        // Nimbus accent palette
+        static final Color NIMBUS_FOCUS         = new Color(115, 164, 209);
+        static final Color NIMBUS_GREEN         = new Color(176, 179, 50);
+        static final Color NIMBUS_INFO_BLUE     = new Color(66, 139, 221);
+        static final Color NIMBUS_ORANGE        = new Color(191, 98, 4);
+        static final Color NIMBUS_RED           = new Color(169, 46, 34);
+        static final Color NIMBUS_ALERT_YELLOW  = new Color(248, 187, 0);
+        static final Color NIMBUS_DISABLED_TEXT = new Color(128, 128, 128);
+        static final Color NIMBUS_SELECTION_BG  = new Color(75, 110, 175);
+        // App-specific
+        static final Color OWN_BUBBLE_BG = new Color(66, 95, 120);
+        static final Color BUBBLE_BORDER = new Color(180, 180, 180);
+        static final Color BANNER_FG     = new Color(0, 100, 180);
+        static final Color APP_ICON_BG   = new Color(33, 150, 243);
     }
 
-    /** Runs on EDT each timer tick: elapsed time since last AWT user input. */
-    private void onUserIdlePollTick() {
-        long idleMs = System.currentTimeMillis() - lastUserActivityMillis;
-        if (USER_IDLE_LOGOUT_AFTER_MS > 0
-                && controller.isLoggedIn()
-                && idleMs >= USER_IDLE_LOGOUT_AFTER_MS) {
-            controller.logout();
+    public ClientUI(ClientController controller) {
+        this.controller = controller;
+        this.idleWatcher = new IdleWatcher();
+
+        SwingUtilities.invokeLater(() -> {
+            applyNimbusLookAndFeel();
+            applyDarkModeTheme();
+            initFrameAndCards();
+            installWindowListener();
+            installKeyboardShortcuts();
+            idleWatcher.installAwtListener();
+        });
+
+        idleWatcher.start();
+    }
+
+    private void applyNimbusLookAndFeel() {
+        try {
+            UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+        } catch (Exception ignored) {
+            // If Nimbus is unavailable, keep current LAF and continue.
+        }
+    }
+
+    private void applyDarkModeTheme() {
+        UIManager.put("control", Theme.SURFACE_BG);
+        UIManager.put("info", Theme.FIELD_BG);
+        UIManager.put("nimbusBase", Theme.FIELD_BG);
+        UIManager.put("nimbusAlertYellow", Theme.NIMBUS_ALERT_YELLOW);
+        UIManager.put("nimbusDisabledText", Theme.NIMBUS_DISABLED_TEXT);
+        UIManager.put("nimbusFocus", Theme.NIMBUS_FOCUS);
+        UIManager.put("nimbusGreen", Theme.NIMBUS_GREEN);
+        UIManager.put("nimbusInfoBlue", Theme.NIMBUS_INFO_BLUE);
+        UIManager.put("nimbusLightBackground", Theme.SURFACE_BG);
+        UIManager.put("nimbusOrange", Theme.NIMBUS_ORANGE);
+        UIManager.put("nimbusRed", Theme.NIMBUS_RED);
+        UIManager.put("nimbusSelectedText", Theme.WHITE);
+        UIManager.put("nimbusSelectionBackground", Theme.NIMBUS_SELECTION_BG);
+        UIManager.put("text", Theme.TEXT_PRIMARY);
+        UIManager.put("Panel.background", Theme.SURFACE_BG);
+        UIManager.put("Label.foreground", Theme.TEXT_PRIMARY);
+        UIManager.put("TextField.background", Theme.FIELD_BG);
+        UIManager.put("TextField.foreground", Theme.TEXT_PRIMARY);
+        UIManager.put("TextField.caretForeground", Theme.TEXT_PRIMARY);
+        UIManager.put("TextArea.background", Theme.FIELD_BG);
+        UIManager.put("TextArea.foreground", Theme.TEXT_PRIMARY);
+        UIManager.put("TextArea.caretForeground", Theme.TEXT_PRIMARY);
+        UIManager.put("Button.background", Theme.FIELD_BG);
+        UIManager.put("Button.foreground", Theme.TEXT_PRIMARY);
+        UIManager.put("List.background", Theme.SURFACE_BG);
+        UIManager.put("List.foreground", Theme.TEXT_PRIMARY);
+        UIManager.put("List.selectionBackground", Theme.NIMBUS_SELECTION_BG);
+        UIManager.put("List.selectionForeground", Theme.WHITE);
+        UIManager.put("OptionPane.background", Theme.SURFACE_BG);
+        UIManager.put("OptionPane.messageForeground", Theme.TEXT_PRIMARY);
+    }
+
+    private void initFrameAndCards() {
+        frame = new JFrame();
+        frame.setTitle(BASE_TITLE);
+        frame.setIconImage(createAppIcon());
+        frame.setMinimumSize(MAIN_FRAME_MIN_SIZE);
+        cards = new ScreenCards();
+        directoryModel = cards.main.directoryView.getListModel();
+        conversationMessageModel = cards.main.conversationView.getListModel();
+        conversationListModel = cards.main.conversationListView.getListModel();
+        frame.add(cards);
+        frame.pack();
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private void installWindowListener() {
+        frame.addWindowListener(new WindowAdapter() {
+            @Override public void windowActivated(WindowEvent e) {
+                // Tell the controller the window is active and drain any
+                // deferred read-advances that piled up while we were inactive.
+                controller.setWindowActive(true);
+                controller.replayReadAdvanceIfNeeded();
+                if (suppressActivationReset) {
+                    suppressActivationReset = false;
+                    return;
+                }
+                unreadWhileAway = 0;
+                frame.setTitle(BASE_TITLE);
+            }
+            @Override public void windowDeactivated(WindowEvent e) {
+                controller.setWindowActive(false);
+            }
+        });
+    }
+
+    private void installKeyboardShortcuts() {
+        JRootPane rp = frame.getRootPane();
+        InputMap im = rp.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+        ActionMap am = rp.getActionMap();
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_L, InputEvent.CTRL_DOWN_MASK), "shortcutLogout");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.CTRL_DOWN_MASK), "shortcutNewConv");
+        am.put("shortcutLogout", new AbstractAction() {
+            @Override public void actionPerformed(ActionEvent e) {
+                if (controller.isLoggedIn()) controller.logout();
+            }
+        });
+        am.put("shortcutNewConv", new AbstractAction() {
+            @Override public void actionPerformed(ActionEvent e) {
+                if (controller.isLoggedIn()
+                        && cards.main.directoryView.createConversationButton.isEnabled()) {
+                    cards.main.directoryView.createConversationButton.doClick();
+                }
+            }
+        });
+    }
+
+    /** Tracks UI idleness via a global AWT key/mouse listener and ends the
+     *  session if the user has been inactive past {@link #LOGOUT_AFTER_MS}. */
+    private final class IdleWatcher {
+        private static final int POLL_MS = 5_000;
+        private static final long LOGOUT_AFTER_MS = 30L * 60L * 1000L;
+
+        private volatile long lastActivityMillis = System.currentTimeMillis();
+        private final Timer pollTimer;
+
+        IdleWatcher() {
+            pollTimer = new Timer(POLL_MS, e -> onTick());
+            pollTimer.setRepeats(true);
+        }
+
+        void start() { pollTimer.start(); }
+
+        void installAwtListener() {
+            Toolkit.getDefaultToolkit().addAWTEventListener(
+                e -> lastActivityMillis = System.currentTimeMillis(),
+                AWTEvent.KEY_EVENT_MASK | AWTEvent.MOUSE_EVENT_MASK
+            );
+        }
+
+        private void onTick() {
+            long idleMs = System.currentTimeMillis() - lastActivityMillis;
+            if (LOGOUT_AFTER_MS > 0 && controller.isLoggedIn() && idleMs >= LOGOUT_AFTER_MS) {
+                controller.logout();
+            }
         }
     }
 
@@ -162,16 +212,15 @@ public class ClientUI {
     /** #139B: pre-fill login id (e.g. with the just-registered loginName) before showing the screen. */
     public void showLoginView(String prefilledLoginId) {
         SwingUtilities.invokeLater(() -> {
-            // Fix 5: dispose any open dialogs before switching to login
             DirectoryView dv = cards.main.directoryView;
             ConversationView cv = cards.main.conversationView;
-            if (dv.createDialog != null && dv.createDialog.isVisible()) dv.createDialog.dispose();
-            if (dv.adminDialog != null && dv.adminDialog.isVisible()) dv.adminDialog.dispose();
-            if (cv.addDialog != null && cv.addDialog.isVisible()) cv.addDialog.dispose();
+            disposeIfVisible(dv.createDialog);
+            disposeIfVisible(dv.adminDialog);
+            disposeIfVisible(cv.addDialog);
 
             clearLoginAndRegisterFields();
             if (prefilledLoginId != null && !prefilledLoginId.isEmpty()) {
-                cards.login.login_idField.setText(prefilledLoginId);
+                cards.login.loginIdField.setText(prefilledLoginId);
             }
             cards.main.directoryView.adminButton.setVisible(false);
             cards.main.directoryView.revalidate();
@@ -199,7 +248,7 @@ public class ClientUI {
             boolean isAdmin = currentUser != null && currentUser.getUserType() == UserType.ADMIN;
             cards.main.directoryView.adminButton.setVisible(isAdmin);
             // Refresh directory list from the latest controller-side cache on main-view entry.
-            // Fix 6: exclude the logged-in user from the directory picker list
+            // Exclude the logged-in user from the directory picker list.
             String myId = (currentUser != null) ? currentUser.getUserId() : null;
             directoryModel.clear();
             for (UserInfo userInfo : controller.getFilteredDirectory("")) {
@@ -224,7 +273,6 @@ public class ClientUI {
                 idL.setForeground(Color.GRAY);
             }
             cards.layout.show(cards, "main");
-            // Fix 2b: repack and re-center after switching to main card
             frame.pack();
             frame.setLocationRelativeTo(null);
         });
@@ -276,7 +324,7 @@ public class ClientUI {
     }
 
     private void clearLoginAndRegisterFields() {
-        cards.login.login_idField.setText("");
+        cards.login.loginIdField.setText("");
         cards.login.passwordField.setText("");
         cards.register.userId.setText("");
         cards.register.name.setText("");
@@ -313,7 +361,7 @@ public class ClientUI {
 
     public void showLoginError(LoginStatus loginStatus) {
         SwingUtilities.invokeLater(() -> {
-            // #139A: always clear the password on login failure.
+            // Always clear the password on login failure.
             cards.login.passwordField.setText("");
             String msg;
             String title = "Login Error";
@@ -325,7 +373,6 @@ public class ClientUI {
                     msg = "No account exists. Please create an account.";
                     break;
                 case DUPLICATE_SESSION:
-                    // #144: coherent, actionable copy that doesn't contradict itself.
                     title = "Session Already Active";
                     msg = "You are already logged in from another location. Please log out of "
                         + "that session first, then try again. If you closed the app without "
@@ -374,41 +421,40 @@ public class ClientUI {
 
     public void updateConversationListModel(ArrayList<Conversation> conversations) {
         SwingUtilities.invokeLater(() -> {
-            // Fix 7: preserve selection across model rebuild
-            JList<Conversation> convList = cards.main.conversationListView.list;
-            cards.main.conversationListView.suppressSelectionEvents = true;
-            Conversation selected = convList.getSelectedValue();
-            Long selectedId = (selected != null) ? selected.getConversationId() : null;
+            ConversationListView clv = cards.main.conversationListView;
+            clv.withSuppressedSelection(() -> {
+                Conversation selected = clv.list.getSelectedValue();
+                Long selectedId = (selected != null) ? selected.getConversationId() : null;
 
-            // Sort by highest latest sequence number descending (most recent first),
-            // which also keeps offline-received updates ordered correctly on initial paint.
-            conversations.sort((a, b) -> {
-                ArrayList<Message> aMsgs = a.getMessages();
-                ArrayList<Message> bMsgs = b.getMessages();
-                long aSeq = aMsgs.isEmpty()
-                        ? a.getConversationId()
-                        : aMsgs.get(aMsgs.size() - 1).getSequenceNumber();
-                long bSeq = bMsgs.isEmpty()
-                        ? b.getConversationId()
-                        : bMsgs.get(bMsgs.size() - 1).getSequenceNumber();
-                return Long.compare(bSeq, aSeq);
-            });
+                // Sort by highest latest sequence number descending (most recent first),
+                // which also keeps offline-received updates ordered correctly on initial paint.
+                conversations.sort((a, b) -> {
+                    ArrayList<Message> aMsgs = a.getMessages();
+                    ArrayList<Message> bMsgs = b.getMessages();
+                    long aSeq = aMsgs.isEmpty()
+                            ? a.getConversationId()
+                            : aMsgs.get(aMsgs.size() - 1).getSequenceNumber();
+                    long bSeq = bMsgs.isEmpty()
+                            ? b.getConversationId()
+                            : bMsgs.get(bMsgs.size() - 1).getSequenceNumber();
+                    return Long.compare(bSeq, aSeq);
+                });
 
-            conversationListModel.clear();
-            for (Conversation conversation : conversations) {
-                conversationListModel.addElement(conversation);
-            }
+                conversationListModel.clear();
+                for (Conversation conversation : conversations) {
+                    conversationListModel.addElement(conversation);
+                }
 
-            // Restore selection after rebuild
-            if (selectedId != null) {
-                for (int i = 0; i < conversationListModel.getSize(); i++) {
-                    if (conversationListModel.getElementAt(i).getConversationId() == selectedId.longValue()) {
-                        convList.setSelectedIndex(i);
-                        break;
+                // Restore selection after rebuild.
+                if (selectedId != null) {
+                    for (int i = 0; i < conversationListModel.getSize(); i++) {
+                        if (conversationListModel.getElementAt(i).getConversationId() == selectedId.longValue()) {
+                            clv.list.setSelectedIndex(i);
+                            break;
+                        }
                     }
                 }
-            }
-            cards.main.conversationListView.suppressSelectionEvents = false;
+            });
         });
     }
 
@@ -422,22 +468,28 @@ public class ClientUI {
             // Route through ConversationView so auto-switch flows (first conversation,
             // leave-to-next conversation, etc.) also enable input and action buttons.
             cards.main.conversationView.setListModel(conversation);
-            // Issue #189: auto-switch should hand focus to message input, not leave it on
-            // a stale directory selection.
-            cards.main.directoryView.list.clearSelection();
-            cards.main.directoryView.selecting = null;
-            SwingUtilities.invokeLater(() -> cards.main.conversationView.text.requestFocusInWindow());
+            // Auto-switch should hand focus to message input, not leave it on a stale
+            // directory selection.
+            cards.main.directoryView.clearSelecting();
+            SwingUtilities.invokeLater(cards.main.conversationView::focusInput);
 
             ArrayList<Message> msgs = conversation.getMessages();
             if (!msgs.isEmpty()) {
-                Message last = msgs.get(msgs.size() - 1);
-                UserInfo me = controller.getCurrentUserInfo();
-                if (me != null) {
-                    me.setLastRead(conversation.getConversationId(), last.getSequenceNumber());
-                }
-                controller.updateReadMessages(conversation.getConversationId(), last.getSequenceNumber());
+                markConversationRead(conversation, msgs.get(msgs.size() - 1).getSequenceNumber());
             }
         });
+    }
+
+    /** Marks {@code conversation} as read up to {@code sequenceNumber} on both the
+     *  client-side model and the server. {@link ClientController#updateReadMessages}
+     *  is the network round-trip; the {@code setLastRead} call ahead of it keeps the
+     *  local cache in sync immediately. */
+    private void markConversationRead(Conversation conversation, long sequenceNumber) {
+        UserInfo me = controller.getCurrentUserInfo();
+        if (me != null) {
+            me.setLastRead(conversation.getConversationId(), sequenceNumber);
+        }
+        controller.updateReadMessages(conversation.getConversationId(), sequenceNumber);
     }
 
     public void appendMessageToConversationView(Message message) {
@@ -453,25 +505,24 @@ public class ClientUI {
                 cv.modelHasDivider = true;
             }
             conversationMessageModel.addElement(message);
-            // Fix 9 + Fix E1: auto-scroll to newest only when the user is parked at the
-            // bottom. Otherwise preserve their scroll position so they can read history.
+            // Auto-scroll to newest only when the user is parked at the bottom. Otherwise
+            // preserve their scroll position so they can read history.
             if (cv.userIsAtBottom) {
                 SwingUtilities.invokeLater(() -> {
                     int last = cv.list.getModel().getSize() - 1;
                     if (last >= 0) cv.list.ensureIndexIsVisible(last);
                 });
             }
-            // Composed gate (Fix A + Fix E1): slide the per-message snapshot forward only
-            // when the OS window is active AND the user is parked at the bottom — i.e. they
-            // can actually see the message. Otherwise leave the snapshot frozen; the deferred
-            // read-advance buffer on the controller will replay on the next window activation
-            // or scroll-to-bottom transition, which calls back into markDisplayedReadUpTo to
-            // re-sync. Do NOT call updateReadMessages here — the controller owns that wire
-            // concern via tryAdvanceReadOnInbound.
+            // Slide the per-message read snapshot forward only when the OS window is
+            // active AND the user is parked at the bottom — i.e. they can actually see
+            // the message. Otherwise leave the snapshot frozen; the deferred read-advance
+            // buffer on the controller will replay on the next window activation or
+            // scroll-to-bottom transition, which calls back into markDisplayedReadUpTo to
+            // re-sync. Do NOT call updateReadMessages here — the controller owns that
+            // wire concern via tryAdvanceReadOnInbound.
             if (frame.isActive() && cv.userIsAtBottom) {
                 cv.markDisplayedReadUpTo(message.getSequenceNumber());
             }
-            // Issue #176: notify user when window is not active
             if (fromOther && !frame.isActive()) {
                 unreadWhileAway++;
                 frame.setTitle(BASE_TITLE + " (" + unreadWhileAway + " new)");
@@ -552,7 +603,7 @@ public class ClientUI {
             new java.awt.image.BufferedImage(size, size, java.awt.image.BufferedImage.TYPE_INT_ARGB);
         Graphics2D g = img.createGraphics();
         g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        g.setColor(new Color(33, 150, 243));
+        g.setColor(Theme.APP_ICON_BG);
         g.fillOval(0, 0, size, size);
         g.setColor(Color.WHITE);
         g.fillRoundRect(6, 7, 20, 14, 6, 6);
@@ -561,6 +612,90 @@ public class ClientUI {
         g.fillPolygon(xs, ys, 3);
         g.dispose();
         return img;
+    }
+
+    /** Format a message timestamp as "LLL dd, HH:mm" (or include the year if it
+     *  isn't the current year). Shared by message renderers. */
+    private static String formatMessageTimestamp(java.util.Date when) {
+        ZonedDateTime zdt = when.toInstant().atZone(ZoneId.systemDefault());
+        DateTimeFormatter dtf = zdt.getYear() == ZonedDateTime.now().getYear()
+                ? DateTimeFormatter.ofPattern("LLL dd, HH:mm", java.util.Locale.ENGLISH)
+                : DateTimeFormatter.ofPattern("LLL dd yyyy, HH:mm", java.util.Locale.ENGLISH);
+        return zdt.format(dtf);
+    }
+
+    /** Look up a sender's display name in a conversation's historical participants
+     *  (so removed users still show their name). Returns null if not found. */
+    private static String resolveHistoricalSenderName(Conversation conv, String senderId) {
+        if (conv == null) return null;
+        for (UserInfo p : conv.getHistoricalParticipants()) {
+            if (p.getUserId().equals(senderId)) return p.getName();
+        }
+        return null;
+    }
+
+    private static boolean isDialogShowing(JDialog d) {
+        return d != null && d.isVisible();
+    }
+
+    private static void disposeIfVisible(JDialog d) {
+        if (isDialogShowing(d)) d.dispose();
+    }
+
+    /** If {@code d} is already on screen, raise it and return true so the caller
+     *  can short-circuit instead of opening a second instance. */
+    private static boolean focusExistingDialog(JDialog d) {
+        if (!isDialogShowing(d)) return false;
+        d.toFront();
+        d.requestFocus();
+        return true;
+    }
+
+    /** Display-ready snapshot of a {@link Message} for the cell renderers.
+     *  Header text and sender resolution are computed once instead of being
+     *  recomputed inside each renderer's getListCellRendererComponent. */
+    private static final class MessageRow {
+        final String headerText;
+        final String body;
+        final String senderName;
+        final String timestamp;
+        final boolean isOwn;
+
+        private MessageRow(String headerText, String body, String senderName,
+                           String timestamp, boolean isOwn) {
+            this.headerText = headerText;
+            this.body = body;
+            this.senderName = senderName;
+            this.timestamp = timestamp;
+            this.isOwn = isOwn;
+        }
+
+        /** Built for the live conversation view: own messages elide the sender
+         *  name in the header so the bubble side ("EAST") carries the identity. */
+        static MessageRow forConversation(Message msg, Conversation conv, UserInfo me) {
+            String ts = formatMessageTimestamp(msg.getTimestamp());
+            String body = msg.getText() == null ? "" : msg.getText();
+            boolean isOwn = me != null && me.getUserId() != null
+                    && me.getUserId().equals(msg.getSenderId());
+            String senderName;
+            if (isOwn) {
+                senderName = me.getName();
+            } else {
+                String resolved = resolveHistoricalSenderName(conv, msg.getSenderId());
+                senderName = resolved != null ? resolved : "(former participant)";
+            }
+            String header = isOwn ? ts : (ts + " " + senderName + ":");
+            return new MessageRow(header, body, senderName, ts, isOwn);
+        }
+
+        /** Built for the admin viewer: no "me" concept, sender name always shown. */
+        static MessageRow forAdmin(Message msg, Conversation viewedConv) {
+            String ts = formatMessageTimestamp(msg.getTimestamp());
+            String body = msg.getText() == null ? "" : msg.getText();
+            String resolved = resolveHistoricalSenderName(viewedConv, msg.getSenderId());
+            String senderName = resolved != null ? resolved : "(former participant)";
+            return new MessageRow(ts + " " + senderName + ":", body, senderName, ts, false);
+        }
     }
 
     private static class PlaceholderTextField extends JTextField {
@@ -623,101 +758,81 @@ public class ClientUI {
         JButton backButton;
 
         RegisterView() {
-        	setLayout(new BorderLayout());
+            buildLayout();
+            wireRegisterButton();
+            wireBackButton();
+        }
 
-        	// initialize components
-        	JPanel inputPanel = new JPanel(new GridBagLayout());
-        	userId = new JTextField(15);
-        	name = new JTextField(15);
-        	loginName = new JTextField(15);
-        	password = new JPasswordField(15);
-        	passwordAgain = new JPasswordField(15);
-        	createButton = new JButton("Create Account");
-        	backButton = new JButton("Back");
+        private void buildLayout() {
+            setLayout(new BorderLayout());
 
-        	// #143: tooltips clarify which ID is which.
-        	userId.setToolTipText("Your organization-assigned employee ID. Must be pre-authorized.");
-        	loginName.setToolTipText("Choose a username for logging in. Letters, numbers, hyphens, or underscores only.");
+            JPanel inputPanel = new JPanel(new GridBagLayout());
+            userId = new JTextField(15);
+            name = new JTextField(15);
+            loginName = new JTextField(15);
+            password = new JPasswordField(15);
+            passwordAgain = new JPasswordField(15);
+            createButton = new JButton("Create Account");
+            backButton = new JButton("Back");
 
-        	// #146: heading at the top of the form.
-        	JLabel heading = new JLabel("Register / Create Account", SwingConstants.CENTER);
-        	heading.setFont(heading.getFont().deriveFont(Font.BOLD, heading.getFont().getSize() + 6f));
-        	heading.setBorder(BorderFactory.createEmptyBorder(20, 0, 10, 0));
-        	add(heading, BorderLayout.NORTH);
+            // Tooltips clarify which ID is which.
+            userId.setToolTipText("Your organization-assigned employee ID. Must be pre-authorized.");
+            loginName.setToolTipText("Choose a username for logging in. Letters, numbers, hyphens, or underscores only.");
 
-        	// layout for  the buttons
+            JLabel heading = new JLabel("Register / Create Account", SwingConstants.CENTER);
+            heading.setFont(heading.getFont().deriveFont(Font.BOLD, heading.getFont().getSize() + 6f));
+            heading.setBorder(BorderFactory.createEmptyBorder(20, 0, 10, 0));
+            add(heading, BorderLayout.NORTH);
+
             JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 10, 0));
             buttonPanel.add(createButton);
             buttonPanel.add(backButton);
 
-        	// use grid layout to put the parts
-        	GridBagConstraints gridConst = new GridBagConstraints();
+            GridBagConstraints gridConst = new GridBagConstraints();
             gridConst.insets = new Insets(5, 5, 5, 5);
             gridConst.fill = GridBagConstraints.HORIZONTAL;
 
-            // #143: "User ID" → "Employee ID" (organization-assigned, validated against authorized list).
-            gridConst.gridx = 0;
-            gridConst.gridy = 0;
+            // "Employee ID" is organization-assigned and validated against the authorized list.
+            gridConst.gridx = 0; gridConst.gridy = 0;
             inputPanel.add(new JLabel("Employee ID"), gridConst);
-
-            // put the text field on the right side of the label
-            gridConst.gridx = 1;
-            gridConst.gridwidth = 2;
+            gridConst.gridx = 1; gridConst.gridwidth = 2;
             inputPanel.add(userId, gridConst);
 
-            // put the label for user name below User ID
-            gridConst.gridx = 0;
-            gridConst.gridy = 1;
-            gridConst.gridwidth = 1;
+            gridConst.gridx = 0; gridConst.gridy = 1; gridConst.gridwidth = 1;
             inputPanel.add(new JLabel("User Name"), gridConst);
-
-            // put the text field on the right side of the label
             gridConst.gridx = 1;
             inputPanel.add(name, gridConst);
 
-            // put the label for user name below User ID
-            gridConst.gridx = 0;
-            gridConst.gridy = 2;
+            gridConst.gridx = 0; gridConst.gridy = 2;
             inputPanel.add(new JLabel("Login ID"), gridConst);
-
-            // put the text field on the right side of the label
             gridConst.gridx = 1;
             inputPanel.add(loginName, gridConst);
 
-            // put the label for password below login Name
-            gridConst.gridx = 0;
-            gridConst.gridy = 3;
+            gridConst.gridx = 0; gridConst.gridy = 3;
             inputPanel.add(new JLabel("Password"), gridConst);
-
-            // #141: password text field with Show/Hide toggle on the right side of the label
+            // Password text field with Show/Hide toggle.
             gridConst.gridx = 1;
             inputPanel.add(passwordFieldWithToggle(password), gridConst);
 
-            // put the label for the password (confirmation)
-            gridConst.gridx = 0;
-            gridConst.gridy = 4;
+            gridConst.gridx = 0; gridConst.gridy = 4;
             inputPanel.add(new JLabel("Confirm Password"), gridConst);
-
-            // #141: confirmation password field also gets a toggle
             gridConst.gridx = 1;
             inputPanel.add(passwordFieldWithToggle(passwordAgain), gridConst);
 
-            // put the button layout below the fields
-            gridConst.gridx = 1;
-            gridConst.gridy = 5;
+            gridConst.gridx = 1; gridConst.gridy = 5;
             inputPanel.add(buttonPanel, gridConst);
 
-            // locate these parts at the center of the window
             add(inputPanel, BorderLayout.CENTER);
+        }
 
-            // #137: extract submit lambda so Enter on any field also fires it.
+        private void wireRegisterButton() {
+            // Extract submit lambda so Enter on any field also fires it.
             ActionListener createAction = e -> {
                 char[] pwd1 = password.getPassword();
                 char[] pwd2 = passwordAgain.getPassword();
                 if (java.util.Arrays.equals(pwd1, pwd2)) {
                     controller.register(userId.getText(), name.getText(), loginName.getText(), password.getPassword());
                 } else {
-                    // Fix 4: use frame as parent instead of null
                     JOptionPane.showMessageDialog(frame, "Passwords don't match. Type them again.", "Error", JOptionPane.ERROR_MESSAGE);
                 }
                 java.util.Arrays.fill(pwd1, '0');
@@ -729,33 +844,32 @@ public class ClientUI {
             loginName.addActionListener(createAction);
             password.addActionListener(createAction);
             passwordAgain.addActionListener(createAction);
+        }
 
-            // #148: route through showLoginView so clearLoginAndRegisterFields() is called.
+        private void wireBackButton() {
+            // Route through showLoginView so clearLoginAndRegisterFields() is called.
             backButton.addActionListener(e -> showLoginView());
         }
     }
 
     // =========================================================================
     class LoginView extends JPanel {
-        JTextField login_idField;
+        JTextField loginIdField;
         JPasswordField passwordField;
         JButton loginButton;
         JButton createButton;
 
         LoginView() {
-
             setLayout(new BorderLayout());
 
-            // initialize components
-            login_idField = new JTextField(15);
+            loginIdField = new JTextField(15);
             passwordField = new JPasswordField(15);
             loginButton = new JButton("Login");
             createButton = new JButton("Create Account");
 
-            // #143: tooltip clarifies the field is the login username, not the Employee ID.
-            login_idField.setToolTipText("Your chosen login username (not your Employee ID).");
+            // Tooltip clarifies the field is the login username, not the Employee ID.
+            loginIdField.setToolTipText("Your chosen login username (not your Employee ID).");
 
-            // #146: heading at the top of the form.
             JLabel heading = new JLabel("Login", SwingConstants.CENTER);
             heading.setFont(heading.getFont().deriveFont(Font.BOLD, heading.getFont().getSize() + 6f));
             heading.setBorder(BorderFactory.createEmptyBorder(20, 0, 10, 0));
@@ -766,48 +880,39 @@ public class ClientUI {
             gridConst.insets = new Insets(5, 5, 5, 5);
             gridConst.fill = GridBagConstraints.HORIZONTAL;
 
-
-            // add label for login_id
             gridConst.gridx = 0;
             gridConst.gridy = 0;
             inputPanel.add(new JLabel("Login ID"), gridConst);
-            // add text field on the right side of the label
             gridConst.gridx = 1;
-            inputPanel.add(login_idField, gridConst);
-            // add label for password below the login_id
+            inputPanel.add(loginIdField, gridConst);
             gridConst.gridx = 0;
             gridConst.gridy = 1;
             inputPanel.add(new JLabel("Password"), gridConst);
-            // #141: password text field with Show/Hide toggle on the right side of the label
+            // Password text field with Show/Hide toggle.
             gridConst.gridx = 1;
             inputPanel.add(passwordFieldWithToggle(passwordField), gridConst);
-            // add login button next to the fields
             gridConst.gridx = 2;
             gridConst.gridy = 0;
             gridConst.gridheight = 2;
             inputPanel.add(loginButton, gridConst);
 
-            // add create button below the text fields
             gridConst.gridx = 1;
             gridConst.gridy = 2;
             gridConst.insets = new Insets(20, 5, 5, 5);
 
-            // wrap a layout with create button which can be located on the middle
             JPanel createBtnPane = new JPanel();
             createBtnPane.setLayout(new FlowLayout(FlowLayout.CENTER));
             createBtnPane.add(createButton);
             inputPanel.add(createBtnPane, gridConst);
 
-            // add to loginView
             add(inputPanel, BorderLayout.CENTER);
 
-
-            ActionListener loginAction = e -> controller.login(login_idField.getText(), passwordField.getPassword());
+            ActionListener loginAction = e -> controller.login(loginIdField.getText(), passwordField.getPassword());
             loginButton.addActionListener(loginAction);
-            login_idField.addActionListener(loginAction);
+            loginIdField.addActionListener(loginAction);
             passwordField.addActionListener(loginAction);
 
-            // #148 (symmetric): route through showRegisterView so fields are cleared.
+            // Route through showRegisterView so fields are cleared.
             createButton.addActionListener(e -> showRegisterView());
         }
     }
@@ -820,31 +925,28 @@ public class ClientUI {
         ConversationListView conversationListView;
 
         MainView() {
-        	setLayout(new GridBagLayout());
-        	GridBagConstraints gridConst = new GridBagConstraints();
-        	conversationView = new ConversationView();
+            setLayout(new GridBagLayout());
+            GridBagConstraints gridConst = new GridBagConstraints();
+            conversationView = new ConversationView();
             directoryView = new DirectoryView();
             conversationListView = new ConversationListView();
             conversationListView.setMinimumSize(new Dimension(MIN_CONVERSATION_LIST_WIDTH, 0));
 
-        	gridConst.gridy = 0;
-        	gridConst.fill = GridBagConstraints.BOTH;
-        	gridConst.weighty = 1.0;
+            gridConst.gridy = 0;
+            gridConst.fill = GridBagConstraints.BOTH;
+            gridConst.weighty = 1.0;
 
-        	// left
-        	gridConst.gridx = 0;
-        	gridConst.weightx = 0.2; // 20%
-        	add(directoryView, gridConst);
+            gridConst.gridx = 0;
+            gridConst.weightx = 0.2;
+            add(directoryView, gridConst);
 
-        	// middle
-        	gridConst.gridx = 1;
-        	gridConst.weightx = 0.6; // 60%
-        	add(conversationView, gridConst);
+            gridConst.gridx = 1;
+            gridConst.weightx = 0.6;
+            add(conversationView, gridConst);
 
-        	// right
-        	gridConst.gridx = 2;
-        	gridConst.weightx = 0.2; // 20%
-        	add(conversationListView, gridConst);
+            gridConst.gridx = 2;
+            gridConst.weightx = 0.2;
+            add(conversationListView, gridConst);
 
         }
 
@@ -853,17 +955,17 @@ public class ClientUI {
     // =========================================================================
     class ConversationView extends JPanel {
         JLabel participantsLabel;
-        DefaultListModel<Object> conversationMessageListModel = new DefaultListModel<>();
-        JList<Object> list = new JList<>(conversationMessageListModel);
+        final DefaultListModel<Object> conversationMessageListModel = new DefaultListModel<>();
+        final JList<Object> list = new JList<>(conversationMessageListModel);
         private JScrollPane messageScrollPane;
         // Snapshot of read state at the time this conversation view was opened/refreshed.
         // Renderer uses this instead of live lastRead updates so unread markers remain meaningful.
         private long displayedLastReadSeq = 0L;
-        // Fix E1: track whether the vertical scrollbar is at (or within 4px of) the bottom.
+        // Tracks whether the vertical scrollbar is at (or within 4px of) the bottom.
         // Volatile because the network reader thread reads it via userIsViewingBottom() while the
         // EDT mutates it in the AdjustmentListener.
         private volatile boolean userIsAtBottom = true;
-        // Fix E1: tracks whether NewMessagesDivider.INSTANCE is currently in the list model.
+        // Tracks whether NewMessagesDivider.INSTANCE is currently in the list model.
         // Set true on insert by setListModel or appendMessageToConversationView; cleared on
         // model clear (setListModel/clearConversation). EDT-only access.
         private boolean modelHasDivider = false;
@@ -874,24 +976,22 @@ public class ClientUI {
         JDialog addDialog;
         SelectUserWindow addUserWindow;
 
-        // Fix 8: placeholder label shown when no conversation is selected
         private final JLabel placeholderLabel = new JLabel("Select a conversation to start chatting", SwingConstants.CENTER);
 
-        // Fix C: sentinel inserted into the message-list model to mark the boundary
+        // Sentinel inserted into the message-list model to mark the boundary
         // between messages already read at conversation-open time and unread messages
-        // that arrived since. Replaces the per-message ● dot with a single horizontal
-        // "─── New messages ───" cue.
+        // that arrived since. Renders as a single horizontal "─── New messages ───" cue.
         private static final class NewMessagesDivider {
             static final NewMessagesDivider INSTANCE = new NewMessagesDivider();
             private NewMessagesDivider() {}
         }
 
-        // Fix 6/#196: use JTextArea-based bubbles for deterministic wrapping.
+        // Use JTextArea-based bubbles for deterministic wrapping.
         private final class MessageCellRenderer extends JPanel implements ListCellRenderer<Object> {
             private final JPanel bubble = new JPanel(new BorderLayout(0, 2));
             private final JTextArea headerArea = new JTextArea();
             private final JTextArea bodyArea = new JTextArea();
-            // Fix C: a separate component returned for NewMessagesDivider sentinels.
+            // A separate component returned for NewMessagesDivider sentinels.
             private final JPanel dividerPanel = new JPanel(new BorderLayout(6, 0));
             private final JLabel dividerLabel = new JLabel("New messages", SwingConstants.CENTER);
 
@@ -900,7 +1000,7 @@ public class ClientUI {
                 setOpaque(true);
                 bubble.setOpaque(true);
                 bubble.setBorder(BorderFactory.createCompoundBorder(
-                        new LineBorder(new Color(180, 180, 180), 1, true),
+                        new LineBorder(Theme.BUBBLE_BORDER, 1, true),
                         BorderFactory.createEmptyBorder(4, 10, 4, 10)));
                 headerArea.setOpaque(false);
                 headerArea.setLineWrap(true);
@@ -919,7 +1019,7 @@ public class ClientUI {
                 bubble.add(bodyArea, BorderLayout.CENTER);
 
                 Color alert = UIManager.getColor("nimbusAlertYellow");
-                if (alert == null) alert = new Color(248, 187, 0);
+                if (alert == null) alert = Theme.NIMBUS_ALERT_YELLOW;
                 dividerPanel.setOpaque(true);
                 dividerPanel.setBorder(BorderFactory.createEmptyBorder(2, 6, 2, 6));
                 dividerLabel.setForeground(alert);
@@ -948,86 +1048,43 @@ public class ClientUI {
                 }
 
                 Message msg = (Message) value;
+                MessageRow row = MessageRow.forConversation(
+                        msg, controller.getCurrentConversation(), controller.getCurrentUserInfo());
 
-                // Resolve sender's display name.
-                // Short-circuit to own name first so own messages always render correctly
-                // even if the cached conversation's participants list is stale or empty.
-                // Use historicalParticipants (not participants) so removed users still show their name.
-                String senderName = null;
-                UserInfo me = controller.getCurrentUserInfo();
-                if (me != null && me.getUserId() != null && me.getUserId().equals(msg.getSenderId())) {
-                    senderName = me.getName();
-                }
-                if (senderName == null) {
-                    Conversation conv = controller.getCurrentConversation();
-                    if (conv != null) {
-                        for (UserInfo p : conv.getHistoricalParticipants()) {
-                            if (p.getUserId().equals(msg.getSenderId())) {
-                                senderName = p.getName();
-                                break;
-                            }
-                        }
-                    }
-                }
-                // Last-resort fallback if even the historical roster has no record of this sender.
-                if (senderName == null) {
-                    senderName = "(former participant)";
-                }
-                ZonedDateTime zdt = msg.getTimestamp().toInstant().atZone(ZoneId.systemDefault());
-                DateTimeFormatter dtf = zdt.getYear() == ZonedDateTime.now().getYear()
-                        ? DateTimeFormatter.ofPattern("LLL dd, HH:mm", java.util.Locale.ENGLISH)
-                        : DateTimeFormatter.ofPattern("LLL dd yyyy, HH:mm", java.util.Locale.ENGLISH);
-                String ts = zdt.format(dtf);
-                String rawText = msg.getText() == null ? "" : msg.getText();
-                boolean isOwnMessage = msg.getSenderId().equals(controller.getCurrentUserInfo().getUserId());
-                String header = isOwnMessage ? ts : (ts + " " + senderName + ":");
-
-                // Remove prior label so we can re-add in the correct position
                 removeAll();
                 setBackground(list.getBackground());
-
                 // Compute wrap width from the viewport (not just list width) so bubbles
                 // adapt correctly when the conversation pane is resized.
-                int wrapPx = computeWrapWidthPx(list);
+                configureBubble(row.isOwn, row.headerText, row.body,
+                        computeWrapWidthPx(list), list.getFont(), list.getBackground());
 
-                // Fix C: per-message ● dot is gone — the NewMessagesDivider sentinel inserted
-                // into the model carries that signal now. Render every message plain.
-                if (isOwnMessage) {
-                    bubble.setBackground(new Color(66, 95, 120));
-                    headerArea.setBackground(bubble.getBackground());
-                    bodyArea.setBackground(bubble.getBackground());
-                    headerArea.setForeground(new Color(235, 235, 235));
-                    bodyArea.setForeground(new Color(235, 235, 235));
-                    headerArea.setText(header);
-                    headerArea.setFont(list.getFont().deriveFont(Font.PLAIN));
-                    bodyArea.setFont(list.getFont().deriveFont(Font.PLAIN));
-                    bodyArea.setText(rawText);
-                    installBubbleWidth(wrapPx);
-                    add(bubble, BorderLayout.EAST);
-                } else {
-                    bubble.setBackground(list.getBackground());
-                    headerArea.setBackground(bubble.getBackground());
-                    bodyArea.setBackground(bubble.getBackground());
-                    headerArea.setForeground(new Color(220, 220, 220));
-                    bodyArea.setForeground(new Color(220, 220, 220));
-                    headerArea.setText(header);
-                    headerArea.setFont(list.getFont().deriveFont(Font.PLAIN));
-                    bodyArea.setFont(list.getFont().deriveFont(Font.PLAIN));
-                    bodyArea.setText(rawText);
-                    installBubbleWidth(wrapPx);
-                    add(bubble, BorderLayout.WEST);
-                }
-
-                // Fix E3: accessible name for screen readers. Truncate long bodies so the
+                // Accessible name for screen readers. Truncate long bodies so the
                 // announcement stays manageable. Suffix "(unread)" when the message is past
                 // the per-cell read snapshot so a sweep through the list announces boundaries.
                 boolean isUnreadMsg = msg.getSequenceNumber() > displayedLastReadSeq;
                 String suffix = isUnreadMsg ? " (unread)" : "";
-                String shortBody = rawText.length() > 80 ? rawText.substring(0, 77) + "…" : rawText;
+                String shortBody = row.body.length() > 80 ? row.body.substring(0, 77) + "…" : row.body;
                 getAccessibleContext().setAccessibleName(
-                        senderName + " at " + ts + ", " + shortBody + suffix);
+                        row.senderName + " at " + row.timestamp + ", " + shortBody + suffix);
 
                 return this;
+            }
+
+            private void configureBubble(boolean isOwn, String header, String rawText,
+                                         int wrapPx, Font listFont, Color listBg) {
+                Color bg = isOwn ? Theme.OWN_BUBBLE_BG : listBg;
+                Color fg = isOwn ? Theme.TEXT_ON_OWN_BUBBLE : Theme.TEXT_PRIMARY;
+                bubble.setBackground(bg);
+                headerArea.setBackground(bg);
+                bodyArea.setBackground(bg);
+                headerArea.setForeground(fg);
+                bodyArea.setForeground(fg);
+                headerArea.setText(header);
+                headerArea.setFont(listFont.deriveFont(Font.PLAIN));
+                bodyArea.setFont(listFont.deriveFont(Font.PLAIN));
+                bodyArea.setText(rawText);
+                installBubbleWidth(wrapPx);
+                add(bubble, isOwn ? BorderLayout.EAST : BorderLayout.WEST);
             }
 
             private void installBubbleWidth(int wrapPx) {
@@ -1075,13 +1132,12 @@ public class ClientUI {
         }
 
         ConversationView() {
-        	participantsLabel = new JLabel();
+            participantsLabel = new JLabel();
             addButton = new JButton("Add");
             leaveButton = new JButton("Leave");
             text = new JTextField(15);
             text.setEnabled(false);
             sendButton = new JButton("Send");
-            // Fix 10: gate buttons — disabled until a conversation is selected
             addButton.setEnabled(false);
             leaveButton.setEnabled(false);
             sendButton.setEnabled(false);
@@ -1089,7 +1145,6 @@ public class ClientUI {
             setLayout(new BorderLayout());
             setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
-            // conversation info is located on the upper side of the window
             JPanel infoPane = new JPanel(new GridBagLayout());
             GridBagConstraints gridConst = new GridBagConstraints();
             gridConst.insets = new Insets(5, 5, 5, 5);
@@ -1107,11 +1162,10 @@ public class ClientUI {
 
             add(infoPane, BorderLayout.NORTH);
 
-            // Fix 6: install the reusable cell renderer
             list.setCellRenderer(new MessageCellRenderer());
 
-            // Fix #183/#196: re-invalidate cached row heights whenever either the list or
-            // its viewport changes size so wrap width updates with window resizing.
+            // Re-invalidate cached row heights whenever either the list or its viewport
+            // changes size so wrap width updates with window resizing.
             ComponentAdapter wrapResizeAdapter = new ComponentAdapter() {
                 @Override public void componentResized(ComponentEvent e) {
                     list.setFixedCellHeight(10);
@@ -1122,13 +1176,13 @@ public class ClientUI {
             };
             list.addComponentListener(wrapResizeAdapter);
 
-            // Fix 8: create a layered center panel with the placeholder on top when no conversation
+            // Layered center panel: placeholder shows when no conversation is selected.
             JPanel centerPanel = new JPanel(new BorderLayout());
             messageScrollPane = new JScrollPane(list);
             messageScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
             messageScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
             messageScrollPane.getViewport().addComponentListener(wrapResizeAdapter);
-            // Fix E1: track whether the user is parked at the bottom of the message list.
+            // Track whether the user is parked at the bottom of the message list.
             // When they scroll up to read history, suppress the read-advance and per-message
             // snapshot slide so the unread cue persists. Drain the deferred-read buffer on
             // the up→bottom transition so the catch-up wire request fires once.
@@ -1147,7 +1201,6 @@ public class ClientUI {
             centerPanel.add(placeholderLabel, BorderLayout.SOUTH);
             add(centerPanel, BorderLayout.CENTER);
 
-            // sendPane is located on the bottom of the window
             JLabel charCountLabel = new JLabel("0/500");
             charCountLabel.setBorder(BorderFactory.createEmptyBorder(0, 4, 0, 4));
             JPanel sendPane = new JPanel(new BorderLayout());
@@ -1160,21 +1213,16 @@ public class ClientUI {
 
             add(sendPane, BorderLayout.SOUTH);
 
-            // add action to add button
             addButton.addActionListener(e -> {
 
-            	if (addDialog != null && addDialog.isVisible()) {
-            		addDialog.toFront();
-            		addDialog.requestFocus();
-                    return;
-                }
+                if (focusExistingDialog(addDialog)) return;
 
                 addUserWindow = new SelectUserWindow(
                     users -> controller.addToConversation(users, controller.getCurrentConversationId()));
 
                 addDialog = new JDialog(frame, "Select User", false);
                 addDialog.add(addUserWindow);
-                addDialog.setSize(300, 400);
+                addDialog.setSize(SELECT_USER_DIALOG_SIZE);
                 addDialog.setLocationRelativeTo(frame);
                 addDialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
                 bindEscapeToDispose(addDialog);
@@ -1184,7 +1232,7 @@ public class ClientUI {
                     public void windowClosed(WindowEvent e) {
                         addDialog = null;
                     }
-                    // #149: focus the list on open so Tab order is correct and Delete works.
+                    // Focus the list on open so Tab order is correct and Delete works.
                     @Override
                     public void windowOpened(WindowEvent e) {
                         addUserWindow.list.requestFocusInWindow();
@@ -1193,20 +1241,17 @@ public class ClientUI {
 
                 // Single-user picker fix: clear directory selection so the first click
                 // always emits a fresh ListSelectionEvent (see createConversationButton).
-                cards.main.directoryView.list.clearSelection();
-                cards.main.directoryView.selecting = null;
+                cards.main.directoryView.clearSelecting();
 
                 addDialog.setVisible(true);
 
             });
 
-            // add action to leave button
             leaveButton.addActionListener(e -> {
-            	// Fix 4: use frame as parent instead of null
-            	int result = JOptionPane.showConfirmDialog(frame, "Are you sure to leave this conversation?", "Confirm to Leave", JOptionPane.YES_NO_OPTION);
-            	if(result == JOptionPane.YES_OPTION) {
-            		controller.leaveConversation(controller.getCurrentConversationId());
-            	}
+                int result = JOptionPane.showConfirmDialog(frame, "Are you sure to leave this conversation?", "Confirm to Leave", JOptionPane.YES_NO_OPTION);
+                if(result == JOptionPane.YES_OPTION) {
+                    controller.leaveConversation(controller.getCurrentConversationId());
+                }
             });
 
             // 500-char hard cap
@@ -1233,7 +1278,6 @@ public class ClientUI {
                         }
                     });
 
-            // add action to text field (detecting if there is a text)
             text.getDocument().addDocumentListener(new DocumentListener() {
 
                 private void update() {
@@ -1259,7 +1303,6 @@ public class ClientUI {
                 }
             });
 
-            // add action to send button
             sendButton.addActionListener(e -> doSend());
 
             text.addActionListener(e -> doSend());
@@ -1296,7 +1339,7 @@ public class ClientUI {
         }
 
         private void setListModel(Conversation currConv, long lastReadAtOpen, ArrayList<Message> msgs) {
-            // Fix 3: exclude self, show up to 3 names, append "+N more" if needed
+            // Exclude self; show up to 3 names, then append "+N more".
             UserInfo me = controller.getCurrentUserInfo();
             String myId = (me != null) ? me.getUserId() : null;
             ArrayList<UserInfo> others = new ArrayList<>();
@@ -1316,16 +1359,16 @@ public class ClientUI {
             }
             final String finalMember = memberSb.toString();
             final long finalLastReadAtOpen = lastReadAtOpen;
-        	SwingUtilities.invokeLater(() -> {
+            SwingUtilities.invokeLater(() -> {
                 displayedLastReadSeq = finalLastReadAtOpen;
-                // Fix E1: opening a conversation auto-scrolls to bottom (see scrollToBottom
+                // Opening a conversation auto-scrolls to bottom (see scrollToBottom
                 // below), so the user is parked at the bottom by definition. Reset the
                 // tracker so a stale "scrolled up" state from a previous conversation
                 // doesn't suppress the read-advance for the freshly-opened one.
                 userIsAtBottom = true;
-        		participantsLabel.setText(finalMember);
+                participantsLabel.setText(finalMember);
                 conversationMessageListModel.clear();
-                // Fix C: insert the "New messages" divider between read and unread.
+                // Insert the "New messages" divider between read and unread.
                 // Suppress when finalLastReadAtOpen == 0 (nothing has ever been read; a
                 // divider above message 1 is meaningless).
                 boolean dividerInserted = false;
@@ -1342,38 +1385,33 @@ public class ClientUI {
                 modelHasDivider = dividerInserted;
                 refreshWrapLayout();
                 text.setEnabled(true);
-                // Fix 10: enable buttons when a conversation is selected
                 addButton.setEnabled(true);
                 leaveButton.setEnabled(true);
                 sendButton.setEnabled(!text.getText().trim().isEmpty());
-                // Fix 8: hide placeholder once a conversation is loaded
                 placeholderLabel.setVisible(false);
-                // Fix 9: auto-scroll to newest message after loading
                 SwingUtilities.invokeLater(() -> {
                     int last = list.getModel().getSize() - 1;
                     if (last >= 0) list.ensureIndexIsVisible(last);
                     scrollToBottom();
                     refreshWrapLayout();
                 });
-        	});
+            });
         }
 
         /** Clears the view and disables action buttons (no conversation active). */
         public void clearConversation() {
             SwingUtilities.invokeLater(() -> {
                 displayedLastReadSeq = 0L;
-                // Fix E1: model is cleared so no divider remains; reset bottom tracker.
+                // Model is cleared so no divider remains; reset bottom tracker.
                 modelHasDivider = false;
                 userIsAtBottom = true;
                 participantsLabel.setText("");
                 conversationMessageListModel.clear();
                 refreshWrapLayout();
                 text.setEnabled(false);
-                // Fix 10: disable buttons when no conversation is active
                 addButton.setEnabled(false);
                 leaveButton.setEnabled(false);
                 sendButton.setEnabled(false);
-                // Fix 8: show placeholder again
                 placeholderLabel.setVisible(true);
             });
         }
@@ -1387,11 +1425,16 @@ public class ClientUI {
         }
 
         public DefaultListModel<Object> getListModel() {
-        	return this.conversationMessageListModel;
+            return this.conversationMessageListModel;
+        }
+
+        /** Hands keyboard focus to the message input. */
+        void focusInput() {
+            text.requestFocusInWindow();
         }
 
         public boolean isAddingUser() {
-        	return addDialog != null && addDialog.isVisible();
+            return isDialogShowing(addDialog);
         }
 
         public void markDisplayedReadUpTo(long sequenceNumber) {
@@ -1451,11 +1494,10 @@ public class ClientUI {
     class DirectoryView extends JPanel {
         JLabel profileUserIdLabel;
         JLabel profileNameLabel;
-        // Fix 5: banner shown when directory is in picker mode
         JLabel pickerBannerLabel;
         JTextField searchField;
         DefaultListModel<UserInfo> listModel = new DefaultListModel<>();
-        JList<UserInfo> list = new JList<>(listModel);
+        final JList<UserInfo> list = new JList<>(listModel);
         JButton logoutButton;
         JButton createConversationButton;
         JButton adminButton;
@@ -1466,23 +1508,29 @@ public class ClientUI {
         AdminConversationSearchWindow adminConversationSearchWindow;
 
         DirectoryView() {
-        	profileUserIdLabel = new JLabel();
-        	profileNameLabel = new JLabel();
+            buildLayout();
+            wireSearchField();
+            wireLogoutButton();
+            wireCreateConversationButton();
+            wireAdminButton();
+            wireListSelectionListener();
+        }
 
-            // Fix 5: picker mode banner — hidden by default
+        private void buildLayout() {
+            profileUserIdLabel = new JLabel();
+            profileNameLabel = new JLabel();
+
             pickerBannerLabel = new JLabel("Selecting participants — click to add", SwingConstants.CENTER);
-            pickerBannerLabel.setForeground(new Color(0, 100, 180));
+            pickerBannerLabel.setForeground(Theme.BANNER_FG);
             pickerBannerLabel.setFont(pickerBannerLabel.getFont().deriveFont(Font.BOLD));
             pickerBannerLabel.setVisible(false);
 
             searchField = makePlaceholderField("Search users...", 15);
             logoutButton = new JButton("Log Out");
             createConversationButton = new JButton("Create Conversation");
-            // gray-out until select the user
             createConversationButton.setEnabled(false);
 
-            // construct admin button unconditionally and enable later if the user is admin
-            // #127: tooltip explains the prerequisite (a user must be selected). Label kept
+            // Tooltip explains the prerequisite (a user must be selected). Label kept
             // as "Admin" per the silent-viewer feature; the dialog itself shows what the
             // admin is doing.
             adminButton = new JButton("Admin");
@@ -1493,48 +1541,35 @@ public class ClientUI {
             setLayout(new BorderLayout());
             setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
-            // userPanel is located upper side of the window
             JPanel userPane = new JPanel(new GridBagLayout());
             GridBagConstraints gridConst = new GridBagConstraints();
             gridConst.insets = new Insets(5, 5, 5, 5);
             gridConst.fill = GridBagConstraints.HORIZONTAL;
 
-
-            gridConst.gridx = 0;
-            gridConst.gridy = 0;
+            gridConst.gridx = 0; gridConst.gridy = 0;
             userPane.add(profileUserIdLabel, gridConst);
-
             gridConst.gridy = 1;
             userPane.add(profileNameLabel, gridConst);
-
             gridConst.gridy = 2;
             userPane.add(searchField, gridConst);
-
-            gridConst.gridx = 1;
-            gridConst.gridy = 0;
-            gridConst.gridheight = 2;
+            gridConst.gridx = 1; gridConst.gridy = 0; gridConst.gridheight = 2;
             userPane.add(logoutButton, gridConst);
 
-            // Fix 5: wrap userPane and pickerBannerLabel in a combined north panel
             JPanel northPanel = new JPanel(new BorderLayout());
             northPanel.add(userPane, BorderLayout.NORTH);
             northPanel.add(pickerBannerLabel, BorderLayout.SOUTH);
             add(northPanel, BorderLayout.NORTH);
 
-
-            // list is located center of the window with JScrollPane
             list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
             add(new JScrollPane(list), BorderLayout.CENTER);
 
-
-            // buttonPane is located at the bottom side of the window
             JPanel buttonPane = new JPanel(new FlowLayout());
             buttonPane.add(createConversationButton);
             buttonPane.add(adminButton);
-
             add(buttonPane, BorderLayout.SOUTH);
+        }
 
-            // add action for searchField
+        private void wireSearchField() {
             searchField.getDocument().addDocumentListener(new DocumentListener() {
                 @Override public void insertUpdate(DocumentEvent e) { filter(); }
                 @Override public void removeUpdate(DocumentEvent e) { filter(); }
@@ -1543,7 +1578,7 @@ public class ClientUI {
                 private void filter() {
                     String text = searchField.getText().toUpperCase();
                     listModel.clear();
-                    // Fix 6: exclude the logged-in user from the directory list
+                    // Exclude the logged-in user from the directory list.
                     UserInfo me = controller.getCurrentUserInfo();
                     String myId = (me != null) ? me.getUserId() : null;
                     for(UserInfo item: controller.getFilteredDirectory(text)) {
@@ -1553,30 +1588,25 @@ public class ClientUI {
                     }
                 }
             });
+        }
 
-            // add action to the log in button
-            logoutButton.addActionListener(e -> {
-            	controller.logout();
-            });
+        private void wireLogoutButton() {
+            logoutButton.addActionListener(e -> controller.logout());
+        }
 
-            // add action to the create conversation button
+        private void wireCreateConversationButton() {
             createConversationButton.addActionListener(e -> {
-            	// if createDialog is open
-            	if (createDialog != null && createDialog.isVisible()) {
-                    createDialog.toFront();
-                    createDialog.requestFocus();
-                    return;
-                }
+                if (focusExistingDialog(createDialog)) return;
 
-            	createConversationUserWindow = new SelectUserWindow(users -> controller.createConversation(users));
-                // Issue #192: seed the picker with the current directory selection
-                // so the first selection is honored without requiring reselection.
+                createConversationUserWindow = new SelectUserWindow(users -> controller.createConversation(users));
+                // Seed the picker with the current directory selection so the
+                // first selection is honored without requiring reselection.
                 if (selecting != null) {
                     createConversationUserWindow.addUser(selecting);
                 }
                 createDialog = new JDialog(frame, "Select User", false);
                 createDialog.add(createConversationUserWindow);
-                createDialog.setSize(300, 400);
+                createDialog.setSize(SELECT_USER_DIALOG_SIZE);
                 createDialog.setLocationRelativeTo(frame);
                 createDialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
                 bindEscapeToDispose(createDialog);
@@ -1586,7 +1616,7 @@ public class ClientUI {
                     public void windowClosed(WindowEvent e) {
                         createDialog = null;
                     }
-                    // #149: focus the list on open so Tab order is correct and Delete works.
+                    // Focus the list on open so Tab order is correct and Delete works.
                     @Override
                     public void windowOpened(WindowEvent e) {
                         createConversationUserWindow.list.requestFocusInWindow();
@@ -1601,25 +1631,21 @@ public class ClientUI {
                 selecting = null;
 
                 createDialog.setVisible(true);
-
             });
+        }
 
-            // add action to admin button
+        private void wireAdminButton() {
             adminButton.addActionListener(e -> {
-            	if (adminDialog != null && adminDialog.isVisible()) {
-            		adminDialog.toFront();
-            		adminDialog.requestFocus();
-                    return;
-                }
+                if (focusExistingDialog(adminDialog)) return;
 
-                if(selecting == null) {
+                if (selecting == null) {
                     return;
                 }
-            	controller.adminGetUserConversations(selecting.getUserId());
-            	adminConversationSearchWindow= new AdminConversationSearchWindow();
+                controller.adminGetUserConversations(selecting.getUserId());
+                adminConversationSearchWindow = new AdminConversationSearchWindow();
                 adminDialog = new JDialog(frame, "Searching Conversations", false);
                 adminDialog.add(adminConversationSearchWindow);
-                adminDialog.setSize(900, 600);
+                adminDialog.setSize(ADMIN_SEARCH_DIALOG_SIZE);
                 adminDialog.setLocationRelativeTo(frame);
                 adminDialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
                 bindEscapeToDispose(adminDialog);
@@ -1627,22 +1653,22 @@ public class ClientUI {
                 adminDialog.addWindowListener(new WindowAdapter() {
                     @Override
                     public void windowClosed(WindowEvent e) {
-                    	// #128: clear all admin-dialog state so reopening shows a fresh empty list.
-                    	// Do NOT disable adminButton here — the directory selection listener
-                    	// owns its enable/disable state, and disabling on close traps the
-                    	// button in a dead state when the same user is still selected (the
-                    	// listener only fires on selection-change events).
-                    	adminDialog = null;
-                    	adminConversationSearchWindow = null;
-                    	controller.clearAdminConversationSearch();
+                        // Clear all admin-dialog state so reopening shows a fresh empty list.
+                        // Do NOT disable adminButton here — the directory selection listener
+                        // owns its enable/disable state, and disabling on close traps the
+                        // button in a dead state when the same user is still selected (the
+                        // listener only fires on selection-change events).
+                        adminDialog = null;
+                        adminConversationSearchWindow = null;
+                        controller.clearAdminConversationSearch();
                     }
                 });
 
                 adminDialog.setVisible(true);
-
             });
+        }
 
-            // add action for selecting an item from the list
+        private void wireListSelectionListener() {
             list.getSelectionModel().addListSelectionListener(e -> {
                 UserInfo selectedValue = list.getSelectedValue();
                 if (e.getValueIsAdjusting()) {
@@ -1650,49 +1676,49 @@ public class ClientUI {
                 }
                 selecting = selectedValue;
 
-                // Fix 5: show picker banner when a dialog is open (picker mode active)
-                boolean inPickerMode = (createDialog != null && createDialog.isVisible())
-                        || (cards.main.conversationView.addDialog != null && cards.main.conversationView.addDialog.isVisible());
+                JDialog addDialog = cards.main.conversationView.addDialog;
+                boolean inPickerMode = isDialogShowing(createDialog) || isDialogShowing(addDialog);
                 pickerBannerLabel.setVisible(inPickerMode);
 
-                // if the another window is not visible, shows the button
-                if(selecting != null && (createDialog == null || !createDialog.isVisible()) && (adminDialog == null || !adminDialog.isVisible())
-                        && (cards.main.conversationView.addDialog == null || !cards.main.conversationView.addDialog.isVisible())) {
+                if (selecting != null && !isDialogShowing(createDialog) && !isDialogShowing(adminDialog) && !isDialogShowing(addDialog)) {
                     createConversationButton.setEnabled(true);
-                    // adminButton is always constructed; visibility is toggled at login time
                     adminButton.setEnabled(true);
-                } else if(createDialog != null && createDialog.isVisible()) { // if selectUser window is open
+                } else if (isDialogShowing(createDialog)) {
                     createConversationUserWindow.addUser(selecting);
-                } else if(cards.main.conversationView.addDialog != null && cards.main.conversationView.addDialog.isVisible()) {
-                    if(selecting != null) cards.main.conversationView.addUserWindow.addUser(selecting);
+                } else if (isDialogShowing(addDialog)) {
+                    if (selecting != null) cards.main.conversationView.addUserWindow.addUser(selecting);
                 }
             });
-
         }
 
-        // Fix 1: setListModel now also calls list.setModel() so the JList reflects the new model
         public void setListModel(DefaultListModel<UserInfo> model) {
-        	this.listModel = model;
-        	list.setModel(model);
+            this.listModel = model;
+            list.setModel(model);
         }
 
         public DefaultListModel<UserInfo> getListModel() {
-        	return this.listModel;
+            return this.listModel;
         }
 
         public boolean isCreatingConversation() {
-            return createDialog != null && createDialog.isVisible();
+            return isDialogShowing(createDialog);
         }
 
         public boolean isAdminSearching() {
-            return adminDialog != null && adminDialog.isVisible();
+            return isDialogShowing(adminDialog);
         }
 
         public DefaultListModel<ConversationMetadata> getAdminConversationModel() {
             if(adminConversationSearchWindow == null) {
                 return new DefaultListModel<>();
             }
-        	return adminConversationSearchWindow.getAdminConversationSearch();
+            return adminConversationSearchWindow.getAdminConversationSearch();
+        }
+
+        /** Drops the selected directory user without firing the selection listener side effects. */
+        void clearSelecting() {
+            list.clearSelection();
+            selecting = null;
         }
 
 
@@ -1702,11 +1728,21 @@ public class ClientUI {
     class ConversationListView extends JPanel {
         JTextField searchField;
         DefaultListModel<Conversation> listModel = new DefaultListModel<>();
-        JList<Conversation>	list = new JList<>(listModel);
-        boolean suppressSelectionEvents = false;
+        final JList<Conversation> list = new JList<>(listModel);
+        // Suppresses the selection listener while an external rebuild restores selection.
+        // Don't toggle this directly — go through withSuppressedSelection(...).
+        private boolean suppressSelectionEvents = false;
 
-        // Fix 2 / Fix D: custom renderer that shows the conversation display name plus a
-        // numeric unread badge on the right when there are unread messages.
+        /** Runs {@code body} with the selection listener silenced; restores the flag in
+         *  a finally so an exception in {@code body} can't leave the listener wedged. */
+        void withSuppressedSelection(Runnable body) {
+            suppressSelectionEvents = true;
+            try { body.run(); }
+            finally { suppressSelectionEvents = false; }
+        }
+
+        // Renders a conversation row as the display name plus a numeric
+        // unread badge on the right when there are unread messages.
         private final class ConversationCellRenderer extends JPanel implements ListCellRenderer<Conversation> {
             private final JLabel nameLabel = new JLabel();
             private final JLabel badgeLabel = new JLabel();
@@ -1717,7 +1753,7 @@ public class ClientUI {
                 setOpaque(true);
 
                 Color badgeBg = UIManager.getColor("nimbusRed");
-                if (badgeBg == null) badgeBg = new Color(169, 46, 34);
+                if (badgeBg == null) badgeBg = Theme.NIMBUS_RED;
                 badgeLabel.setOpaque(true);
                 badgeLabel.setBackground(badgeBg);
                 badgeLabel.setForeground(Color.WHITE);
@@ -1784,21 +1820,24 @@ public class ClientUI {
         }
 
         ConversationListView() {
-        	searchField = makePlaceholderField("Search conversations...", 15);
+            buildLayout();
+            wireSearchField();
+            wireListSelectionListener();
+        }
 
+        private void buildLayout() {
+            searchField = makePlaceholderField("Search conversations...", 15);
 
-            // searchField is located on the upper of the window.
             setLayout(new BorderLayout());
             setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
             add(searchField, BorderLayout.NORTH);
 
-            // Fix 2: install the custom cell renderer
             list.setCellRenderer(new ConversationCellRenderer());
 
-            // list is located on the middle of the window.
             add(new JScrollPane(list), BorderLayout.CENTER);
+        }
 
-            // add action for searchField
+        private void wireSearchField() {
             searchField.getDocument().addDocumentListener(new DocumentListener() {
                 @Override public void insertUpdate(DocumentEvent e) { filter(); }
                 @Override public void removeUpdate(DocumentEvent e) { filter(); }
@@ -1807,57 +1846,53 @@ public class ClientUI {
                 private void filter() {
                     String text = searchField.getText().toUpperCase();
                     listModel.clear();
-
-                    for(Conversation item: controller.getFilteredConversationList(text)) {
-                    	listModel.addElement(item);
+                    for (Conversation item : controller.getFilteredConversationList(text)) {
+                        listModel.addElement(item);
                     }
                 }
             });
+        }
 
-            // TODO: label the conversation
-            // add action for selecting an item from the list
-            list.addListSelectionListener(e-> {
+        private void wireListSelectionListener() {
+            list.addListSelectionListener(e -> {
                 if (suppressSelectionEvents) {
                     return;
                 }
-            	if (!e.getValueIsAdjusting()) {
-    				if(list.getSelectedValue() != null) {
-    					Conversation selected = list.getSelectedValue();
-    					// Atomic open: capture (lastRead, messages) and publish currentConversationId
-    					// under one lock so a concurrent inbound can't advance lastRead past the
-    					// new message between snapshot and divider check.
-    					ClientController.ConversationOpenSnapshot snap =
-    					        controller.openConversationAtomically(selected.getConversationId());
-    					if (snap == null) return; // logged out / unknown conv (shouldn't happen here)
-    					// delegates to ConversationView.setListModel so both the
-    					// participant label and the message list are updated together
-    					if (!snap.messages.isEmpty()) {
-    					    Message last = snap.messages.get(snap.messages.size() - 1);
-    					    controller.getCurrentUserInfo().setLastRead(
-    					            selected.getConversationId(), last.getSequenceNumber());
-    					    controller.updateReadMessages(selected.getConversationId(), last.getSequenceNumber());
-    					}
-    					cards.main.conversationView.setListModel(snap);
-    				}
-            	}
+                if (!e.getValueIsAdjusting()) {
+                    if (list.getSelectedValue() != null) {
+                        Conversation selected = list.getSelectedValue();
+                        // Atomic open: capture (lastRead, messages) and publish currentConversationId
+                        // under one lock so a concurrent inbound can't advance lastRead past the
+                        // new message between snapshot and divider check.
+                        ClientController.ConversationOpenSnapshot snap =
+                                controller.openConversationAtomically(selected.getConversationId());
+                        if (snap == null) return;
+                        if (!snap.messages.isEmpty()) {
+                            Message last = snap.messages.get(snap.messages.size() - 1);
+                            controller.getCurrentUserInfo().setLastRead(
+                                    selected.getConversationId(), last.getSequenceNumber());
+                            controller.updateReadMessages(selected.getConversationId(), last.getSequenceNumber());
+                        }
+                        cards.main.conversationView.setListModel(snap);
+                    }
+                }
             });
         }
 
-        // Fix 1: setListModel now also calls list.setModel() so the JList reflects the new model
         public void setListModel(DefaultListModel<Conversation> model) {
-        	this.listModel = model;
-        	list.setModel(model);
+            this.listModel = model;
+            list.setModel(model);
         }
 
         public DefaultListModel<Conversation> getListModel() {
-        	return this.listModel;
+            return this.listModel;
         }
     }
 
     // =========================================================================
     class SelectUserWindow extends JPanel {
-        DefaultListModel<UserInfo> model = new DefaultListModel<>();
-        JList<UserInfo> list = new JList<>(model);
+        final DefaultListModel<UserInfo> model = new DefaultListModel<>();
+        final JList<UserInfo> list = new JList<>(model);
         JButton removeButton;
         JButton okButton;
         JButton cancelButton;
@@ -1865,37 +1900,43 @@ public class ClientUI {
 
         SelectUserWindow(java.util.function.Consumer<ArrayList<UserInfo>> onConfirm) {
             this.onConfirm = onConfirm;
+            buildLayout();
+            wireRemoveButton();
+            wireConfirmButton();
+            wireCancelButton();
+            wireListSelectionListener();
+            installDeleteKeyShortcut();
+        }
+
+        private void buildLayout() {
             removeButton = new JButton("Remove");
             removeButton.setEnabled(false);
             okButton = new JButton("OK");
             cancelButton = new JButton("Cancel");
 
-            // List located on the middle of the window
             setLayout(new BorderLayout());
             setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
             add(new JScrollPane(list), BorderLayout.CENTER);
 
-            // buttons are located on the bottom of the window
-        	JPanel buttonPane = new JPanel(new FlowLayout());
-        	buttonPane.add(removeButton);
-        	buttonPane.add(okButton);
-        	buttonPane.add(cancelButton);
+            JPanel buttonPane = new JPanel(new FlowLayout());
+            buttonPane.add(removeButton);
+            buttonPane.add(okButton);
+            buttonPane.add(cancelButton);
+            add(buttonPane, BorderLayout.SOUTH);
+        }
 
-        	add(buttonPane, BorderLayout.SOUTH);
+        private void wireRemoveButton() {
+            removeButton.addActionListener(e -> {
+                UserInfo selected = list.getSelectedValue();
+                if (selected != null) {
+                    model.removeElement(selected);
+                }
+            });
+        }
 
-        	// add action to Remove button
-        	removeButton.addActionListener(e -> {
-
-        	    UserInfo selected = list.getSelectedValue();
-
-        	    if (selected != null) {
-        	        model.removeElement(selected);
-        	    }
-        	});
-
-        	// add action to OK button
+        private void wireConfirmButton() {
             okButton.addActionListener(e -> {
-                // Fix 7: warn and do not proceed if no participants are selected
+                // Warn and do not proceed if no participants are selected.
                 if (model.isEmpty()) {
                     JOptionPane.showMessageDialog(frame, "Please select at least one participant.",
                             "No participants selected", JOptionPane.WARNING_MESSAGE);
@@ -1907,25 +1948,27 @@ public class ClientUI {
                 Window window = SwingUtilities.getWindowAncestor(this);
                 window.dispose();
             });
+        }
 
-            // add action to cancel button
+        private void wireCancelButton() {
             cancelButton.addActionListener(e -> {
-            	model.clear();
+                model.clear();
                 Window window = SwingUtilities.getWindowAncestor(this);
                 window.dispose();
             });
+        }
 
-
-            // add action for selecting an item from the list
-            list.addListSelectionListener(e-> {
-            	if (!e.getValueIsAdjusting()) {
-						 UserInfo selecting = list.getSelectedValue();
-						 // if the another window is not visible, shows the button
-						 removeButton.setEnabled(selecting != null);
-			    }
+        private void wireListSelectionListener() {
+            list.addListSelectionListener(e -> {
+                if (!e.getValueIsAdjusting()) {
+                    UserInfo selecting = list.getSelectedValue();
+                    removeButton.setEnabled(selecting != null);
+                }
             });
+        }
 
-            // #149: Delete key on the list invokes Remove (so the button is reachable by keyboard).
+        private void installDeleteKeyShortcut() {
+            // Delete key on the list invokes Remove (so the button is reachable by keyboard).
             list.getInputMap(JComponent.WHEN_FOCUSED)
                     .put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), "removeSelected");
             list.getInputMap(JComponent.WHEN_FOCUSED)
@@ -1937,14 +1980,13 @@ public class ClientUI {
             });
         }
 
-        // add user to selecting list
         public void addUser(UserInfo user) {
-        	for(int i = 0; i < model.size(); i++) {
-        		if(user.getUserId().equals(model.get(i).getUserId())){
-        			return;
-        		}
-        	}
-        	model.addElement(user);
+            for(int i = 0; i < model.size(); i++) {
+                if(user.getUserId().equals(model.get(i).getUserId())){
+                    return;
+                }
+            }
+            model.addElement(user);
         }
 
 
@@ -1953,12 +1995,12 @@ public class ClientUI {
     // =========================================================================
     class AdminConversationSearchWindow extends JPanel {
         JTextField searchField;
-        DefaultListModel<ConversationMetadata> model = new DefaultListModel<>();
-        JList<ConversationMetadata> list = new JList<>(model);
+        final DefaultListModel<ConversationMetadata> model = new DefaultListModel<>();
+        final JList<ConversationMetadata> list = new JList<>(model);
         JButton closeButton;
         ViewerPanel viewerPanel;
 
-        // #126: render each search result as "[ID: N] TYPE • K participant(s) • last active <ts>"
+        // Renders each search result as "[ID: N] TYPE • K participant(s) • last active <ts>"
         // (or "no messages yet"). Modeled on ConversationCellRenderer above.
         private final class AdminConversationCellRenderer extends DefaultListCellRenderer {
             @Override
@@ -1992,12 +2034,7 @@ public class ClientUI {
                     if (ts <= 0L) {
                         activity = "no messages yet";
                     } else {
-                        ZonedDateTime zdt = java.time.Instant.ofEpochMilli(ts)
-                                .atZone(ZoneId.systemDefault());
-                        DateTimeFormatter dtf = zdt.getYear() == ZonedDateTime.now().getYear()
-                                ? DateTimeFormatter.ofPattern("LLL dd, HH:mm", java.util.Locale.ENGLISH)
-                                : DateTimeFormatter.ofPattern("LLL dd yyyy, HH:mm", java.util.Locale.ENGLISH);
-                        activity = "last active " + zdt.format(dtf);
+                        activity = "last active " + formatMessageTimestamp(new java.util.Date(ts));
                     }
                     setText("[ID: " + m.getConversationId() + "]  "
                             + m.getType() + "  •  "
@@ -2022,7 +2059,7 @@ public class ClientUI {
                 setOpaque(true);
                 label.setOpaque(true);
                 label.setBorder(BorderFactory.createCompoundBorder(
-                        new LineBorder(new Color(180, 180, 180), 1, true),
+                        new LineBorder(Theme.BUBBLE_BORDER, 1, true),
                         BorderFactory.createEmptyBorder(4, 10, 4, 10)));
             }
 
@@ -2032,27 +2069,11 @@ public class ClientUI {
             public Component getListCellRendererComponent(
                     JList<? extends Message> list, Message msg, int index,
                     boolean isSelected, boolean cellHasFocus) {
-                String senderName = null;
-                if (viewedConv != null) {
-                    for (UserInfo p : viewedConv.getHistoricalParticipants()) {
-                        if (p.getUserId().equals(msg.getSenderId())) {
-                            senderName = p.getName();
-                            break;
-                        }
-                    }
-                }
-                if (senderName == null) senderName = "(former participant)";
-
-                ZonedDateTime zdt = msg.getTimestamp().toInstant().atZone(ZoneId.systemDefault());
-                DateTimeFormatter dtf = zdt.getYear() == ZonedDateTime.now().getYear()
-                        ? DateTimeFormatter.ofPattern("LLL dd, HH:mm", java.util.Locale.ENGLISH)
-                        : DateTimeFormatter.ofPattern("LLL dd yyyy, HH:mm", java.util.Locale.ENGLISH);
-                String ts = zdt.format(dtf);
-                String rawText = msg.getText() == null ? "" : msg.getText();
-                String displayText = ts + " " + senderName + ": " + rawText;
+                MessageRow row = MessageRow.forAdmin(msg, viewedConv);
+                String displayText = row.headerText + " " + row.body;
 
                 int listW = list.getWidth();
-                int wrapPx = listW > 0 ? (int) (listW * 0.70) : 360;
+                int wrapPx = listW > 0 ? (int) (listW * BUBBLE_WRAP_FRACTION) : 360;
 
                 removeAll();
                 setBackground(list.getBackground());
@@ -2140,43 +2161,49 @@ public class ClientUI {
         }
 
         AdminConversationSearchWindow() {
+            buildLayout();
+            seedFromCache();
+            wireSearchField();
+            wireListSelectionListener();
+            wireCloseButton();
+        }
+
+        private void buildLayout() {
             searchField = makePlaceholderField("Search conversations...", 15);
             closeButton = new JButton("Close");
 
             setLayout(new BorderLayout());
             setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
-            // LEFT pane — search field + conversation list
             JPanel leftPanel = new JPanel(new BorderLayout());
             leftPanel.add(searchField, BorderLayout.NORTH);
-            // #126: install the custom cell renderer so each row shows ID, type, count, recency.
             list.setCellRenderer(new AdminConversationCellRenderer());
             leftPanel.add(new JScrollPane(list), BorderLayout.CENTER);
 
-            // RIGHT pane — read-only message viewer
             viewerPanel = new ViewerPanel();
 
-            // Split-pane combines list + viewer
             JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, leftPanel, viewerPanel);
             split.setDividerLocation(320);
             split.setResizeWeight(0.0);
             add(split, BorderLayout.CENTER);
 
-            // Close at the bottom right
             JPanel buttonPane = new JPanel(new FlowLayout(FlowLayout.RIGHT));
             buttonPane.add(closeButton);
             add(buttonPane, BorderLayout.SOUTH);
+        }
 
-            // #55/#124: seed from the controller's cache. If the ADMIN_CONVERSATION_RESULT
+        private void seedFromCache() {
+            // Seed from the controller's cache. If the ADMIN_CONVERSATION_RESULT
             // response arrived before this window was constructed (race on fast loopback),
             // the data is already in the cache and we render it immediately. The async
             // updateAdminConversationSearchModel callback path stays for late responses.
             for (ConversationMetadata m : controller.getCurrentAdminConversationSearch()) {
                 model.addElement(m);
             }
+        }
 
-        	// add action to searchField
-        	searchField.getDocument().addDocumentListener(new DocumentListener() {
+        private void wireSearchField() {
+            searchField.getDocument().addDocumentListener(new DocumentListener() {
                 @Override public void insertUpdate(DocumentEvent e) { filter(); }
                 @Override public void removeUpdate(DocumentEvent e) { filter(); }
                 @Override public void changedUpdate(DocumentEvent e) { filter(); }
@@ -2184,13 +2211,14 @@ public class ClientUI {
                 private void filter() {
                     String text = searchField.getText().toUpperCase();
                     model.clear();
-
-                    for(ConversationMetadata item: controller.getFilteredAdminConversationSearch(text)) {
-                    	model.addElement(item);
+                    for (ConversationMetadata item : controller.getFilteredAdminConversationSearch(text)) {
+                        model.addElement(item);
                     }
                 }
             });
+        }
 
+        private void wireListSelectionListener() {
             // Selecting a row pulls the full conversation silently — no Join button.
             list.addListSelectionListener(e -> {
                 if (e.getValueIsAdjusting()) return;
@@ -2199,7 +2227,9 @@ public class ClientUI {
                     controller.adminViewConversation(sel.getConversationId());
                 }
             });
+        }
 
+        private void wireCloseButton() {
             // Close button just disposes the dialog; existing windowClosed handler does cleanup.
             closeButton.addActionListener(e -> {
                 Window window = SwingUtilities.getWindowAncestor(this);
@@ -2208,7 +2238,7 @@ public class ClientUI {
         }
 
         public DefaultListModel<ConversationMetadata> getAdminConversationSearch() {
-        	return model;
+            return model;
         }
 
         /** #193 entry point — called from ClientUI.showAdminConversationView. */

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -447,20 +447,6 @@ public class ClientUI {
                 Conversation selected = clv.list.getSelectedValue();
                 Long selectedId = (selected != null) ? selected.getConversationId() : null;
 
-                // Sort by highest latest sequence number descending (most recent first),
-                // which also keeps offline-received updates ordered correctly on initial paint.
-                conversations.sort((a, b) -> {
-                    ArrayList<Message> aMsgs = a.getMessages();
-                    ArrayList<Message> bMsgs = b.getMessages();
-                    long aSeq = aMsgs.isEmpty()
-                            ? a.getConversationId()
-                            : aMsgs.get(aMsgs.size() - 1).getSequenceNumber();
-                    long bSeq = bMsgs.isEmpty()
-                            ? b.getConversationId()
-                            : bMsgs.get(bMsgs.size() - 1).getSequenceNumber();
-                    return Long.compare(bSeq, aSeq);
-                });
-
                 cards.main.conversationListView.listModel.clear();
                 for (Conversation conversation : conversations) {
                     cards.main.conversationListView.listModel.addElement(conversation);

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -24,7 +24,7 @@ public class ClientUI {
     private JFrame frame;
     private ScreenCards cards;
     private DefaultListModel<UserInfo> directoryModel;
-    private DefaultListModel<Message> conversationMessageModel;
+    private DefaultListModel<Object> conversationMessageModel;
     private DefaultListModel<Conversation> conversationListModel;
     /** Fires on the EDT every 5s to compare wall clock to {@link #lastUserActivityMillis}. */
     private final Timer userIdlePollTimer;
@@ -97,12 +97,19 @@ public class ClientUI {
 
             frame.addWindowListener(new WindowAdapter() {
                 @Override public void windowActivated(WindowEvent e) {
+                    // Fix A: tell the controller the window is active and drain any
+                    // deferred read-advances that piled up while we were inactive.
+                    controller.setWindowActive(true);
+                    controller.replayReadAdvanceIfNeeded();
                     if (suppressActivationReset) {
                         suppressActivationReset = false;
                         return;
                     }
                     unreadWhileAway = 0;
                     frame.setTitle(BASE_TITLE);
+                }
+                @Override public void windowDeactivated(WindowEvent e) {
+                    controller.setWindowActive(false);
                 }
             });
 
@@ -395,7 +402,7 @@ public class ClientUI {
             // Restore selection after rebuild
             if (selectedId != null) {
                 for (int i = 0; i < conversationListModel.getSize(); i++) {
-                    if (conversationListModel.getElementAt(i).getConversationId() == selectedId) {
+                    if (conversationListModel.getElementAt(i).getConversationId() == selectedId.longValue()) {
                         convList.setSelectedIndex(i);
                         break;
                     }
@@ -435,15 +442,36 @@ public class ClientUI {
 
     public void appendMessageToConversationView(Message message) {
         SwingUtilities.invokeLater(() -> {
-            conversationMessageModel.addElement(message);
-            // Fix 9: auto-scroll to newest message
-            SwingUtilities.invokeLater(() -> {
-                int last = cards.main.conversationView.list.getModel().getSize() - 1;
-                if (last >= 0) cards.main.conversationView.list.ensureIndexIsVisible(last);
-            });
-            // Issue #176: notify user when window is not active
+            ConversationView cv = cards.main.conversationView;
+            // "Actively viewing" requires BOTH window focused AND parked at bottom; userIsAtBottom
+            // defaults to true, so checking it alone would suppress the divider in the alt-tab case.
             UserInfo me = controller.getCurrentUserInfo();
             boolean fromOther = me != null && !message.getSenderId().equals(me.getUserId());
+            boolean userActivelyViewing = frame.isActive() && cv.userIsAtBottom;
+            if (fromOther && !userActivelyViewing && !cv.modelHasDivider) {
+                conversationMessageModel.addElement(ConversationView.NewMessagesDivider.INSTANCE);
+                cv.modelHasDivider = true;
+            }
+            conversationMessageModel.addElement(message);
+            // Fix 9 + Fix E1: auto-scroll to newest only when the user is parked at the
+            // bottom. Otherwise preserve their scroll position so they can read history.
+            if (cv.userIsAtBottom) {
+                SwingUtilities.invokeLater(() -> {
+                    int last = cv.list.getModel().getSize() - 1;
+                    if (last >= 0) cv.list.ensureIndexIsVisible(last);
+                });
+            }
+            // Composed gate (Fix A + Fix E1): slide the per-message snapshot forward only
+            // when the OS window is active AND the user is parked at the bottom — i.e. they
+            // can actually see the message. Otherwise leave the snapshot frozen; the deferred
+            // read-advance buffer on the controller will replay on the next window activation
+            // or scroll-to-bottom transition, which calls back into markDisplayedReadUpTo to
+            // re-sync. Do NOT call updateReadMessages here — the controller owns that wire
+            // concern via tryAdvanceReadOnInbound.
+            if (frame.isActive() && cv.userIsAtBottom) {
+                cv.markDisplayedReadUpTo(message.getSequenceNumber());
+            }
+            // Issue #176: notify user when window is not active
             if (fromOther && !frame.isActive()) {
                 unreadWhileAway++;
                 frame.setTitle(BASE_TITLE + " (" + unreadWhileAway + " new)");
@@ -456,6 +484,28 @@ public class ClientUI {
 
     public void repaintMessageList() {
         SwingUtilities.invokeLater(() -> cards.main.conversationView.list.repaint());
+    }
+
+    /** Pass-through used by {@link ClientController#replayReadAdvanceIfNeeded()} to
+     *  re-sync the open conversation's per-message snapshot after a deferred replay. */
+    public void markDisplayedReadUpTo(long sequenceNumber) {
+        SwingUtilities.invokeLater(() ->
+                cards.main.conversationView.markDisplayedReadUpTo(sequenceNumber));
+    }
+
+    /** Fix E1: composed-gate input for {@link ClientController#tryAdvanceReadOnInbound}.
+     *  Returns true when the user is parked at (or near) the bottom of the open conversation,
+     *  i.e. they can actually see freshly-arrived messages. Read from the network reader
+     *  thread, so the underlying field is volatile. */
+    public boolean userIsViewingBottom() {
+        if (cards == null || cards.main == null || cards.main.conversationView == null) {
+            return true;
+        }
+        return cards.main.conversationView.userIsAtBottom;
+    }
+
+    public void repaintConversationList() {
+        SwingUtilities.invokeLater(() -> cards.main.conversationListView.list.repaint());
     }
 
     public void updateAdminConversationSearchModel(ArrayList<ConversationMetadata> conversations) {
@@ -803,12 +853,20 @@ public class ClientUI {
     // =========================================================================
     class ConversationView extends JPanel {
         JLabel participantsLabel;
-        DefaultListModel<Message> conversationMessageListModel = new DefaultListModel<>();
-        JList<Message> list = new JList<>(conversationMessageListModel);
+        DefaultListModel<Object> conversationMessageListModel = new DefaultListModel<>();
+        JList<Object> list = new JList<>(conversationMessageListModel);
         private JScrollPane messageScrollPane;
         // Snapshot of read state at the time this conversation view was opened/refreshed.
         // Renderer uses this instead of live lastRead updates so unread markers remain meaningful.
         private long displayedLastReadSeq = 0L;
+        // Fix E1: track whether the vertical scrollbar is at (or within 4px of) the bottom.
+        // Volatile because the network reader thread reads it via userIsViewingBottom() while the
+        // EDT mutates it in the AdjustmentListener.
+        private volatile boolean userIsAtBottom = true;
+        // Fix E1: tracks whether NewMessagesDivider.INSTANCE is currently in the list model.
+        // Set true on insert by setListModel or appendMessageToConversationView; cleared on
+        // model clear (setListModel/clearConversation). EDT-only access.
+        private boolean modelHasDivider = false;
         JButton addButton;
         JButton leaveButton;
         JTextField text;
@@ -819,11 +877,23 @@ public class ClientUI {
         // Fix 8: placeholder label shown when no conversation is selected
         private final JLabel placeholderLabel = new JLabel("Select a conversation to start chatting", SwingConstants.CENTER);
 
+        // Fix C: sentinel inserted into the message-list model to mark the boundary
+        // between messages already read at conversation-open time and unread messages
+        // that arrived since. Replaces the per-message ● dot with a single horizontal
+        // "─── New messages ───" cue.
+        private static final class NewMessagesDivider {
+            static final NewMessagesDivider INSTANCE = new NewMessagesDivider();
+            private NewMessagesDivider() {}
+        }
+
         // Fix 6/#196: use JTextArea-based bubbles for deterministic wrapping.
-        private final class MessageCellRenderer extends JPanel implements ListCellRenderer<Message> {
+        private final class MessageCellRenderer extends JPanel implements ListCellRenderer<Object> {
             private final JPanel bubble = new JPanel(new BorderLayout(0, 2));
             private final JTextArea headerArea = new JTextArea();
             private final JTextArea bodyArea = new JTextArea();
+            // Fix C: a separate component returned for NewMessagesDivider sentinels.
+            private final JPanel dividerPanel = new JPanel(new BorderLayout(6, 0));
+            private final JLabel dividerLabel = new JLabel("New messages", SwingConstants.CENTER);
 
             MessageCellRenderer() {
                 setLayout(new BorderLayout());
@@ -847,14 +917,37 @@ public class ClientUI {
                 bodyArea.setBorder(null);
                 bubble.add(headerArea, BorderLayout.NORTH);
                 bubble.add(bodyArea, BorderLayout.CENTER);
+
+                Color alert = UIManager.getColor("nimbusAlertYellow");
+                if (alert == null) alert = new Color(248, 187, 0);
+                dividerPanel.setOpaque(true);
+                dividerPanel.setBorder(BorderFactory.createEmptyBorder(2, 6, 2, 6));
+                dividerLabel.setForeground(alert);
+                dividerLabel.setFont(dividerLabel.getFont().deriveFont(Font.BOLD));
+                JSeparator left = new JSeparator(SwingConstants.HORIZONTAL);
+                JSeparator right = new JSeparator(SwingConstants.HORIZONTAL);
+                left.setForeground(alert);
+                right.setForeground(alert);
+                dividerPanel.add(left, BorderLayout.WEST);
+                dividerPanel.add(dividerLabel, BorderLayout.CENTER);
+                dividerPanel.add(right, BorderLayout.EAST);
+                dividerPanel.setPreferredSize(new Dimension(10, 22));
+                dividerPanel.getAccessibleContext().setAccessibleName("New messages divider");
             }
 
             @Override
             public Component getListCellRendererComponent(
-                    JList<? extends Message> list, Message value, int index,
+                    JList<? extends Object> list, Object value, int index,
                     boolean isSelected, boolean cellHasFocus) {
 
-                Message msg = value;
+                if (value instanceof NewMessagesDivider) {
+                    dividerPanel.setBackground(list.getBackground());
+                    // Make the embedded label transparent so the bg shows through evenly.
+                    dividerLabel.setOpaque(false);
+                    return dividerPanel;
+                }
+
+                Message msg = (Message) value;
 
                 // Resolve sender's display name.
                 // Short-circuit to own name first so own messages always render correctly
@@ -889,8 +982,6 @@ public class ClientUI {
                 boolean isOwnMessage = msg.getSenderId().equals(controller.getCurrentUserInfo().getUserId());
                 String header = isOwnMessage ? ts : (ts + " " + senderName + ":");
 
-                long lastReadSeq = displayedLastReadSeq;
-
                 // Remove prior label so we can re-add in the correct position
                 removeAll();
                 setBackground(list.getBackground());
@@ -899,7 +990,8 @@ public class ClientUI {
                 // adapt correctly when the conversation pane is resized.
                 int wrapPx = computeWrapWidthPx(list);
 
-                // displaying the current user's messages on the right side
+                // Fix C: per-message ● dot is gone — the NewMessagesDivider sentinel inserted
+                // into the model carries that signal now. Render every message plain.
                 if (isOwnMessage) {
                     bubble.setBackground(new Color(66, 95, 120));
                     headerArea.setBackground(bubble.getBackground());
@@ -912,25 +1004,28 @@ public class ClientUI {
                     bodyArea.setText(rawText);
                     installBubbleWidth(wrapPx);
                     add(bubble, BorderLayout.EAST);
-                } else { // displaying the other participants' messages on the left side
+                } else {
                     bubble.setBackground(list.getBackground());
                     headerArea.setBackground(bubble.getBackground());
                     bodyArea.setBackground(bubble.getBackground());
                     headerArea.setForeground(new Color(220, 220, 220));
                     bodyArea.setForeground(new Color(220, 220, 220));
-                    if (msg.getSequenceNumber() > lastReadSeq) {
-                        headerArea.setFont(list.getFont().deriveFont(Font.BOLD));
-                        bodyArea.setFont(list.getFont().deriveFont(Font.PLAIN));
-                        headerArea.setText("● " + header);
-                    } else {
-                        headerArea.setFont(list.getFont().deriveFont(Font.PLAIN));
-                        bodyArea.setFont(list.getFont().deriveFont(Font.PLAIN));
-                        headerArea.setText(header);
-                    }
+                    headerArea.setText(header);
+                    headerArea.setFont(list.getFont().deriveFont(Font.PLAIN));
+                    bodyArea.setFont(list.getFont().deriveFont(Font.PLAIN));
                     bodyArea.setText(rawText);
                     installBubbleWidth(wrapPx);
                     add(bubble, BorderLayout.WEST);
                 }
+
+                // Fix E3: accessible name for screen readers. Truncate long bodies so the
+                // announcement stays manageable. Suffix "(unread)" when the message is past
+                // the per-cell read snapshot so a sweep through the list announces boundaries.
+                boolean isUnreadMsg = msg.getSequenceNumber() > displayedLastReadSeq;
+                String suffix = isUnreadMsg ? " (unread)" : "";
+                String shortBody = rawText.length() > 80 ? rawText.substring(0, 77) + "…" : rawText;
+                getAccessibleContext().setAccessibleName(
+                        senderName + " at " + ts + ", " + shortBody + suffix);
 
                 return this;
             }
@@ -1033,6 +1128,20 @@ public class ClientUI {
             messageScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
             messageScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
             messageScrollPane.getViewport().addComponentListener(wrapResizeAdapter);
+            // Fix E1: track whether the user is parked at the bottom of the message list.
+            // When they scroll up to read history, suppress the read-advance and per-message
+            // snapshot slide so the unread cue persists. Drain the deferred-read buffer on
+            // the up→bottom transition so the catch-up wire request fires once.
+            messageScrollPane.getVerticalScrollBar().addAdjustmentListener(e -> {
+                JScrollBar vsb = (JScrollBar) e.getSource();
+                int max = vsb.getMaximum() - vsb.getVisibleAmount();
+                boolean newAtBottom = (vsb.getValue() >= max - 4);
+                boolean wasAtBottom = userIsAtBottom;
+                userIsAtBottom = newAtBottom;
+                if (newAtBottom && !wasAtBottom) {
+                    controller.replayReadAdvanceIfNeeded();
+                }
+            });
             centerPanel.add(messageScrollPane, BorderLayout.CENTER);
             placeholderLabel.setVisible(true);
             centerPanel.add(placeholderLabel, BorderLayout.SOUTH);
@@ -1163,6 +1272,8 @@ public class ClientUI {
             if (msg.trim().isEmpty()) return;
             controller.sendMessage(controller.getCurrentConversation().getConversationId(), msg);
             text.setText("");
+            // Sending a reply is an unambiguous read-acknowledgement.
+            removeDividerNow();
         }
 
         public void setListModel(Conversation currConv) {
@@ -1170,7 +1281,21 @@ public class ClientUI {
             setListModel(currConv, lastReadAtOpen);
         }
 
+        /**
+         * Fix E2: race-free overload. Uses the message list captured atomically with
+         * {@code lastReadAtOpen} by {@link ClientController#getConversationSnapshotForOpen(long)}
+         * so the divider boundary always matches the consistent (lastRead, messages) pair —
+         * even if {@link Conversation#append} fires between capture and render.
+         */
+        public void setListModel(ClientController.ConversationOpenSnapshot snap) {
+            setListModel(snap.conversation, snap.lastReadAtOpen, snap.messages);
+        }
+
         public void setListModel(Conversation currConv, long lastReadAtOpen) {
+            setListModel(currConv, lastReadAtOpen, currConv.getMessages());
+        }
+
+        private void setListModel(Conversation currConv, long lastReadAtOpen, ArrayList<Message> msgs) {
             // Fix 3: exclude self, show up to 3 names, append "+N more" if needed
             UserInfo me = controller.getCurrentUserInfo();
             String myId = (me != null) ? me.getUserId() : null;
@@ -1193,11 +1318,28 @@ public class ClientUI {
             final long finalLastReadAtOpen = lastReadAtOpen;
         	SwingUtilities.invokeLater(() -> {
                 displayedLastReadSeq = finalLastReadAtOpen;
+                // Fix E1: opening a conversation auto-scrolls to bottom (see scrollToBottom
+                // below), so the user is parked at the bottom by definition. Reset the
+                // tracker so a stale "scrolled up" state from a previous conversation
+                // doesn't suppress the read-advance for the freshly-opened one.
+                userIsAtBottom = true;
         		participantsLabel.setText(finalMember);
                 conversationMessageListModel.clear();
-                for(int i = 0; i < currConv.getMessages().size(); i++) {
-                    conversationMessageListModel.addElement(currConv.getMessages().get(i));
+                // Fix C: insert the "New messages" divider between read and unread.
+                // Suppress when finalLastReadAtOpen == 0 (nothing has ever been read; a
+                // divider above message 1 is meaningless).
+                boolean dividerInserted = false;
+                for (int i = 0; i < msgs.size(); i++) {
+                    Message m = msgs.get(i);
+                    if (!dividerInserted
+                            && finalLastReadAtOpen > 0L
+                            && m.getSequenceNumber() > finalLastReadAtOpen) {
+                        conversationMessageListModel.addElement(NewMessagesDivider.INSTANCE);
+                        dividerInserted = true;
+                    }
+                    conversationMessageListModel.addElement(m);
                 }
+                modelHasDivider = dividerInserted;
                 refreshWrapLayout();
                 text.setEnabled(true);
                 // Fix 10: enable buttons when a conversation is selected
@@ -1220,6 +1362,9 @@ public class ClientUI {
         public void clearConversation() {
             SwingUtilities.invokeLater(() -> {
                 displayedLastReadSeq = 0L;
+                // Fix E1: model is cleared so no divider remains; reset bottom tracker.
+                modelHasDivider = false;
+                userIsAtBottom = true;
                 participantsLabel.setText("");
                 conversationMessageListModel.clear();
                 refreshWrapLayout();
@@ -1241,7 +1386,7 @@ public class ClientUI {
             list.repaint();
         }
 
-        public DefaultListModel<Message> getListModel() {
+        public DefaultListModel<Object> getListModel() {
         	return this.conversationMessageListModel;
         }
 
@@ -1251,6 +1396,46 @@ public class ClientUI {
 
         public void markDisplayedReadUpTo(long sequenceNumber) {
             displayedLastReadSeq = Math.max(displayedLastReadSeq, sequenceNumber);
+            removeDividerIfCaughtUp();
+        }
+
+        /** Drops the divider once every message below it has been read. Without this the
+         *  {@code modelHasDivider} guard above keeps the divider pinned at first insertion. */
+        private void removeDividerIfCaughtUp() {
+            if (!modelHasDivider) return;
+            int dividerIdx = -1;
+            for (int i = 0; i < conversationMessageListModel.size(); i++) {
+                if (conversationMessageListModel.get(i) == NewMessagesDivider.INSTANCE) {
+                    dividerIdx = i;
+                    break;
+                }
+            }
+            if (dividerIdx < 0) {
+                modelHasDivider = false;
+                return;
+            }
+            for (int i = dividerIdx + 1; i < conversationMessageListModel.size(); i++) {
+                Object el = conversationMessageListModel.get(i);
+                if (el instanceof Message
+                        && ((Message) el).getSequenceNumber() > displayedLastReadSeq) {
+                    return;
+                }
+            }
+            conversationMessageListModel.remove(dividerIdx);
+            modelHasDivider = false;
+        }
+
+        /** Unconditional divider removal — for cases where the act itself (e.g. sending)
+         *  is the read-acknowledgement signal, regardless of snapshot state. */
+        private void removeDividerNow() {
+            if (!modelHasDivider) return;
+            for (int i = 0; i < conversationMessageListModel.size(); i++) {
+                if (conversationMessageListModel.get(i) == NewMessagesDivider.INSTANCE) {
+                    conversationMessageListModel.remove(i);
+                    break;
+                }
+            }
+            modelHasDivider = false;
         }
 
         private void scrollToBottom() {
@@ -1520,41 +1705,80 @@ public class ClientUI {
         JList<Conversation>	list = new JList<>(listModel);
         boolean suppressSelectionEvents = false;
 
-        // Fix 2: custom renderer that shows a friendly display name
-        private final class ConversationCellRenderer extends DefaultListCellRenderer {
+        // Fix 2 / Fix D: custom renderer that shows the conversation display name plus a
+        // numeric unread badge on the right when there are unread messages.
+        private final class ConversationCellRenderer extends JPanel implements ListCellRenderer<Conversation> {
+            private final JLabel nameLabel = new JLabel();
+            private final JLabel badgeLabel = new JLabel();
+
+            ConversationCellRenderer() {
+                setLayout(new BorderLayout(6, 0));
+                setBorder(BorderFactory.createEmptyBorder(2, 6, 2, 6));
+                setOpaque(true);
+
+                Color badgeBg = UIManager.getColor("nimbusRed");
+                if (badgeBg == null) badgeBg = new Color(169, 46, 34);
+                badgeLabel.setOpaque(true);
+                badgeLabel.setBackground(badgeBg);
+                badgeLabel.setForeground(Color.WHITE);
+                badgeLabel.setFont(badgeLabel.getFont().deriveFont(Font.BOLD));
+                badgeLabel.setBorder(BorderFactory.createEmptyBorder(1, 6, 1, 6));
+                badgeLabel.setHorizontalAlignment(SwingConstants.CENTER);
+
+                add(nameLabel, BorderLayout.CENTER);
+                add(badgeLabel, BorderLayout.EAST);
+            }
+
             @Override
             public Component getListCellRendererComponent(
-                    JList<?> list, Object value, int index,
+                    JList<? extends Conversation> list, Conversation value, int index,
                     boolean isSelected, boolean cellHasFocus) {
-                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-                if (value instanceof Conversation) {
-                    Conversation conv = (Conversation) value;
-                    UserInfo me = controller.getCurrentUserInfo();
-                    String myId = (me != null) ? me.getUserId() : null;
+                Conversation conv = value;
+                UserInfo me = controller.getCurrentUserInfo();
+                String myId = (me != null) ? me.getUserId() : null;
 
-                    // Collect other participants (excluding self)
-                    ArrayList<UserInfo> others = new ArrayList<>();
-                    for (UserInfo p : conv.getParticipants()) {
-                        if (!p.getUserId().equals(myId)) {
-                            others.add(p);
-                        }
+                ArrayList<UserInfo> others = new ArrayList<>();
+                for (UserInfo p : conv.getParticipants()) {
+                    if (!p.getUserId().equals(myId)) {
+                        others.add(p);
                     }
-
-                    String display;
-                    if (conv.getType() == shared.enums.ConversationType.PRIVATE) {
-                        String otherName = others.isEmpty() ? "(empty)" : others.get(0).getName();
-                        display = "DM: " + otherName;
-                    } else {
-                        StringBuilder sb = new StringBuilder("Group: ");
-                        for (int i = 0; i < others.size(); i++) {
-                            if (i > 0) sb.append(", ");
-                            sb.append(others.get(i).getName());
-                        }
-                        if (others.isEmpty()) sb.append("(empty)");
-                        display = sb.toString();
-                    }
-                    setText(display);
                 }
+
+                String display;
+                if (conv.getType() == shared.enums.ConversationType.PRIVATE) {
+                    String otherName = others.isEmpty() ? "(empty)" : others.get(0).getName();
+                    display = "DM: " + otherName;
+                } else {
+                    StringBuilder sb = new StringBuilder("Group: ");
+                    for (int i = 0; i < others.size(); i++) {
+                        if (i > 0) sb.append(", ");
+                        sb.append(others.get(i).getName());
+                    }
+                    if (others.isEmpty()) sb.append("(empty)");
+                    display = sb.toString();
+                }
+
+                int unread = ClientController.unreadCount(conv, me);
+                if (unread > 0) {
+                    nameLabel.setFont(list.getFont().deriveFont(Font.BOLD));
+                    badgeLabel.setText(unread > 99 ? "99+" : Integer.toString(unread));
+                    badgeLabel.setVisible(true);
+                    getAccessibleContext().setAccessibleName(display + " (" + unread + " unread)");
+                } else {
+                    nameLabel.setFont(list.getFont().deriveFont(Font.PLAIN));
+                    badgeLabel.setVisible(false);
+                    getAccessibleContext().setAccessibleName(display);
+                }
+                nameLabel.setText(display);
+
+                if (isSelected) {
+                    setBackground(list.getSelectionBackground());
+                    nameLabel.setForeground(list.getSelectionForeground());
+                } else {
+                    setBackground(list.getBackground());
+                    nameLabel.setForeground(list.getForeground());
+                }
+
                 return this;
             }
         }
@@ -1591,7 +1815,6 @@ public class ClientUI {
             });
 
             // TODO: label the conversation
-            // TODO: unread markers
             // add action for selecting an item from the list
             list.addListSelectionListener(e-> {
                 if (suppressSelectionEvents) {
@@ -1600,17 +1823,21 @@ public class ClientUI {
             	if (!e.getValueIsAdjusting()) {
     				if(list.getSelectedValue() != null) {
     					Conversation selected = list.getSelectedValue();
-    					controller.setCurrentConversationId(selected.getConversationId());
-                        long lastReadBeforeOpen = controller.getCurrentUserInfo().getLastRead(selected.getConversationId());
+    					// Atomic open: capture (lastRead, messages) and publish currentConversationId
+    					// under one lock so a concurrent inbound can't advance lastRead past the
+    					// new message between snapshot and divider check.
+    					ClientController.ConversationOpenSnapshot snap =
+    					        controller.openConversationAtomically(selected.getConversationId());
+    					if (snap == null) return; // logged out / unknown conv (shouldn't happen here)
     					// delegates to ConversationView.setListModel so both the
     					// participant label and the message list are updated together
-    					if (!selected.getMessages().isEmpty()) {
-    					    Message last = selected.getMessages().get(selected.getMessages().size() - 1);
+    					if (!snap.messages.isEmpty()) {
+    					    Message last = snap.messages.get(snap.messages.size() - 1);
     					    controller.getCurrentUserInfo().setLastRead(
     					            selected.getConversationId(), last.getSequenceNumber());
     					    controller.updateReadMessages(selected.getConversationId(), last.getSequenceNumber());
     					}
-    					cards.main.conversationView.setListModel(selected, lastReadBeforeOpen);
+    					cards.main.conversationView.setListModel(snap);
     				}
             	}
             });

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -1293,7 +1293,6 @@ public class ClientUI {
                 }
             });
 
-            // 500-char hard cap
             ((javax.swing.text.AbstractDocument) messageInputField.getDocument()).setDocumentFilter(
                     new javax.swing.text.DocumentFilter() {
                         private static final int MAX = 500;
@@ -1733,8 +1732,6 @@ public class ClientUI {
             finally { suppressSelectionEvents = false; }
         }
 
-        // Renders a conversation row as the display name plus a numeric
-        // unread badge on the right when there are unread messages.
         private final class ConversationCellRenderer extends JPanel implements ListCellRenderer<Conversation> {
             private final JLabel nameLabel = new JLabel();
             private final JLabel badgeLabel = new JLabel();
@@ -1906,7 +1903,6 @@ public class ClientUI {
 
         private void wireConfirmButton() {
             okButton.addActionListener(e -> {
-                // Warn and do not proceed if no participants are selected.
                 if (model.isEmpty()) {
                     JOptionPane.showMessageDialog(frame, "Please select at least one participant.",
                             "No participants selected", JOptionPane.WARNING_MESSAGE);

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -14,16 +14,15 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.List;
 
 public class ClientUI {
 
     private final ClientController controller;
     private JFrame frame;
     private ScreenCards cards;
-    private DefaultListModel<UserInfo> directoryModel;
-    private DefaultListModel<Object> conversationMessageModel;
-    private DefaultListModel<Conversation> conversationListModel;
     private final IdleWatcher idleWatcher;
+    private volatile ConversationView activeConversationView;
 
     private int unreadWhileAway = 0;
     private volatile boolean suppressActivationReset = false;
@@ -34,17 +33,38 @@ public class ClientUI {
     private static final Dimension ADMIN_SEARCH_DIALOG_SIZE  = new Dimension(900, 600);
     private static final double    BUBBLE_WRAP_FRACTION      = 0.70;
 
-    /** Named RGB constants for the dark-mode theme. Values are unchanged from the
-     *  original inline literals — this class only gives them readable names. */
+    private static final class Constants {
+        private Constants() {}
+        static final String NIMBUS_LAF_FQCN = "javax.swing.plaf.nimbus.NimbusLookAndFeel";
+
+        static final String CARD_LOGIN    = "login";
+        static final String CARD_REGISTER = "register";
+        static final String CARD_MAIN     = "main";
+
+        static final String DLG_SELECT_USER  = "Select User";
+        static final String DLG_ADMIN_SEARCH = "Searching Conversations";
+
+        static final String DM_PREFIX                     = "DM: ";
+        static final String GROUP_PREFIX                  = "Group: ";
+        static final String EMPTY_PARTICIPANT_PLACEHOLDER = "(empty)";
+        static final int    UNREAD_BADGE_CAP              = 99;
+        static final String UNREAD_BADGE_CAP_TEXT         = "99+";
+
+        static final int MIN_HTML_WRAP_PX           = 80;
+        static final int MIN_BUBBLE_WIDTH_PX        = 120;
+        static final int BUBBLE_INSET_PX            = 28;
+        static final int SCROLL_BOTTOM_TOLERANCE_PX = 4;
+        static final int ADMIN_SPLIT_DIVIDER_PX     = 320;
+        static final int APP_ICON_SIZE_PX           = 32;
+        static final Dimension DIVIDER_PANEL_DIM    = new Dimension(10, 22);
+    }
+
     private static final class Theme {
-        // Surfaces
         static final Color SURFACE_BG          = new Color(43, 43, 43);
         static final Color FIELD_BG            = new Color(60, 63, 65);
-        // Text
         static final Color TEXT_PRIMARY        = new Color(220, 220, 220);
         static final Color TEXT_ON_OWN_BUBBLE  = new Color(235, 235, 235);
         static final Color WHITE               = new Color(255, 255, 255);
-        // Nimbus accent palette
         static final Color NIMBUS_FOCUS         = new Color(115, 164, 209);
         static final Color NIMBUS_GREEN         = new Color(176, 179, 50);
         static final Color NIMBUS_INFO_BLUE     = new Color(66, 139, 221);
@@ -53,7 +73,6 @@ public class ClientUI {
         static final Color NIMBUS_ALERT_YELLOW  = new Color(248, 187, 0);
         static final Color NIMBUS_DISABLED_TEXT = new Color(128, 128, 128);
         static final Color NIMBUS_SELECTION_BG  = new Color(75, 110, 175);
-        // App-specific
         static final Color OWN_BUBBLE_BG = new Color(66, 95, 120);
         static final Color BUBBLE_BORDER = new Color(180, 180, 180);
         static final Color BANNER_FG     = new Color(0, 100, 180);
@@ -71,14 +90,13 @@ public class ClientUI {
             installWindowListener();
             installKeyboardShortcuts();
             idleWatcher.installAwtListener();
+            idleWatcher.start();
         });
-
-        idleWatcher.start();
     }
 
     private void applyNimbusLookAndFeel() {
         try {
-            UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+            UIManager.setLookAndFeel(Constants.NIMBUS_LAF_FQCN);
         } catch (Exception ignored) {
             // If Nimbus is unavailable, keep current LAF and continue.
         }
@@ -123,9 +141,7 @@ public class ClientUI {
         frame.setIconImage(createAppIcon());
         frame.setMinimumSize(MAIN_FRAME_MIN_SIZE);
         cards = new ScreenCards();
-        directoryModel = cards.main.directoryView.getListModel();
-        conversationMessageModel = cards.main.conversationView.getListModel();
-        conversationListModel = cards.main.conversationListView.getListModel();
+        activeConversationView = cards.main.conversationView;
         frame.add(cards);
         frame.pack();
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -136,8 +152,7 @@ public class ClientUI {
     private void installWindowListener() {
         frame.addWindowListener(new WindowAdapter() {
             @Override public void windowActivated(WindowEvent e) {
-                // Tell the controller the window is active and drain any
-                // deferred read-advances that piled up while we were inactive.
+                // drain reads deferred while window inactive
                 controller.setWindowActive(true);
                 controller.replayReadAdvanceIfNeeded();
                 if (suppressActivationReset) {
@@ -149,6 +164,10 @@ public class ClientUI {
             }
             @Override public void windowDeactivated(WindowEvent e) {
                 controller.setWindowActive(false);
+            }
+            @Override public void windowClosing(WindowEvent e) {
+                idleWatcher.stop();
+                idleWatcher.uninstallAwtListener();
             }
         });
     }
@@ -182,6 +201,7 @@ public class ClientUI {
 
         private volatile long lastActivityMillis = System.currentTimeMillis();
         private final Timer pollTimer;
+        private AWTEventListener awtActivityListener;
 
         IdleWatcher() {
             pollTimer = new Timer(POLL_MS, e -> onTick());
@@ -190,16 +210,26 @@ public class ClientUI {
 
         void start() { pollTimer.start(); }
 
+        void stop() { pollTimer.stop(); }
+
         void installAwtListener() {
+            awtActivityListener = e -> lastActivityMillis = System.currentTimeMillis();
             Toolkit.getDefaultToolkit().addAWTEventListener(
-                e -> lastActivityMillis = System.currentTimeMillis(),
+                awtActivityListener,
                 AWTEvent.KEY_EVENT_MASK | AWTEvent.MOUSE_EVENT_MASK
             );
         }
 
+        void uninstallAwtListener() {
+            if (awtActivityListener != null) {
+                Toolkit.getDefaultToolkit().removeAWTEventListener(awtActivityListener);
+                awtActivityListener = null;
+            }
+        }
+
         private void onTick() {
             long idleMs = System.currentTimeMillis() - lastActivityMillis;
-            if (LOGOUT_AFTER_MS > 0 && controller.isLoggedIn() && idleMs >= LOGOUT_AFTER_MS) {
+            if (controller.isLoggedIn() && idleMs >= LOGOUT_AFTER_MS) {
                 controller.logout();
             }
         }
@@ -209,7 +239,7 @@ public class ClientUI {
         showLoginView(null);
     }
 
-    /** #139B: pre-fill login id (e.g. with the just-registered loginName) before showing the screen. */
+    /** Pre-fills login id before showing the screen (e.g. with the just-registered loginName). */
     public void showLoginView(String prefilledLoginId) {
         SwingUtilities.invokeLater(() -> {
             DirectoryView dv = cards.main.directoryView;
@@ -225,41 +255,35 @@ public class ClientUI {
             cards.main.directoryView.adminButton.setVisible(false);
             cards.main.directoryView.revalidate();
             cards.main.directoryView.repaint();
-            cards.layout.show(cards, "login");
+            cards.layout.show(cards, Constants.CARD_LOGIN);
         });
     }
     public void showRegisterView() {
         SwingUtilities.invokeLater(() -> {
             clearLoginAndRegisterFields();
-            cards.layout.show(cards, "register");
+            cards.layout.show(cards, Constants.CARD_REGISTER);
         });
     }
 
-    // currentUser is set by the time this is called
     public void showMainView() {
         SwingUtilities.invokeLater(() -> {
             clearLoginAndRegisterFields();
-            // Reset the center pane so stale messages from a prior session in the
-            // same JVM don't render against a null currentConversation (which would
-            // surface every sender as "(former participant)" with no body).
+            // Same-JVM relogin: stale messages would render as "(former participant)" with no body.
             cards.main.conversationView.clearConversation();
             cards.main.conversationListView.list.clearSelection();
             UserInfo currentUser = controller.getCurrentUserInfo();
             boolean isAdmin = currentUser != null && currentUser.getUserType() == UserType.ADMIN;
             cards.main.directoryView.adminButton.setVisible(isAdmin);
-            // Refresh directory list from the latest controller-side cache on main-view entry.
-            // Exclude the logged-in user from the directory picker list.
             String myId = (currentUser != null) ? currentUser.getUserId() : null;
-            directoryModel.clear();
+            cards.main.directoryView.listModel.clear();
             for (UserInfo userInfo : controller.getFilteredDirectory("")) {
                 if (myId == null || !userInfo.getUserId().equals(myId)) {
-                    directoryModel.addElement(userInfo);
+                    cards.main.directoryView.listModel.addElement(userInfo);
                 }
             }
-            // Populate conversation list from login result.
-            conversationListModel.clear();
+            cards.main.conversationListView.listModel.clear();
             for (Conversation c : controller.getFilteredConversationList("")) {
-                conversationListModel.addElement(c);
+                cards.main.conversationListView.listModel.addElement(c);
             }
             cards.main.directoryView.revalidate();
             cards.main.directoryView.repaint();
@@ -272,15 +296,13 @@ public class ClientUI {
                 idL.setFont(idL.getFont().deriveFont(Font.PLAIN, idL.getFont().getSize() - 1f));
                 idL.setForeground(Color.GRAY);
             }
-            cards.layout.show(cards, "main");
+            cards.layout.show(cards, Constants.CARD_MAIN);
             frame.pack();
             frame.setLocationRelativeTo(null);
         });
     }
 
-    /** Escapes HTML special chars, wraps the result in {@code <html><body style='width:Npx'>...},
-     *  and emits a JLabel-ready string. Shared between {@link ConversationView.MessageCellRenderer}
-     *  and the admin viewer's read-only renderer so wrapping width math stays in one place. */
+    /** Wraps escaped HTML in a width-bounded body so JLabel wraps the same way in both renderers. */
     static String escapeAndWrapHtml(String raw, int maxPx) {
         if (raw == null) raw = "";
         StringBuilder sb = new StringBuilder(raw.length() + 16);
@@ -297,12 +319,11 @@ public class ClientUI {
                 default:   sb.append(c);
             }
         }
-        int safe = Math.max(80, maxPx);
+        int safe = Math.max(Constants.MIN_HTML_WRAP_PX, maxPx);
         return "<html><body style='width:" + safe + "px'>" + sb + "</body></html>";
     }
 
-    /** #141: wrap a password field with a Show/Hide toggle button. The wrapper JPanel takes the
-     *  field's place in any layout; the field reference itself is unchanged. */
+    /** #141: outer JPanel wraps field so layout swaps survive Show/Hide toggle. */
     private static JPanel passwordFieldWithToggle(JPasswordField field) {
         JPanel wrap = new JPanel(new BorderLayout(2, 0));
         JButton toggle = new JButton("Show");
@@ -397,7 +418,6 @@ public class ClientUI {
     /** #140/#142: drives the visible "submit in flight" state for both login and register. */
     public void setLoginInFlight(boolean inFlight) {
         SwingUtilities.invokeLater(() -> {
-            if (cards == null) return; // pre-EDT init guard
             cards.login.loginButton.setEnabled(!inFlight);
             cards.login.loginButton.setText(inFlight ? "Logging in..." : "Login");
             cards.register.createButton.setEnabled(!inFlight);
@@ -412,9 +432,9 @@ public class ClientUI {
 
     public void updateDirectoryModel(ArrayList<UserInfo> users) {
         SwingUtilities.invokeLater(() -> {
-            directoryModel.clear();
+            cards.main.directoryView.listModel.clear();
             for (UserInfo user : users) {
-                directoryModel.addElement(user);
+                cards.main.directoryView.listModel.addElement(user);
             }
         });
     }
@@ -440,15 +460,15 @@ public class ClientUI {
                     return Long.compare(bSeq, aSeq);
                 });
 
-                conversationListModel.clear();
+                cards.main.conversationListView.listModel.clear();
                 for (Conversation conversation : conversations) {
-                    conversationListModel.addElement(conversation);
+                    cards.main.conversationListView.listModel.addElement(conversation);
                 }
 
                 // Restore selection after rebuild.
                 if (selectedId != null) {
-                    for (int i = 0; i < conversationListModel.getSize(); i++) {
-                        if (conversationListModel.getElementAt(i).getConversationId() == selectedId.longValue()) {
+                    for (int i = 0; i < cards.main.conversationListView.listModel.getSize(); i++) {
+                        if (cards.main.conversationListView.listModel.getElementAt(i).getConversationId() == selectedId.longValue()) {
                             clv.list.setSelectedIndex(i);
                             break;
                         }
@@ -471,7 +491,7 @@ public class ClientUI {
             // Auto-switch should hand focus to message input, not leave it on a stale
             // directory selection.
             cards.main.directoryView.clearSelecting();
-            SwingUtilities.invokeLater(cards.main.conversationView::focusInput);
+            cards.main.conversationView.focusInput();
 
             ArrayList<Message> msgs = conversation.getMessages();
             if (!msgs.isEmpty()) {
@@ -480,10 +500,7 @@ public class ClientUI {
         });
     }
 
-    /** Marks {@code conversation} as read up to {@code sequenceNumber} on both the
-     *  client-side model and the server. {@link ClientController#updateReadMessages}
-     *  is the network round-trip; the {@code setLastRead} call ahead of it keeps the
-     *  local cache in sync immediately. */
+    /** Marks {@code conversation} read up to {@code sequenceNumber} both locally and on the server. */
     private void markConversationRead(Conversation conversation, long sequenceNumber) {
         UserInfo me = controller.getCurrentUserInfo();
         if (me != null) {
@@ -501,23 +518,21 @@ public class ClientUI {
             boolean fromOther = me != null && !message.getSenderId().equals(me.getUserId());
             boolean userActivelyViewing = frame.isActive() && cv.userIsAtBottom;
             if (fromOther && !userActivelyViewing && !cv.modelHasDivider) {
-                conversationMessageModel.addElement(ConversationView.NewMessagesDivider.INSTANCE);
+                cards.main.conversationView.conversationMessageListModel.addElement(ConversationView.NewMessagesDivider.INSTANCE);
                 cv.modelHasDivider = true;
             }
-            conversationMessageModel.addElement(message);
+            cards.main.conversationView.conversationMessageListModel.addElement(message);
             // Auto-scroll to newest only when the user is parked at the bottom. Otherwise
             // preserve their scroll position so they can read history.
-            if (cv.userIsAtBottom) {
+            if (cv.userIsAtBottom && !cv.scrollPending) {
+                cv.scrollPending = true;
                 SwingUtilities.invokeLater(() -> {
+                    cv.scrollPending = false;
                     int last = cv.list.getModel().getSize() - 1;
                     if (last >= 0) cv.list.ensureIndexIsVisible(last);
                 });
             }
-            // Slide the per-message read snapshot forward only when the OS window is
-            // active AND the user is parked at the bottom. Otherwise leave the snapshot
-            // frozen; the controller's deferred read-advance buffer replays on the next
-            // window activation or scroll-to-bottom, calling back into markDisplayedReadUpTo.
-            // Do NOT call updateReadMessages here — the controller owns the wire concern.
+            // deferred replay: window was inactive when message arrived
             if (frame.isActive() && cv.userIsAtBottom) {
                 cv.markDisplayedReadUpTo(message.getSequenceNumber());
             }
@@ -542,13 +557,10 @@ public class ClientUI {
                 cards.main.conversationView.markDisplayedReadUpTo(sequenceNumber));
     }
 
-    /** True when user is parked at the bottom of the open conversation.
-     *  Read from the network reader thread; underlying field is volatile. */
+    /** Called from network reader thread; activeConversationView and its userIsAtBottom field are volatile. */
     public boolean userIsViewingBottom() {
-        if (cards == null || cards.main == null || cards.main.conversationView == null) {
-            return true;
-        }
-        return cards.main.conversationView.userIsAtBottom;
+        ConversationView cv = activeConversationView;
+        return cv == null || cv.userIsAtBottom;
     }
 
     public void repaintConversationList() {
@@ -569,8 +581,7 @@ public class ClientUI {
         });
     }
 
-    /** Routes a silent admin read into the right pane of the open admin viewer. No-op if
-     *  the viewer dialog isn't open (defensive — late responses after dialog close are dropped). */
+    /** Late responses dropped after dialog close. */
     public void showAdminConversationView(Conversation conv) {
         if (conv == null) return;
         SwingUtilities.invokeLater(() -> {
@@ -578,10 +589,6 @@ public class ClientUI {
             if (dv.adminConversationSearchWindow == null) return;
             dv.adminConversationSearchWindow.loadConversation(conv);
         });
-    }
-
-    private JTextField makePlaceholderField(String placeholder, int cols) {
-        return new PlaceholderTextField(placeholder, cols);
     }
 
     private void bindEscapeToDispose(JDialog dialog) {
@@ -593,8 +600,52 @@ public class ClientUI {
         });
     }
 
+    private static DocumentListener filteringListener(Runnable onChange) {
+        return new DocumentListener() {
+            @Override public void insertUpdate(DocumentEvent e) { onChange.run(); }
+            @Override public void removeUpdate(DocumentEvent e) { onChange.run(); }
+            @Override public void changedUpdate(DocumentEvent e) { onChange.run(); }
+        };
+    }
+
+    private JDialog buildModalDialog(String title, JComponent content, Dimension size) {
+        JDialog dialog = new JDialog(frame, title, false);
+        dialog.add(content);
+        dialog.setSize(size);
+        dialog.setLocationRelativeTo(frame);
+        dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+        bindEscapeToDispose(dialog);
+        return dialog;
+    }
+
+    private static ArrayList<UserInfo> excludeSelf(List<UserInfo> participants, String myUserId) {
+        ArrayList<UserInfo> others = new ArrayList<>();
+        for (UserInfo p : participants) {
+            if (myUserId == null || !p.getUserId().equals(myUserId)) others.add(p);
+        }
+        return others;
+    }
+
+    private static String buildParticipantSummary(List<UserInfo> others, int maxNames) {
+        if (others.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder();
+        int limit = Math.min(maxNames, others.size());
+        for (int i = 0; i < limit; i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(others.get(i).getName());
+        }
+        if (others.size() > maxNames) {
+            sb.append(" +").append(others.size() - maxNames).append(" more");
+        }
+        return sb.toString();
+    }
+
+    private static ArrayList<UserInfo> displayParticipants(ArrayList<UserInfo> active, ArrayList<UserInfo> historical) {
+        return !active.isEmpty() ? active : historical;
+    }
+
     private Image createAppIcon() {
-        int size = 32;
+        int size = Constants.APP_ICON_SIZE_PX;
         java.awt.image.BufferedImage img =
             new java.awt.image.BufferedImage(size, size, java.awt.image.BufferedImage.TYPE_INT_ARGB);
         Graphics2D g = img.createGraphics();
@@ -610,18 +661,19 @@ public class ClientUI {
         return img;
     }
 
-    /** Format a message timestamp as "LLL dd, HH:mm" (or include the year if it
-     *  isn't the current year). Shared by message renderers. */
+    private static final DateTimeFormatter FMT_SAME_YEAR =
+            DateTimeFormatter.ofPattern("LLL dd, HH:mm", java.util.Locale.ENGLISH);
+    private static final DateTimeFormatter FMT_OTHER_YEAR =
+            DateTimeFormatter.ofPattern("LLL dd yyyy, HH:mm", java.util.Locale.ENGLISH);
+
+    /** Includes year only when not current year. */
     private static String formatMessageTimestamp(java.util.Date when) {
         ZonedDateTime zdt = when.toInstant().atZone(ZoneId.systemDefault());
-        DateTimeFormatter dtf = zdt.getYear() == ZonedDateTime.now().getYear()
-                ? DateTimeFormatter.ofPattern("LLL dd, HH:mm", java.util.Locale.ENGLISH)
-                : DateTimeFormatter.ofPattern("LLL dd yyyy, HH:mm", java.util.Locale.ENGLISH);
+        DateTimeFormatter dtf = zdt.getYear() == ZonedDateTime.now().getYear() ? FMT_SAME_YEAR : FMT_OTHER_YEAR;
         return zdt.format(dtf);
     }
 
-    /** Look up a sender's display name in a conversation's historical participants
-     *  (so removed users still show their name). Returns null if not found. */
+    /** Preserves removed-user names for historical render. */
     private static String resolveHistoricalSenderName(Conversation conv, String senderId) {
         if (conv == null) return null;
         for (UserInfo p : conv.getHistoricalParticipants()) {
@@ -724,12 +776,11 @@ public class ClientUI {
         }
     }
 
-    // =========================================================================
     class ScreenCards extends JPanel {
-        CardLayout layout;
-        MainView main;
-        LoginView login;
-        RegisterView register;
+        private CardLayout layout;
+        private MainView main;
+        private LoginView login;
+        private RegisterView register;
 
         ScreenCards() {
             layout = new CardLayout();
@@ -737,13 +788,12 @@ public class ClientUI {
             login = new LoginView();
             register = new RegisterView();
             main = new MainView();
-            add(login, "login");
-            add(register, "register");
-            add(main, "main");
+            add(login, Constants.CARD_LOGIN);
+            add(register, Constants.CARD_REGISTER);
+            add(main, Constants.CARD_MAIN);
         }
     }
 
-    // =========================================================================
     class RegisterView extends JPanel {
         JTextField userId;
         JTextField loginName;
@@ -771,7 +821,6 @@ public class ClientUI {
             createButton = new JButton("Create Account");
             backButton = new JButton("Back");
 
-            // Tooltips clarify which ID is which.
             userId.setToolTipText("Your organization-assigned employee ID. Must be pre-authorized.");
             loginName.setToolTipText("Choose a username for logging in. Letters, numbers, hyphens, or underscores only.");
 
@@ -788,7 +837,6 @@ public class ClientUI {
             gridConst.insets = new Insets(5, 5, 5, 5);
             gridConst.fill = GridBagConstraints.HORIZONTAL;
 
-            // "Employee ID" is organization-assigned and validated against the authorized list.
             gridConst.gridx = 0; gridConst.gridy = 0;
             inputPanel.add(new JLabel("Employee ID"), gridConst);
             gridConst.gridx = 1; gridConst.gridwidth = 2;
@@ -806,7 +854,6 @@ public class ClientUI {
 
             gridConst.gridx = 0; gridConst.gridy = 3;
             inputPanel.add(new JLabel("Password"), gridConst);
-            // Password text field with Show/Hide toggle.
             gridConst.gridx = 1;
             inputPanel.add(passwordFieldWithToggle(password), gridConst);
 
@@ -843,12 +890,10 @@ public class ClientUI {
         }
 
         private void wireBackButton() {
-            // Route through showLoginView so clearLoginAndRegisterFields() is called.
             backButton.addActionListener(e -> showLoginView());
         }
     }
 
-    // =========================================================================
     class LoginView extends JPanel {
         JTextField loginIdField;
         JPasswordField passwordField;
@@ -863,7 +908,6 @@ public class ClientUI {
             loginButton = new JButton("Login");
             createButton = new JButton("Create Account");
 
-            // Tooltip clarifies the field is the login username, not the Employee ID.
             loginIdField.setToolTipText("Your chosen login username (not your Employee ID).");
 
             JLabel heading = new JLabel("Login", SwingConstants.CENTER);
@@ -884,7 +928,6 @@ public class ClientUI {
             gridConst.gridx = 0;
             gridConst.gridy = 1;
             inputPanel.add(new JLabel("Password"), gridConst);
-            // Password text field with Show/Hide toggle.
             gridConst.gridx = 1;
             inputPanel.add(passwordFieldWithToggle(passwordField), gridConst);
             gridConst.gridx = 2;
@@ -908,12 +951,10 @@ public class ClientUI {
             loginIdField.addActionListener(loginAction);
             passwordField.addActionListener(loginAction);
 
-            // Route through showRegisterView so fields are cleared.
             createButton.addActionListener(e -> showRegisterView());
         }
     }
 
-    // =========================================================================
     class MainView extends JPanel {
         private static final int MIN_CONVERSATION_LIST_WIDTH = 240;
         ConversationView conversationView;
@@ -948,9 +989,8 @@ public class ClientUI {
 
     }
 
-    // =========================================================================
     class ConversationView extends JPanel {
-        JLabel participantsLabel;
+        private JLabel participantsLabel;
         final DefaultListModel<Object> conversationMessageListModel = new DefaultListModel<>();
         final JList<Object> list = new JList<>(conversationMessageListModel);
         private JScrollPane messageScrollPane;
@@ -965,12 +1005,13 @@ public class ClientUI {
         // Set true on insert by setListModel or appendMessageToConversationView; cleared on
         // model clear (setListModel/clearConversation). EDT-only access.
         private boolean modelHasDivider = false;
-        JButton addButton;
-        JButton leaveButton;
-        JTextField text;
-        JButton sendButton;
-        JDialog addDialog;
-        SelectUserWindow addUserWindow;
+        private boolean scrollPending = false;
+        private JButton addButton;
+        private JButton leaveButton;
+        private JTextField messageInputField;
+        private JButton sendButton;
+        private JDialog addDialog;
+        private SelectUserWindow addUserWindow;
 
         private final JLabel placeholderLabel = new JLabel("Select a conversation to start chatting", SwingConstants.CENTER);
 
@@ -982,7 +1023,6 @@ public class ClientUI {
             private NewMessagesDivider() {}
         }
 
-        // Use JTextArea-based bubbles for deterministic wrapping.
         private final class MessageCellRenderer extends JPanel implements ListCellRenderer<Object> {
             private final JPanel bubble = new JPanel(new BorderLayout(0, 2));
             private final JTextArea headerArea = new JTextArea();
@@ -990,6 +1030,8 @@ public class ClientUI {
             // A separate component returned for NewMessagesDivider sentinels.
             private final JPanel dividerPanel = new JPanel(new BorderLayout(6, 0));
             private final JLabel dividerLabel = new JLabel("New messages", SwingConstants.CENTER);
+            private final java.util.HashMap<Long, MessageRow> rowCache = new java.util.HashMap<>();
+            private Conversation cachedFor;
 
             MessageCellRenderer() {
                 setLayout(new BorderLayout());
@@ -1027,7 +1069,7 @@ public class ClientUI {
                 dividerPanel.add(left, BorderLayout.WEST);
                 dividerPanel.add(dividerLabel, BorderLayout.CENTER);
                 dividerPanel.add(right, BorderLayout.EAST);
-                dividerPanel.setPreferredSize(new Dimension(10, 22));
+                dividerPanel.setPreferredSize(new Dimension(Constants.DIVIDER_PANEL_DIM));
                 dividerPanel.getAccessibleContext().setAccessibleName("New messages divider");
             }
 
@@ -1038,14 +1080,21 @@ public class ClientUI {
 
                 if (value instanceof NewMessagesDivider) {
                     dividerPanel.setBackground(list.getBackground());
-                    // Make the embedded label transparent so the bg shows through evenly.
                     dividerLabel.setOpaque(false);
                     return dividerPanel;
                 }
 
                 Message msg = (Message) value;
-                MessageRow row = MessageRow.forConversation(
-                        msg, controller.getCurrentConversation(), controller.getCurrentUserInfo());
+                Conversation curr = controller.getCurrentConversation();
+                if (curr != cachedFor) {
+                    rowCache.clear();
+                    cachedFor = curr;
+                }
+                MessageRow row = rowCache.get(msg.getSequenceNumber());
+                if (row == null) {
+                    row = MessageRow.forConversation(msg, curr, controller.getCurrentUserInfo());
+                    rowCache.put(msg.getSequenceNumber(), row);
+                }
 
                 removeAll();
                 setBackground(list.getBackground());
@@ -1084,7 +1133,7 @@ public class ClientUI {
             }
 
             private void installBubbleWidth(int wrapPx) {
-                int safe = Math.max(120, wrapPx);
+                int safe = Math.max(Constants.MIN_BUBBLE_WIDTH_PX, wrapPx);
                 headerArea.setSize(new Dimension(safe, Short.MAX_VALUE));
                 Dimension headerPref = headerArea.getPreferredSize();
                 bodyArea.setSize(new Dimension(safe, Short.MAX_VALUE));
@@ -1122,8 +1171,8 @@ public class ClientUI {
                         baseWidth -= vsb.getWidth();
                     }
                 }
-                int usable = baseWidth - 28;
-                return usable > 0 ? (int) (usable * 0.66) : 220;
+                int usable = baseWidth - Constants.BUBBLE_INSET_PX;
+                return usable > 0 ? (int) (usable * BUBBLE_WRAP_FRACTION) : 220;
             }
         }
 
@@ -1131,8 +1180,8 @@ public class ClientUI {
             participantsLabel = new JLabel();
             addButton = new JButton("Add");
             leaveButton = new JButton("Leave");
-            text = new JTextField(15);
-            text.setEnabled(false);
+            messageInputField = new JTextField(15);
+            messageInputField.setEnabled(false);
             sendButton = new JButton("Send");
             addButton.setEnabled(false);
             leaveButton.setEnabled(false);
@@ -1172,7 +1221,6 @@ public class ClientUI {
             };
             list.addComponentListener(wrapResizeAdapter);
 
-            // Layered center panel: placeholder shows when no conversation is selected.
             JPanel centerPanel = new JPanel(new BorderLayout());
             messageScrollPane = new JScrollPane(list);
             messageScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
@@ -1185,11 +1233,11 @@ public class ClientUI {
             messageScrollPane.getVerticalScrollBar().addAdjustmentListener(e -> {
                 JScrollBar vsb = (JScrollBar) e.getSource();
                 int max = vsb.getMaximum() - vsb.getVisibleAmount();
-                boolean newAtBottom = (vsb.getValue() >= max - 4);
+                boolean newAtBottom = (vsb.getValue() >= max - Constants.SCROLL_BOTTOM_TOLERANCE_PX);
                 boolean wasAtBottom = userIsAtBottom;
                 userIsAtBottom = newAtBottom;
                 if (newAtBottom && !wasAtBottom) {
-                    controller.replayReadAdvanceIfNeeded();
+                    onScrollReachedBottom();
                 }
             });
             centerPanel.add(messageScrollPane, BorderLayout.CENTER);
@@ -1201,7 +1249,7 @@ public class ClientUI {
             charCountLabel.setBorder(BorderFactory.createEmptyBorder(0, 4, 0, 4));
             JPanel sendPane = new JPanel(new BorderLayout());
             sendPane.setBorder(BorderFactory.createEmptyBorder(10, 0, 0, 0));
-            sendPane.add(text, BorderLayout.CENTER);
+            sendPane.add(messageInputField, BorderLayout.CENTER);
             JPanel sendRight = new JPanel(new BorderLayout());
             sendRight.add(charCountLabel, BorderLayout.WEST);
             sendRight.add(sendButton, BorderLayout.EAST);
@@ -1216,12 +1264,7 @@ public class ClientUI {
                 addUserWindow = new SelectUserWindow(
                     users -> controller.addToConversation(users, controller.getCurrentConversationId()));
 
-                addDialog = new JDialog(frame, "Select User", false);
-                addDialog.add(addUserWindow);
-                addDialog.setSize(SELECT_USER_DIALOG_SIZE);
-                addDialog.setLocationRelativeTo(frame);
-                addDialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
-                bindEscapeToDispose(addDialog);
+                addDialog = buildModalDialog(Constants.DLG_SELECT_USER, addUserWindow, SELECT_USER_DIALOG_SIZE);
 
                 addDialog.addWindowListener(new WindowAdapter() {
                     @Override
@@ -1251,7 +1294,7 @@ public class ClientUI {
             });
 
             // 500-char hard cap
-            ((javax.swing.text.AbstractDocument) text.getDocument()).setDocumentFilter(
+            ((javax.swing.text.AbstractDocument) messageInputField.getDocument()).setDocumentFilter(
                     new javax.swing.text.DocumentFilter() {
                         private static final int MAX = 500;
                         @Override
@@ -1274,43 +1317,43 @@ public class ClientUI {
                         }
                     });
 
-            text.getDocument().addDocumentListener(new DocumentListener() {
+            messageInputField.getDocument().addDocumentListener(new DocumentListener() {
 
-                private void update() {
-                    int len = text.getText().length();
+                private void update(DocumentEvent e) {
+                    int len = e.getDocument().getLength();
                     charCountLabel.setText(len + "/500");
                     charCountLabel.setForeground(len >= 500 ? Color.RED : UIManager.getColor("Label.foreground"));
-                    sendButton.setEnabled(!text.getText().trim().isEmpty());
+                    sendButton.setEnabled(len > 0 && !messageInputField.getText().trim().isEmpty());
                 }
 
                 @Override
                 public void insertUpdate(DocumentEvent e) {
-                    update();
+                    update(e);
                 }
 
                 @Override
                 public void removeUpdate(DocumentEvent e) {
-                    update();
+                    update(e);
                 }
 
                 @Override
                 public void changedUpdate(DocumentEvent e) {
-                    update();
+                    update(e);
                 }
             });
 
             sendButton.addActionListener(e -> doSend());
 
-            text.addActionListener(e -> doSend());
+            messageInputField.addActionListener(e -> doSend());
 
         }
 
         private void doSend() {
             if (controller.getCurrentConversation() == null) return;
-            String msg = text.getText();
+            String msg = messageInputField.getText();
             if (msg.trim().isEmpty()) return;
             controller.sendMessage(controller.getCurrentConversation().getConversationId(), msg);
-            text.setText("");
+            messageInputField.setText("");
             // Sending a reply is an unambiguous read-acknowledgement.
             removeDividerNow();
         }
@@ -1320,12 +1363,7 @@ public class ClientUI {
             setListModel(currConv, lastReadAtOpen);
         }
 
-        /**
-         * Fix E2: race-free overload. Uses the message list captured atomically with
-         * {@code lastReadAtOpen} by {@link ClientController#openConversationAtomically(long)}
-         * so the divider boundary always matches the consistent (lastRead, messages) pair —
-         * even if {@link Conversation#append} fires between capture and render.
-         */
+        /** Fix E2: caller atomically captures (lastRead, messages); divider can't drift. */
         public void setListModel(ClientController.ConversationOpenSnapshot snap) {
             setListModel(snap.conversation, snap.lastReadAtOpen, snap.messages);
         }
@@ -1335,25 +1373,9 @@ public class ClientUI {
         }
 
         private void setListModel(Conversation currConv, long lastReadAtOpen, ArrayList<Message> msgs) {
-            // Exclude self; show up to 3 names, then append "+N more".
             UserInfo me = controller.getCurrentUserInfo();
             String myId = (me != null) ? me.getUserId() : null;
-            ArrayList<UserInfo> others = new ArrayList<>();
-            for (UserInfo p : currConv.getParticipants()) {
-                if (!p.getUserId().equals(myId)) {
-                    others.add(p);
-                }
-            }
-            StringBuilder memberSb = new StringBuilder();
-            int limit = Math.min(3, others.size());
-            for (int i = 0; i < limit; i++) {
-                if (i > 0) memberSb.append(", ");
-                memberSb.append(others.get(i).getName());
-            }
-            if (others.size() > 3) {
-                memberSb.append(" +").append(others.size() - 3).append(" more");
-            }
-            final String finalMember = memberSb.toString();
+            final String finalMember = buildParticipantSummary(excludeSelf(currConv.getParticipants(), myId), 3);
             final long finalLastReadAtOpen = lastReadAtOpen;
             SwingUtilities.invokeLater(() -> {
                 displayedLastReadSeq = finalLastReadAtOpen;
@@ -1380,21 +1402,18 @@ public class ClientUI {
                 }
                 modelHasDivider = dividerInserted;
                 refreshWrapLayout();
-                text.setEnabled(true);
+                messageInputField.setEnabled(true);
                 addButton.setEnabled(true);
                 leaveButton.setEnabled(true);
-                sendButton.setEnabled(!text.getText().trim().isEmpty());
+                sendButton.setEnabled(!messageInputField.getText().trim().isEmpty());
                 placeholderLabel.setVisible(false);
-                SwingUtilities.invokeLater(() -> {
-                    int last = list.getModel().getSize() - 1;
-                    if (last >= 0) list.ensureIndexIsVisible(last);
-                    scrollToBottom();
-                    refreshWrapLayout();
-                });
+                int last = list.getModel().getSize() - 1;
+                if (last >= 0) list.ensureIndexIsVisible(last);
+                scrollToBottom();
+                refreshWrapLayout();
             });
         }
 
-        /** Clears the view and disables action buttons (no conversation active). */
         public void clearConversation() {
             SwingUtilities.invokeLater(() -> {
                 displayedLastReadSeq = 0L;
@@ -1404,7 +1423,7 @@ public class ClientUI {
                 participantsLabel.setText("");
                 conversationMessageListModel.clear();
                 refreshWrapLayout();
-                text.setEnabled(false);
+                messageInputField.setEnabled(false);
                 addButton.setEnabled(false);
                 leaveButton.setEnabled(false);
                 sendButton.setEnabled(false);
@@ -1424,13 +1443,20 @@ public class ClientUI {
             return this.conversationMessageListModel;
         }
 
-        /** Hands keyboard focus to the message input. */
         void focusInput() {
-            text.requestFocusInWindow();
+            messageInputField.requestFocusInWindow();
         }
 
         public boolean isAddingUser() {
             return isDialogShowing(addDialog);
+        }
+
+        public void propagateAddUserSelection(UserInfo user) {
+            if (user != null && addUserWindow != null) addUserWindow.addUser(user);
+        }
+
+        private void onScrollReachedBottom() {
+            controller.replayReadAdvanceIfNeeded();
         }
 
         public void markDisplayedReadUpTo(long sequenceNumber) {
@@ -1478,30 +1504,27 @@ public class ClientUI {
         }
 
         private void scrollToBottom() {
-            if (messageScrollPane == null) return;
             JScrollBar vsb = messageScrollPane.getVerticalScrollBar();
-            if (vsb == null) return;
             // Defer one more tick so layout/model updates settle before forcing bottom.
             SwingUtilities.invokeLater(() -> vsb.setValue(vsb.getMaximum()));
         }
     }
 
-    // =========================================================================
     class DirectoryView extends JPanel {
-        JLabel profileUserIdLabel;
-        JLabel profileNameLabel;
-        JLabel pickerBannerLabel;
-        JTextField searchField;
-        DefaultListModel<UserInfo> listModel = new DefaultListModel<>();
-        final JList<UserInfo> list = new JList<>(listModel);
-        JButton logoutButton;
-        JButton createConversationButton;
-        JButton adminButton;
-        JDialog createDialog;
-        JDialog adminDialog;
-        UserInfo selecting;
-        SelectUserWindow createConversationUserWindow;
-        AdminConversationSearchWindow adminConversationSearchWindow;
+        private JLabel profileUserIdLabel;
+        private JLabel profileNameLabel;
+        private JLabel pickerBannerLabel;
+        private JTextField searchField;
+        private final DefaultListModel<UserInfo> listModel = new DefaultListModel<>();
+        private final JList<UserInfo> list = new JList<>(listModel);
+        private JButton logoutButton;
+        private JButton createConversationButton;
+        private JButton adminButton;
+        private JDialog createDialog;
+        private JDialog adminDialog;
+        private UserInfo selectedDirectoryUser;
+        private SelectUserWindow createConversationUserWindow;
+        private AdminConversationSearchWindow adminConversationSearchWindow;
 
         DirectoryView() {
             buildLayout();
@@ -1521,7 +1544,7 @@ public class ClientUI {
             pickerBannerLabel.setFont(pickerBannerLabel.getFont().deriveFont(Font.BOLD));
             pickerBannerLabel.setVisible(false);
 
-            searchField = makePlaceholderField("Search users...", 15);
+            searchField = new PlaceholderTextField("Search users...", 15);
             logoutButton = new JButton("Log Out");
             createConversationButton = new JButton("Create Conversation");
             createConversationButton.setEnabled(false);
@@ -1566,24 +1589,19 @@ public class ClientUI {
         }
 
         private void wireSearchField() {
-            searchField.getDocument().addDocumentListener(new DocumentListener() {
-                @Override public void insertUpdate(DocumentEvent e) { filter(); }
-                @Override public void removeUpdate(DocumentEvent e) { filter(); }
-                @Override public void changedUpdate(DocumentEvent e) { filter(); }
+            searchField.getDocument().addDocumentListener(filteringListener(this::applyDirectoryFilter));
+        }
 
-                private void filter() {
-                    String text = searchField.getText().toUpperCase();
-                    listModel.clear();
-                    // Exclude the logged-in user from the directory list.
-                    UserInfo me = controller.getCurrentUserInfo();
-                    String myId = (me != null) ? me.getUserId() : null;
-                    for(UserInfo item: controller.getFilteredDirectory(text)) {
-                        if (myId == null || !item.getUserId().equals(myId)) {
-                            listModel.addElement(item);
-                        }
-                    }
+        private void applyDirectoryFilter() {
+            String query = searchField.getText().toUpperCase();
+            listModel.clear();
+            UserInfo me = controller.getCurrentUserInfo();
+            String myId = (me != null) ? me.getUserId() : null;
+            for (UserInfo item : controller.getFilteredDirectory(query)) {
+                if (myId == null || !item.getUserId().equals(myId)) {
+                    listModel.addElement(item);
                 }
-            });
+            }
         }
 
         private void wireLogoutButton() {
@@ -1597,15 +1615,10 @@ public class ClientUI {
                 createConversationUserWindow = new SelectUserWindow(users -> controller.createConversation(users));
                 // Seed the picker with the current directory selection so the
                 // first selection is honored without requiring reselection.
-                if (selecting != null) {
-                    createConversationUserWindow.addUser(selecting);
+                if (selectedDirectoryUser != null) {
+                    createConversationUserWindow.addUser(selectedDirectoryUser);
                 }
-                createDialog = new JDialog(frame, "Select User", false);
-                createDialog.add(createConversationUserWindow);
-                createDialog.setSize(SELECT_USER_DIALOG_SIZE);
-                createDialog.setLocationRelativeTo(frame);
-                createDialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
-                bindEscapeToDispose(createDialog);
+                createDialog = buildModalDialog(Constants.DLG_SELECT_USER, createConversationUserWindow, SELECT_USER_DIALOG_SIZE);
 
                 createDialog.addWindowListener(new WindowAdapter() {
                     @Override
@@ -1624,7 +1637,7 @@ public class ClientUI {
                 // has exactly one user, Swing auto-selects index 0 on render, and a click
                 // on that already-selected row is a no-op — addUser is never called.
                 list.clearSelection();
-                selecting = null;
+                selectedDirectoryUser = null;
 
                 createDialog.setVisible(true);
             });
@@ -1634,17 +1647,12 @@ public class ClientUI {
             adminButton.addActionListener(e -> {
                 if (focusExistingDialog(adminDialog)) return;
 
-                if (selecting == null) {
+                if (selectedDirectoryUser == null) {
                     return;
                 }
-                controller.adminGetUserConversations(selecting.getUserId());
+                controller.adminGetUserConversations(selectedDirectoryUser.getUserId());
                 adminConversationSearchWindow = new AdminConversationSearchWindow();
-                adminDialog = new JDialog(frame, "Searching Conversations", false);
-                adminDialog.add(adminConversationSearchWindow);
-                adminDialog.setSize(ADMIN_SEARCH_DIALOG_SIZE);
-                adminDialog.setLocationRelativeTo(frame);
-                adminDialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
-                bindEscapeToDispose(adminDialog);
+                adminDialog = buildModalDialog(Constants.DLG_ADMIN_SEARCH, adminConversationSearchWindow, ADMIN_SEARCH_DIALOG_SIZE);
 
                 adminDialog.addWindowListener(new WindowAdapter() {
                     @Override
@@ -1670,26 +1678,22 @@ public class ClientUI {
                 if (e.getValueIsAdjusting()) {
                     return;
                 }
-                selecting = selectedValue;
+                selectedDirectoryUser = selectedValue;
 
-                JDialog addDialog = cards.main.conversationView.addDialog;
-                boolean inPickerMode = isDialogShowing(createDialog) || isDialogShowing(addDialog);
+                ConversationView convView = cards.main.conversationView;
+                boolean addingUser = convView.isAddingUser();
+                boolean inPickerMode = isDialogShowing(createDialog) || addingUser;
                 pickerBannerLabel.setVisible(inPickerMode);
 
-                if (selecting != null && !isDialogShowing(createDialog) && !isDialogShowing(adminDialog) && !isDialogShowing(addDialog)) {
+                if (selectedDirectoryUser != null && !isDialogShowing(createDialog) && !isDialogShowing(adminDialog) && !addingUser) {
                     createConversationButton.setEnabled(true);
                     adminButton.setEnabled(true);
                 } else if (isDialogShowing(createDialog)) {
-                    createConversationUserWindow.addUser(selecting);
-                } else if (isDialogShowing(addDialog)) {
-                    if (selecting != null) cards.main.conversationView.addUserWindow.addUser(selecting);
+                    createConversationUserWindow.addUser(selectedDirectoryUser);
+                } else if (addingUser) {
+                    convView.propagateAddUserSelection(selectedDirectoryUser);
                 }
             });
-        }
-
-        public void setListModel(DefaultListModel<UserInfo> model) {
-            this.listModel = model;
-            list.setModel(model);
         }
 
         public DefaultListModel<UserInfo> getListModel() {
@@ -1704,23 +1708,15 @@ public class ClientUI {
             return isDialogShowing(adminDialog);
         }
 
-        public DefaultListModel<ConversationMetadata> getAdminConversationModel() {
-            if(adminConversationSearchWindow == null) {
-                return new DefaultListModel<>();
-            }
-            return adminConversationSearchWindow.getAdminConversationSearch();
-        }
-
         /** Drops the selected directory user without firing the selection listener side effects. */
         void clearSelecting() {
             list.clearSelection();
-            selecting = null;
+            selectedDirectoryUser = null;
         }
 
 
     }
 
-    // =========================================================================
     class ConversationListView extends JPanel {
         JTextField searchField;
         DefaultListModel<Conversation> listModel = new DefaultListModel<>();
@@ -1765,35 +1761,23 @@ public class ClientUI {
             public Component getListCellRendererComponent(
                     JList<? extends Conversation> list, Conversation value, int index,
                     boolean isSelected, boolean cellHasFocus) {
-                Conversation conv = value;
                 UserInfo me = controller.getCurrentUserInfo();
                 String myId = (me != null) ? me.getUserId() : null;
-
-                ArrayList<UserInfo> others = new ArrayList<>();
-                for (UserInfo p : conv.getParticipants()) {
-                    if (!p.getUserId().equals(myId)) {
-                        others.add(p);
-                    }
-                }
+                ArrayList<UserInfo> others = excludeSelf(value.getParticipants(), myId);
 
                 String display;
-                if (conv.getType() == shared.enums.ConversationType.PRIVATE) {
-                    String otherName = others.isEmpty() ? "(empty)" : others.get(0).getName();
-                    display = "DM: " + otherName;
+                if (value.getType() == shared.enums.ConversationType.PRIVATE) {
+                    String otherName = others.isEmpty() ? Constants.EMPTY_PARTICIPANT_PLACEHOLDER : others.get(0).getName();
+                    display = Constants.DM_PREFIX + otherName;
                 } else {
-                    StringBuilder sb = new StringBuilder("Group: ");
-                    for (int i = 0; i < others.size(); i++) {
-                        if (i > 0) sb.append(", ");
-                        sb.append(others.get(i).getName());
-                    }
-                    if (others.isEmpty()) sb.append("(empty)");
-                    display = sb.toString();
+                    String summary = buildParticipantSummary(others, Integer.MAX_VALUE);
+                    display = Constants.GROUP_PREFIX + (summary.isEmpty() ? Constants.EMPTY_PARTICIPANT_PLACEHOLDER : summary);
                 }
 
-                int unread = ClientController.unreadCount(conv, me);
+                int unread = ClientController.unreadCount(value, me);
                 if (unread > 0) {
                     nameLabel.setFont(list.getFont().deriveFont(Font.BOLD));
-                    badgeLabel.setText(unread > 99 ? "99+" : Integer.toString(unread));
+                    badgeLabel.setText(unread > Constants.UNREAD_BADGE_CAP ? Constants.UNREAD_BADGE_CAP_TEXT : Integer.toString(unread));
                     badgeLabel.setVisible(true);
                     getAccessibleContext().setAccessibleName(display + " (" + unread + " unread)");
                 } else {
@@ -1822,7 +1806,7 @@ public class ClientUI {
         }
 
         private void buildLayout() {
-            searchField = makePlaceholderField("Search conversations...", 15);
+            searchField = new PlaceholderTextField("Search conversations...", 15);
 
             setLayout(new BorderLayout());
             setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
@@ -1834,19 +1818,15 @@ public class ClientUI {
         }
 
         private void wireSearchField() {
-            searchField.getDocument().addDocumentListener(new DocumentListener() {
-                @Override public void insertUpdate(DocumentEvent e) { filter(); }
-                @Override public void removeUpdate(DocumentEvent e) { filter(); }
-                @Override public void changedUpdate(DocumentEvent e) { filter(); }
+            searchField.getDocument().addDocumentListener(filteringListener(this::applyConversationFilter));
+        }
 
-                private void filter() {
-                    String text = searchField.getText().toUpperCase();
-                    listModel.clear();
-                    for (Conversation item : controller.getFilteredConversationList(text)) {
-                        listModel.addElement(item);
-                    }
-                }
-            });
+        private void applyConversationFilter() {
+            String query = searchField.getText().toUpperCase();
+            listModel.clear();
+            for (Conversation item : controller.getFilteredConversationList(query)) {
+                listModel.addElement(item);
+            }
         }
 
         private void wireListSelectionListener() {
@@ -1875,17 +1855,11 @@ public class ClientUI {
             });
         }
 
-        public void setListModel(DefaultListModel<Conversation> model) {
-            this.listModel = model;
-            list.setModel(model);
-        }
-
         public DefaultListModel<Conversation> getListModel() {
             return this.listModel;
         }
     }
 
-    // =========================================================================
     class SelectUserWindow extends JPanel {
         final DefaultListModel<UserInfo> model = new DefaultListModel<>();
         final JList<UserInfo> list = new JList<>(model);
@@ -1957,8 +1931,8 @@ public class ClientUI {
         private void wireListSelectionListener() {
             list.addListSelectionListener(e -> {
                 if (!e.getValueIsAdjusting()) {
-                    UserInfo selecting = list.getSelectedValue();
-                    removeButton.setEnabled(selecting != null);
+                    UserInfo toRemove = list.getSelectedValue();
+                    removeButton.setEnabled(toRemove != null);
                 }
             });
         }
@@ -1988,7 +1962,6 @@ public class ClientUI {
 
     }
 
-    // =========================================================================
     class AdminConversationSearchWindow extends JPanel {
         JTextField searchField;
         final DefaultListModel<ConversationMetadata> model = new DefaultListModel<>();
@@ -1996,8 +1969,6 @@ public class ClientUI {
         JButton closeButton;
         ViewerPanel viewerPanel;
 
-        // Renders each search result as "[ID: N] TYPE • K participant(s) • last active <ts>"
-        // (or "no messages yet"). Modeled on ConversationCellRenderer above.
         private final class AdminConversationCellRenderer extends DefaultListCellRenderer {
             @Override
             public Component getListCellRendererComponent(
@@ -2007,13 +1978,12 @@ public class ClientUI {
                 if (value instanceof ConversationMetadata) {
                     ConversationMetadata m = (ConversationMetadata) value;
                     ArrayList<UserInfo> active = m.getParticipants();
-                    ArrayList<UserInfo> historical = m.getHistoricalParticipants();
-                    boolean orphan = (active == null || active.isEmpty());
-                    ArrayList<UserInfo> sourceList = !orphan ? active : historical;
+                    ArrayList<UserInfo> sourceList = displayParticipants(active, m.getHistoricalParticipants());
+                    boolean orphan = active.isEmpty();
 
-                    String who;
+                    String participantsSummary;
                     if (sourceList == null || sourceList.isEmpty()) {
-                        who = "0 participant(s)";
+                        participantsSummary = "0 participant(s)";
                     } else {
                         StringBuilder sb = new StringBuilder();
                         if (orphan) sb.append("(left) ");
@@ -2022,33 +1992,31 @@ public class ClientUI {
                             UserInfo p = sourceList.get(i);
                             sb.append(p.getName()).append(" (").append(p.getUserId()).append(')');
                         }
-                        who = sb.toString();
+                        participantsSummary = sb.toString();
                     }
 
-                    String activity;
+                    String lastActivityLabel;
                     long ts = m.getLastMessageTimestampMillis();
                     if (ts <= 0L) {
-                        activity = "no messages yet";
+                        lastActivityLabel = "no messages yet";
                     } else {
-                        activity = "last active " + formatMessageTimestamp(new java.util.Date(ts));
+                        lastActivityLabel = "last active " + formatMessageTimestamp(new java.util.Date(ts));
                     }
                     setText("[ID: " + m.getConversationId() + "]  "
                             + m.getType() + "  •  "
-                            + who + "  •  "
-                            + activity);
+                            + participantsSummary + "  •  "
+                            + lastActivityLabel);
                 }
                 return this;
             }
         }
 
-        // Read-only renderer for the right-pane message list. Holds a local Conversation
-        // reference (set by ViewerPanel before populating the model) and resolves sender
-        // names from that conversation's historicalParticipants — does NOT touch
-        // controller.getCurrentConversation()/Id/UserInfo. No unread-bold logic; admins
-        // have no read pointer in the viewed conversation.
+        // Resolves senders from the locally-held Conversation (admin has no current-conversation context).
         private final class AdminMessageCellRenderer extends JPanel implements ListCellRenderer<Message> {
             private final JLabel label = new JLabel();
             private Conversation viewedConv;
+            private final java.util.HashMap<Long, String> htmlCache = new java.util.HashMap<>();
+            private int cachedWrapPx = -1;
 
             AdminMessageCellRenderer() {
                 setLayout(new BorderLayout());
@@ -2059,39 +2027,51 @@ public class ClientUI {
                         BorderFactory.createEmptyBorder(4, 10, 4, 10)));
             }
 
-            void setConversation(Conversation conv) { this.viewedConv = conv; }
+            void setConversation(Conversation conv) {
+                this.viewedConv = conv;
+                htmlCache.clear();
+            }
 
             @Override
             public Component getListCellRendererComponent(
                     JList<? extends Message> list, Message msg, int index,
                     boolean isSelected, boolean cellHasFocus) {
-                MessageRow row = MessageRow.forAdmin(msg, viewedConv);
-                String displayText = row.headerText + " " + row.body;
-
                 int listW = list.getWidth();
                 int wrapPx = listW > 0 ? (int) (listW * BUBBLE_WRAP_FRACTION) : 360;
+                if (wrapPx != cachedWrapPx) {
+                    htmlCache.clear();
+                    cachedWrapPx = wrapPx;
+                }
+                String html = htmlCache.get(msg.getSequenceNumber());
+                if (html == null) {
+                    MessageRow row = MessageRow.forAdmin(msg, viewedConv);
+                    html = escapeAndWrapHtml(row.headerText + " " + row.body, wrapPx);
+                    htmlCache.put(msg.getSequenceNumber(), html);
+                }
 
                 removeAll();
                 setBackground(list.getBackground());
                 label.setBackground(list.getBackground());
                 label.setFont(label.getFont().deriveFont(Font.PLAIN));
-                label.setText(escapeAndWrapHtml(displayText, wrapPx));
+                label.setText(html);
                 add(label, BorderLayout.WEST);
                 return this;
             }
         }
 
-        // Right pane of the split: read-only message viewer for the selected conversation.
-        // Starts on a placeholder; replaced by the message scroll list once a conversation
-        // is loaded. No input field, no Send/Add/Leave buttons.
+        // Right pane of the split: read-only message viewer; placeholder until a conversation loads.
         final class ViewerPanel extends JPanel {
+            private static final String CARD_EMPTY = "empty";
+            private static final String CARD_MESSAGES = "messages";
+
             JLabel participantsLabel = new JLabel(" ");
             DefaultListModel<Message> msgModel = new DefaultListModel<>();
             JList<Message> msgList = new JList<>(msgModel);
-            JLabel placeholder = new JLabel("Select a conversation to preview", SwingConstants.CENTER);
+            JLabel emptyStateLabel = new JLabel("Select a conversation to preview", SwingConstants.CENTER);
             JScrollPane scroll;
             AdminMessageCellRenderer renderer = new AdminMessageCellRenderer();
-            boolean populated = false;
+            private final CardLayout bodyCards = new CardLayout();
+            private final JPanel body = new JPanel(bodyCards);
 
             ViewerPanel() {
                 setLayout(new BorderLayout());
@@ -2111,39 +2091,28 @@ public class ClientUI {
                     }
                 });
 
-                add(placeholder, BorderLayout.CENTER);
+                body.add(emptyStateLabel, CARD_EMPTY);
+                body.add(scroll, CARD_MESSAGES);
+                add(body, BorderLayout.CENTER);
             }
 
             void loadConversation(Conversation conv) {
                 if (conv == null) return;
                 renderer.setConversation(conv);
                 ArrayList<UserInfo> active = conv.getParticipants();
-                ArrayList<UserInfo> historical = conv.getHistoricalParticipants();
-                StringBuilder names = new StringBuilder();
-                ArrayList<UserInfo> sourceList = !active.isEmpty() ? active : historical;
-                for (int i = 0; i < sourceList.size(); i++) {
-                    if (i > 0) names.append(", ");
-                    names.append(sourceList.get(i).getName());
-                }
+                ArrayList<UserInfo> sourceList = displayParticipants(active, conv.getHistoricalParticipants());
+                String summary = buildParticipantSummary(sourceList, Integer.MAX_VALUE);
                 String prefix = active.isEmpty() ? "Former participants: " : "Participants: ";
-                participantsLabel.setText(prefix + (sourceList.isEmpty() ? "(none)" : names.toString()));
+                participantsLabel.setText(prefix + (summary.isEmpty() ? "(none)" : summary));
 
                 msgModel.clear();
                 ArrayList<Message> messages = conv.getMessages();
                 if (messages.isEmpty()) {
-                    placeholder.setText("No messages yet");
-                    if (populated) {
-                        remove(scroll);
-                        add(placeholder, BorderLayout.CENTER);
-                        populated = false;
-                    }
+                    emptyStateLabel.setText("No messages yet");
+                    bodyCards.show(body, CARD_EMPTY);
                 } else {
                     for (Message m : messages) msgModel.addElement(m);
-                    if (!populated) {
-                        remove(placeholder);
-                        add(scroll, BorderLayout.CENTER);
-                        populated = true;
-                    }
+                    bodyCards.show(body, CARD_MESSAGES);
                     SwingUtilities.invokeLater(() -> {
                         msgList.setFixedCellHeight(10);
                         msgList.setFixedCellHeight(-1);
@@ -2151,8 +2120,6 @@ public class ClientUI {
                         if (last >= 0) msgList.ensureIndexIsVisible(last);
                     });
                 }
-                revalidate();
-                repaint();
             }
         }
 
@@ -2165,7 +2132,7 @@ public class ClientUI {
         }
 
         private void buildLayout() {
-            searchField = makePlaceholderField("Search conversations...", 15);
+            searchField = new PlaceholderTextField("Search conversations...", 15);
             closeButton = new JButton("Close");
 
             setLayout(new BorderLayout());
@@ -2179,7 +2146,7 @@ public class ClientUI {
             viewerPanel = new ViewerPanel();
 
             JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, leftPanel, viewerPanel);
-            split.setDividerLocation(320);
+            split.setDividerLocation(Constants.ADMIN_SPLIT_DIVIDER_PX);
             split.setResizeWeight(0.0);
             add(split, BorderLayout.CENTER);
 
@@ -2199,23 +2166,18 @@ public class ClientUI {
         }
 
         private void wireSearchField() {
-            searchField.getDocument().addDocumentListener(new DocumentListener() {
-                @Override public void insertUpdate(DocumentEvent e) { filter(); }
-                @Override public void removeUpdate(DocumentEvent e) { filter(); }
-                @Override public void changedUpdate(DocumentEvent e) { filter(); }
+            searchField.getDocument().addDocumentListener(filteringListener(this::applyAdminSearchFilter));
+        }
 
-                private void filter() {
-                    String text = searchField.getText().toUpperCase();
-                    model.clear();
-                    for (ConversationMetadata item : controller.getFilteredAdminConversationSearch(text)) {
-                        model.addElement(item);
-                    }
-                }
-            });
+        private void applyAdminSearchFilter() {
+            String query = searchField.getText().toUpperCase();
+            model.clear();
+            for (ConversationMetadata item : controller.getFilteredAdminConversationSearch(query)) {
+                model.addElement(item);
+            }
         }
 
         private void wireListSelectionListener() {
-            // Selecting a row pulls the full conversation silently — no Join button.
             list.addListSelectionListener(e -> {
                 if (e.getValueIsAdjusting()) return;
                 ConversationMetadata sel = list.getSelectedValue();
@@ -2226,7 +2188,6 @@ public class ClientUI {
         }
 
         private void wireCloseButton() {
-            // Close button just disposes the dialog; existing windowClosed handler does cleanup.
             closeButton.addActionListener(e -> {
                 Window window = SwingUtilities.getWindowAncestor(this);
                 if (window != null) window.dispose();
@@ -2237,7 +2198,7 @@ public class ClientUI {
             return model;
         }
 
-        /** #193 entry point — called from ClientUI.showAdminConversationView. */
+        /** Called from ClientUI.showAdminConversationView. */
         public void loadConversation(Conversation conv) {
             viewerPanel.loadConversation(conv);
         }

--- a/src/server/DataManager.java
+++ b/src/server/DataManager.java
@@ -25,8 +25,6 @@ public class DataManager {
 
     private static final long WRITER_SLEEP_MS = 100L;
 
-    // --- Static counters (persisted in server_config.txt) ---
-
     /**
      * Authoritative monotonic message sequence counter; persisted under
      * {@code messageSequenceCounter} in {@code server_data/server_config.txt}.
@@ -38,8 +36,6 @@ public class DataManager {
      * {@code conversationIdCounter} in {@code server_data/server_config.txt}.
      */
     private static final AtomicLong conversationIdCounter = new AtomicLong(0);
-
-    // --- In-memory authoritative state ---
 
     private ConcurrentMap<String, User> usersByUserID;
     private ConcurrentMap<String, User> usersByLoginName;
@@ -55,8 +51,6 @@ public class DataManager {
     private ArrayList<String> authorizedAdminIds;
     private CopyOnWriteArrayList<UserInfo> directoryUserInfos;
 
-    // --- Paths & persistence bookkeeping (resolved at construction) ---
-
     /** Root for {@code server_data/}, {@code conversation_data/}, {@code user_data/}. */
     private final File dataRoot;
     private final File serverDataDir;
@@ -67,20 +61,12 @@ public class DataManager {
     private final File conversationDataDir;
     private final File userDataDir;
 
-    /**
-     * User ids whose {@link User} should be written on the next {@link #writeDirty()}.
-     * Backed by {@link ConcurrentHashMap#newKeySet()} (Java has no {@code ConcurrentHashSet}).
-     */
+    /** Backed by {@link ConcurrentHashMap#newKeySet()} (Java has no {@code ConcurrentHashSet}). */
     private final Set<String> dirtyUsers;
-    /**
-     * Conversation ids whose {@link Conversation} should be written on the next {@link #writeDirty()}.
-     */
     private final Set<Long> dirtyConversations;
 
     /** Background flush of dirty users/conversations every {@value #WRITER_SLEEP_MS} ms. */
     private final Thread writerThread;
-
-    // --- Constructor ---
 
     /**
      * @param dataRootPath path to the root directory for persisted state (absolute or relative).
@@ -91,22 +77,15 @@ public class DataManager {
      */
     public DataManager(String dataRootPath) {
         File root = new File(dataRootPath);
-        // root directory
         this.dataRoot = root;
-        // server data directory
         this.serverDataDir = new File(root, "server_data");
-        // authorized users and admins file
         this.authorizedIdsDir = new File(serverDataDir, "authorized_ids");
         this.authorizedUsersFile = new File(authorizedIdsDir, "authorized_users.txt");
         this.authorizedAdminsFile = new File(authorizedIdsDir, "authorized_admins.txt");
-        // sequential ID counter persistence file in server_data
         this.serverConfigFile = new File(serverDataDir, "server_config.txt");
-        // conversation data directory
         this.conversationDataDir = new File(root, "conversation_data");
-        // user data directory
         this.userDataDir = new File(root, "user_data");
 
-        // in-memory state
         this.usersByUserID = new ConcurrentHashMap<>();
         this.usersByLoginName = new ConcurrentHashMap<>();
         this.conversationIDsByUserID = new ConcurrentHashMap<>();
@@ -125,8 +104,6 @@ public class DataManager {
         t.start();
         this.writerThread = t;
     }
-
-    // --- Lifecycle (shutdown & background writer) ---
 
     public void close() {
         writerThread.interrupt();
@@ -169,30 +146,20 @@ public class DataManager {
         }
     }
 
-    // --- Monotonic ids / sequence (used by handlers) ---
-
-    /**
-     * Returns the next message sequence number. Thread-safe.
-     */
     static long nextMessageSequenceNumber() {
         return messageSequenceCounter.incrementAndGet();
     }
 
-    /** Returns the next conversation id (monotonic long). Thread-safe. */
     static long nextConversationId() {
         return conversationIdCounter.incrementAndGet();
     }
 
-    // --- Mark dirty & flush user/conversation blobs to disk ---
-
-    /** Marks the user's id dirty; {@link #writeDirty()} performs the actual file write. */
     private void persistUser(User user) {
         if (user != null && user.getUserId() != null) {
             dirtyUsers.add(user.getUserId());
         }
     }
 
-    /** Marks the conversation id dirty; {@link #writeDirty()} performs the actual file write. */
     private void persistConversation(Conversation conversation) {
         if (conversation != null) {
             dirtyConversations.add(conversation.getConversationId());
@@ -232,8 +199,6 @@ public class DataManager {
         }
     }
 
-    // --- Persistence file helpers (per-entity blobs under fixed dirs) ---
-
     private File userPersistenceFile(String userId) {
         return new File(userDataDir, userId + ".user");
     }
@@ -242,9 +207,6 @@ public class DataManager {
         return new File(conversationDataDir, Long.toString(conversationId) + ".conversation");
     }
 
-    // --- Server counter persistence (message sequence & conversation id) ---
-
-    // load the server counters from the server config file
     private void loadServerCounters() throws IOException {
         if (!serverConfigFile.isFile() || serverConfigFile.length() == 0) {
             return;
@@ -271,7 +233,6 @@ public class DataManager {
         }
     }
 
-    // persist the server counters to the server config file
     private void persistServerCounters() throws IOException {
         Properties props = new Properties();
         props.setProperty("messageSequenceCounter", Long.toString(messageSequenceCounter.get()));
@@ -280,8 +241,6 @@ public class DataManager {
             props.store(out, "Server counters (message sequence and conversation id)");
         }
     }
-
-    // --- Concurrent set factories & registration validation ---
 
     private Set<String> newConcurrentStringSet() {
         return ConcurrentHashMap.newKeySet();
@@ -295,8 +254,6 @@ public class DataManager {
         return Objects.equals(authorizedUsers.get(userID), userName);
     }
 
-    // --- Startup: load on-disk state into memory ---
-
     /*
      * On-disk layout (root may be e.g. "data" or "test_data"; children are identical):
      *   <dataRoot>/
@@ -309,14 +266,12 @@ public class DataManager {
      *     user_data/*.user
      */
     private void loadData() {
-        // these are assumed to exist, warn if not
         if (!dataRoot.exists()) System.err.println("WARNING: data directory not found");
         if (!serverDataDir.exists()) System.err.println("WARNING: server_data directory not found");
         if (!authorizedIdsDir.exists()) System.err.println("WARNING: authorized_ids directory not found");
         if (!authorizedAdminsFile.exists()) System.err.println("WARNING: authorized_admins.txt not found");
         if (!authorizedUsersFile.exists()) System.err.println("WARNING: authorized_users.txt not found");
 
-        // these are not assumed to exist, create if missing
         try {
             if (!serverConfigFile.exists()) serverConfigFile.createNewFile();
             if (!conversationDataDir.exists()) conversationDataDir.mkdirs();
@@ -325,7 +280,6 @@ public class DataManager {
             e.printStackTrace();
         }
 
-        // rehydrate authorized users and admins
         try {
             if (authorizedUsersFile.isFile()) {
                 loadAuthorizedUsersCsv(authorizedUsersFile);
@@ -336,8 +290,7 @@ public class DataManager {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        
-        // rehydrate Conversations (*.conversation — serialized Conversation per file)
+
         File[] listOfConversationFiles = conversationDataDir.listFiles(
             f -> f.isFile() && f.getName().endsWith(".conversation"));
         if (listOfConversationFiles == null) {
@@ -357,8 +310,7 @@ public class DataManager {
         }catch(ClassNotFoundException e) {
         	e.printStackTrace();
         }
-        
-        // rehydrate Users (*.user — serialized User per file)
+
         File[] listOfUserFiles = userDataDir.listFiles(
             f -> f.isFile() && f.getName().endsWith(".user"));
         if (listOfUserFiles == null) {
@@ -468,9 +420,6 @@ public class DataManager {
         return new ArrayList<>(directoryUserInfos);
     }
 
-    // --- Internal conversation mutation (messages) ---
-
-    // update a conversation with a new message in memory
     private void updateConversation(Message message) {
         Conversation conversation = conversationsByConversationID.get(message.getConversationId());
         if (conversation == null) {
@@ -481,8 +430,6 @@ public class DataManager {
             persistConversation(conversation);
         }
     }
-
-    // --- User ↔ conversation membership index ---
 
     /**
      * Bidirectional index update: {@code userId} is a member of {@code conversationId} in both
@@ -555,28 +502,22 @@ public class DataManager {
         return false;
     }
 
-    // --- Request handlers ---
-
-    // handle a register request
     public Response handleRegister(Request request) {
         RegisterCredentials registerCredentials = (RegisterCredentials) request.getPayload();
         String userId = registerCredentials.getUserId();
         String loginName = registerCredentials.getLoginName();
         String password = registerCredentials.getPassword();
         String name = registerCredentials.getName();
-        // check if the user is authorized
         if(!isValidUser(userId, name)) {
             return new Response(ResponseType.REGISTER_RESULT, new RegisterResult(shared.enums.RegisterStatus.USER_ID_INVALID));
         }
-        // check if the user ID is already taken
         if(usersByUserID.containsKey(userId)) {
             return new Response(ResponseType.REGISTER_RESULT, new RegisterResult(shared.enums.RegisterStatus.USER_ID_TAKEN));
         }
-        // check if the login name is valid (non-empty, alphanumeric/underscores/hyphens only)
+        // loginName forms a filesystem path; restrict to safe charset
         if(loginName == null || loginName.isBlank() || !loginName.matches("[a-zA-Z0-9_\\-]+")) {
             return new Response(ResponseType.REGISTER_RESULT, new RegisterResult(shared.enums.RegisterStatus.LOGIN_NAME_INVALID));
         }
-        // check if the login name is already taken
         if(usersByLoginName.containsKey(loginName)) {
             return new Response(ResponseType.REGISTER_RESULT, new RegisterResult(shared.enums.RegisterStatus.LOGIN_NAME_TAKEN));
         }
@@ -589,23 +530,19 @@ public class DataManager {
         return new Response(ResponseType.REGISTER_RESULT, new RegisterResult(shared.enums.RegisterStatus.SUCCESS, user.toUserInfo()));
     }
 
-    // handle a login request
     public Response handleLogin(Request request) {
         LoginCredentials loginCredentials = (LoginCredentials) request.getPayload();
         String loginName = loginCredentials.getLoginName();
         String password = loginCredentials.getPassword();
 
-        // check if the user exists
         if(!usersByLoginName.containsKey(loginName)) {
             return new Response(ResponseType.LOGIN_RESULT, new LoginResult(shared.enums.LoginStatus.NO_ACCOUNT_EXISTS));
         }
 
-        // check if the password is correct
         if(!usersByLoginName.get(loginName).getPassword().equals(password)) {
             return new Response(ResponseType.LOGIN_RESULT, new LoginResult(shared.enums.LoginStatus.INVALID_CREDENTIALS));
         }
 
-        // return the user's conversation list if the login is successful
         User user = usersByLoginName.get(loginName);
         String userID = user.getUserId();
         Set<Long> conversationIDs = conversationIDsByUserID.get(userID);
@@ -641,10 +578,6 @@ public class DataManager {
     }
 
     public Response handleSendMessage(Request request) {
-        // this method needs to do 3 things:
-        // 1. assign a sequence number and timestamp to the message
-        // 2. append this message to the appropriate conversation
-        // 3. return the message to the controller for subsequent distribution
         RawMessage rawMessage = (RawMessage) request.getPayload();
         String text = rawMessage.getText();
         long conversationId = rawMessage.getTargetConversationId();
@@ -666,13 +599,9 @@ public class DataManager {
      */
     public Response handleUpdateReadMessages(Request request) {
         UpdateReadMessages updateReadMessages = (UpdateReadMessages) request.getPayload();
-        // the conversation being updated
         long conversationID = updateReadMessages.getConversationID();
-        // last seen sequence number in that conversation
         long lastSeenSequenceNumber = updateReadMessages.getLastSeenSequenceNumber();
-        // the user updating the read messages
         User user = usersByUserID.get(request.getSenderId());
-        // update the user's last read sequence number for the conversation
         user.setLastRead(conversationID, lastSeenSequenceNumber);
         persistUser(user);
         UserInfo updated = user.toUserInfo();
@@ -823,7 +752,6 @@ public class DataManager {
         return conversationsByConversationID.get(conversationId);
     }
 
-    //Used to determine recipients for message and conversation distribution.
     public ArrayList<UserInfo> getParticipantList(long conversationId) {
         Conversation c = conversationsByConversationID.get(conversationId);
         if (c == null) {

--- a/src/server/DataManager.java
+++ b/src/server/DataManager.java
@@ -493,6 +493,54 @@ public class DataManager {
         }
     }
 
+    /**
+     * Discord-style "close DM" reactivation. If {@code convId} is a {@link ConversationType#PRIVATE}
+     * conversation whose only active participant is {@code senderId} and whose
+     * {@linkplain Conversation#getHistoricalParticipants() historical participants} contain a user
+     * not in the active roster, re-add that user to the active roster and re-link them in the
+     * server indices. Returns the reactivated user's id, or {@code null} if there is nothing to do.
+     * <p>
+     * Synchronizes on the {@link Conversation} so this is atomic against concurrent leave/send.
+     */
+    public String maybeReactivatePrivatePeerOnSend(long convId, String senderId) {
+        if (senderId == null) {
+            return null;
+        }
+        Conversation conversation = conversationsByConversationID.get(convId);
+        if (conversation == null || conversation.getType() != ConversationType.PRIVATE) {
+            return null;
+        }
+        synchronized (conversation) {
+            ArrayList<UserInfo> active = conversation.getParticipants();
+            if (active.size() != 1) {
+                return null;
+            }
+            if (!senderId.equals(active.get(0).getUserId())) {
+                return null;
+            }
+            UserInfo peer = null;
+            for (UserInfo u : conversation.getHistoricalParticipants()) {
+                if (u == null || u.getUserId() == null) {
+                    continue;
+                }
+                if (senderId.equals(u.getUserId())) {
+                    continue;
+                }
+                peer = u;
+                break;
+            }
+            if (peer == null) {
+                return null;
+            }
+            ArrayList<UserInfo> toAdd = new ArrayList<>();
+            toAdd.add(peer);
+            conversation.addParticipants(toAdd);
+            linkUserToConversation(peer.getUserId(), convId);
+            persistConversation(conversation);
+            return peer.getUserId();
+        }
+    }
+
     private static boolean containsParticipant(ArrayList<UserInfo> participants, String userId) {
         for (UserInfo p : participants) {
             if (p != null && p.getUserId() != null && userId.equals(p.getUserId())) {

--- a/src/server/DataManager.java
+++ b/src/server/DataManager.java
@@ -48,6 +48,9 @@ public class DataManager {
     /** Conversation id → user ids in that conversation. */
     private ConcurrentMap<Long, Set<String>> userIDsByConversationID;
     private ConcurrentMap<Long, Conversation> conversationsByConversationID;
+    /** Serializes check-then-put in {@link #handleCreateConversation} so concurrent
+     *  creates for the same PRIVATE pair cannot race past the duplicate-detection scan. */
+    private final Object createConversationLock = new Object();
     private Map<String, String> authorizedUsers;
     private ArrayList<String> authorizedAdminIds;
     private CopyOnWriteArrayList<UserInfo> directoryUserInfos;
@@ -611,13 +614,30 @@ public class DataManager {
         }
         ArrayList<Conversation> conversationList = new ArrayList<>();
         for (Long conversationId : conversationIDs) {
-            conversationList.add(conversationsByConversationID.get(conversationId));
+            Conversation c = conversationsByConversationID.get(conversationId);
+            if (c != null) {
+                conversationList.add(c);
+            }
         }
+        // #214: sort most-recent-first so the wire payload is deterministic.
+        // Tie-break by conversationId desc so empty conversations keep stable order.
+        conversationList.sort((a, b) -> {
+            int cmp = Long.compare(latestSequenceNumberOrId(b), latestSequenceNumberOrId(a));
+            if (cmp != 0) return cmp;
+            return Long.compare(b.getConversationId(), a.getConversationId());
+        });
         return new Response(ResponseType.LOGIN_RESULT, new LoginResult(
             shared.enums.LoginStatus.SUCCESS,
             user.toUserInfo(),
             conversationList,
             getDirectorySnapshot()));
+    }
+
+    private static long latestSequenceNumberOrId(Conversation c) {
+        if (c == null) return 0L;
+        ArrayList<Message> msgs = c.getMessages();
+        if (msgs == null || msgs.isEmpty()) return c.getConversationId();
+        return msgs.get(msgs.size() - 1).getSequenceNumber();
     }
 
     public Response handleSendMessage(Request request) {
@@ -666,13 +686,34 @@ public class DataManager {
         if (participants == null || participants.isEmpty()) {
             return null;
         }
-        long conversationId = nextConversationId();
-        // Derives PRIVATE vs GROUP from participant count; seeds historicalParticipants from this list.
-        Conversation conversation = new Conversation(conversationId, participants);
-        conversationsByConversationID.put(conversationId, conversation);
-        linkParticipantsToConversation(conversationId, conversation.getParticipants());
-        persistConversation(conversation);
-        return new Response(ResponseType.CONVERSATION, conversation);
+        synchronized (createConversationLock) {
+            // For PRIVATE (2-participant) creates, return the existing conversation if one already
+            // exists with the same active roster. Group dedupe is intentionally out of scope.
+            if (participants.size() == 2) {
+                String aId = participants.get(0) != null ? participants.get(0).getUserId() : null;
+                String bId = participants.get(1) != null ? participants.get(1).getUserId() : null;
+                if (aId != null && bId != null) {
+                    Set<Long> aConvIds = conversationIDsByUserID.getOrDefault(aId, Collections.emptySet());
+                    for (Long cid : aConvIds) {
+                        Conversation existing = conversationsByConversationID.get(cid);
+                        if (existing == null || existing.getType() != ConversationType.PRIVATE) {
+                            continue;
+                        }
+                        ArrayList<UserInfo> active = existing.getParticipants();
+                        if (containsParticipant(active, aId) && containsParticipant(active, bId)) {
+                            return new Response(ResponseType.CONVERSATION, existing);
+                        }
+                    }
+                }
+            }
+            long conversationId = nextConversationId();
+            // Derives PRIVATE vs GROUP from participant count; seeds historicalParticipants from this list.
+            Conversation conversation = new Conversation(conversationId, participants);
+            conversationsByConversationID.put(conversationId, conversation);
+            linkParticipantsToConversation(conversationId, conversation.getParticipants());
+            persistConversation(conversation);
+            return new Response(ResponseType.CONVERSATION, conversation);
+        }
     }
 
     public Response handleAddToConversation(Request request) {

--- a/src/server/ServerController.java
+++ b/src/server/ServerController.java
@@ -140,8 +140,33 @@ public class ServerController {
                 return dataManager.handleLogin(request);
             }
             case MESSAGE: {
+                // Discord-style "close DM" reactivation: if the sender is the lone active
+                // participant of a PRIVATE conversation whose peer previously left, re-add
+                // the peer BEFORE handleSendMessage so the appended message is delivered to
+                // the post-reactivation roster.
+                long messageConvId = ((shared.payload.RawMessage) request.getPayload()).getTargetConversationId();
+                String reactivatedPeerId = dataManager.maybeReactivatePrivatePeerOnSend(
+                        messageConvId, request.getSenderId());
                 Response response = dataManager.handleSendMessage(request);
-                broadcastResponse(request, response);
+                if (reactivatedPeerId != null
+                        && response != null
+                        && response.getPayload() instanceof Message) {
+                    // Push the full conversation (history + just-appended message) to the peer
+                    // so their client re-adds it to the list with full context.
+                    if (hasActiveSession(reactivatedPeerId)) {
+                        Conversation full = dataManager.getConversation(messageConvId);
+                        if (full != null) {
+                            responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(
+                                    reactivatedPeerId,
+                                    new Response(ResponseType.CONVERSATION, full)));
+                        }
+                    }
+                    // Skip the peer in the MESSAGE broadcast — the CONVERSATION push above
+                    // already contains this message; broadcasting MESSAGE too would duplicate.
+                    enqueueMessageBroadcastExcluding(request, response, reactivatedPeerId);
+                } else {
+                    broadcastResponse(request, response);
+                }
                 return response;
             }
             case UPDATE_READ_MESSAGES:
@@ -221,6 +246,27 @@ public class ServerController {
             if (participant == null || participant.getUserId() == null) continue;
             String id = participant.getUserId();
             if (id.equals(senderId)) continue; // sender already gets the response via direct return
+            if (hasActiveSession(id)) {
+                responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(id, response));
+            }
+        }
+    }
+
+    /**
+     * Variant of {@link #enqueueMessageBroadcast(Request, Response)} that also skips
+     * {@code excludeUserId}. Used when a reactivated peer is already receiving the message
+     * inside a {@link ResponseType#CONVERSATION} push and must not be sent the same message
+     * again as a {@link ResponseType#MESSAGE} broadcast.
+     */
+    private void enqueueMessageBroadcastExcluding(Request request, Response response, String excludeUserId) {
+        if (!(response.getPayload() instanceof Message)) return;
+        Message message = (Message) response.getPayload();
+        String senderId = request.getSenderId();
+        for (UserInfo participant : dataManager.getParticipantList(message.getConversationId())) {
+            if (participant == null || participant.getUserId() == null) continue;
+            String id = participant.getUserId();
+            if (id.equals(senderId)) continue;
+            if (id.equals(excludeUserId)) continue;
             if (hasActiveSession(id)) {
                 responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(id, response));
             }

--- a/src/shared/networking/ConnectionHandler.java
+++ b/src/shared/networking/ConnectionHandler.java
@@ -71,10 +71,6 @@ public class ConnectionHandler implements Runnable {
         this.serverController = serverController;
     }
 
-    // -------------------------------------------------------------------------
-    // Lifecycle
-    // -------------------------------------------------------------------------
-
     @Override
     public void run() {
         try {
@@ -110,7 +106,7 @@ public class ConnectionHandler implements Runnable {
      */
     public void close() {
         if (!closed.compareAndSet(false, true)) {
-            return; // already closed
+            return;
         }
         // Deregister session immediately so the server never routes to a dead handler.
         if (authenticated && userInfo != null) {
@@ -126,10 +122,6 @@ public class ConnectionHandler implements Runnable {
         }
     }
 
-    // -------------------------------------------------------------------------
-    // Public API
-    // -------------------------------------------------------------------------
-
     /**
      * Enqueue a {@link Response} for delivery to this client.
      * Thread-safe; may be called from any thread.
@@ -144,15 +136,10 @@ public class ConnectionHandler implements Runnable {
     public boolean isAuthenticated()     { return authenticated; }
     public long getLastPingReceived()    { return lastPingReceived; }
 
-    // -------------------------------------------------------------------------
-    // RequestListener — one thread per handler
-    // -------------------------------------------------------------------------
-
     class RequestListener implements Runnable {
         @Override
         public void run() {
             while (!closed.get() && !Thread.currentThread().isInterrupted()) {
-                // --- read ---
                 Object obj;
                 try {
                     obj = input.readObject();
@@ -182,7 +169,6 @@ public class ConnectionHandler implements Runnable {
 
                 Request request = (Request) obj;
 
-                // Update heartbeat timestamp for PING
                 if (request.getType() == RequestType.PING) {
                     lastPingReceived = System.currentTimeMillis();
                     // Heartbeat stays in transport layer: reply directly, skip app dispatch.
@@ -190,7 +176,6 @@ public class ConnectionHandler implements Runnable {
                     continue;
                 }
 
-                // --- dispatch ---
                 try {
                     Response response = serverController.processRequest(request);
                     handleSessionTransition(request, response);
@@ -235,16 +220,12 @@ public class ConnectionHandler implements Runnable {
         }
     }
 
-    // -------------------------------------------------------------------------
-    // ResponseSender — one thread per handler
-    // -------------------------------------------------------------------------
-
     class ResponseSender implements Runnable {
         @Override
         public void run() {
             while (!closed.get() && !Thread.currentThread().isInterrupted()) {
                 try {
-                    Response response = responseQueue.take(); // blocks until available
+                    Response response = responseQueue.take();
                     output.writeObject(response);
                     output.flush();
                     output.reset(); // prevent object-reference cache memory leak

--- a/src/shared/networking/ConnectionHandler.java
+++ b/src/shared/networking/ConnectionHandler.java
@@ -258,6 +258,11 @@ public class ConnectionHandler implements Runnable {
                     break;
                 }
             }
+            // Cascade writer exit into full shutdown so the session is deregistered from
+            // ServerController.activeSessions. Otherwise broadcasts keep being routed here
+            // and silently piling up in an undrained responseQueue until the read side
+            // notices EOF or the heartbeat times out.
+            close();
         }
     }
 }

--- a/src/shared/networking/User.java
+++ b/src/shared/networking/User.java
@@ -93,6 +93,17 @@ public class User implements Serializable {
         private final String userId;
         private final String name;
         private final UserType userType;
+        /**
+         * Read cursors per conversation. Concurrency contract:
+         *  - The {@code currentUser} reference in {@code client.ClientController} is volatile;
+         *    the response-listener thread always builds a fresh {@code UserInfo} (mutating its
+         *    map) before publishing the new reference. After publication, the map is mutated
+         *    only by EDT code paths (open-conversation, deferred-read replay, in-conversation
+         *    receive). No two threads write to the same map instance concurrently.
+         *  - {@link #getLastReadMap()} returns an unmodifiable view over the live map;
+         *    callers iterating off-EDT must defensive-copy first to avoid
+         *    {@link java.util.ConcurrentModificationException}.
+         */
         private final Map<Long, Long> lastRead;
 
         private UserInfo(String userId, String name, UserType userType, Map<Long, Long> lastRead) {

--- a/src/shared/payload/Conversation.java
+++ b/src/shared/payload/Conversation.java
@@ -4,10 +4,15 @@ import shared.networking.User.UserInfo;
 import shared.enums.ConversationType;
 import java.io.*;
 import java.util.ArrayList;
+import java.util.Comparator;
 
 
 public class Conversation implements ResponsePayload {
     private static final long serialVersionUID = 1L;
+
+    private static final Comparator<UserInfo> BY_NAME_THEN_ID =
+        Comparator.comparing(UserInfo::getName, String.CASE_INSENSITIVE_ORDER)
+                  .thenComparing(UserInfo::getUserId);
 
     private final long conversationId;
     private final ArrayList<Message> messages;
@@ -28,6 +33,7 @@ public class Conversation implements ResponsePayload {
         this.conversationId = conversationId;
         this.messages = new ArrayList<>();
         this.participants = new ArrayList<>(participants != null ? participants : new ArrayList<>());
+        this.participants.sort(BY_NAME_THEN_ID);
         this.historicalParticipants = new ArrayList<>(this.participants);
         this.type = this.participants.size() == 2 ? ConversationType.PRIVATE : ConversationType.GROUP;
     }
@@ -52,6 +58,10 @@ public class Conversation implements ResponsePayload {
             if (historicalParticipants != null) {
                 historicalParticipants.add(u);
             }
+        }
+        participants.sort(BY_NAME_THEN_ID);
+        if (historicalParticipants != null) {
+            historicalParticipants.sort(BY_NAME_THEN_ID);
         }
     }
 
@@ -119,5 +129,15 @@ public class Conversation implements ResponsePayload {
             e.printStackTrace();
         }
         return null;
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        if (participants != null) {
+            participants.sort(BY_NAME_THEN_ID);
+        }
+        if (historicalParticipants != null) {
+            historicalParticipants.sort(BY_NAME_THEN_ID);
+        }
     }
 }

--- a/src/shared/payload/Conversation.java
+++ b/src/shared/payload/Conversation.java
@@ -51,11 +51,11 @@ public class Conversation implements ResponsePayload {
             if (u == null || u.getUserId() == null) {
                 continue;
             }
-            if (indexOfParticipant(u.getUserId()) >= 0) {
-                continue;
+            if (indexOfParticipant(u.getUserId()) < 0) {
+                participants.add(u);
             }
-            participants.add(u);
-            if (historicalParticipants != null) {
+            if (historicalParticipants != null
+                    && indexOfHistoricalParticipant(u.getUserId()) < 0) {
                 historicalParticipants.add(u);
             }
         }
@@ -63,6 +63,19 @@ public class Conversation implements ResponsePayload {
         if (historicalParticipants != null) {
             historicalParticipants.sort(BY_NAME_THEN_ID);
         }
+    }
+
+    private int indexOfHistoricalParticipant(String userId) {
+        if (historicalParticipants == null) {
+            return -1;
+        }
+        for (int i = 0; i < historicalParticipants.size(); i++) {
+            UserInfo u = historicalParticipants.get(i);
+            if (u != null && userId.equals(u.getUserId())) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private int indexOfParticipant(String userId) {

--- a/src/shared/payload/ConversationMetadata.java
+++ b/src/shared/payload/ConversationMetadata.java
@@ -3,9 +3,14 @@ package shared.payload;
 import shared.networking.User.UserInfo;
 import shared.enums.ConversationType;
 import java.util.ArrayList;
+import java.util.Comparator;
 
 public class ConversationMetadata implements ResponsePayload {
     private static final long serialVersionUID = 1L;
+
+    private static final Comparator<UserInfo> BY_NAME_THEN_ID =
+        Comparator.comparing(UserInfo::getName, String.CASE_INSENSITIVE_ORDER)
+                  .thenComparing(UserInfo::getUserId);
 
     private final long conversationId;
     private final ArrayList<UserInfo> participants;
@@ -27,7 +32,9 @@ public class ConversationMetadata implements ResponsePayload {
                                 int unreadCount, String displayName) {
         this.conversationId = c_id;
         this.participants = p != null ? new ArrayList<>(p) : new ArrayList<>();
+        this.participants.sort(BY_NAME_THEN_ID);
         this.historicalParticipants = hp != null ? new ArrayList<>(hp) : new ArrayList<>();
+        this.historicalParticipants.sort(BY_NAME_THEN_ID);
         this.type = t;
         this.lastMessagePreview = lastMessagePreview;
         this.lastMessageTimestampMillis = lastMessageTimestampMillis;

--- a/test/client/ClientControllerLastReadMergeTest.java
+++ b/test/client/ClientControllerLastReadMergeTest.java
@@ -1,0 +1,133 @@
+package client;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import shared.enums.LoginStatus;
+import shared.enums.ResponseType;
+import shared.networking.Response;
+import shared.networking.User.UserInfo;
+import shared.networking.fixtures.NetworkingSeedData;
+import shared.payload.LoginResult;
+import shared.payload.ReadMessagesUpdated;
+
+import javax.swing.SwingUtilities;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Regression tests for issue #209 — verifies {@code handleReadMessagesUpdatedResponse}
+ * merges per-conversation lastRead pointers instead of replacing the {@link UserInfo}
+ * wholesale. Pre-fix, an ack for one conversation wiped optimistic advances for
+ * other conversations whose acks had not yet returned.
+ */
+@Timeout(value = 10, unit = TimeUnit.SECONDS)
+class ClientControllerLastReadMergeTest {
+
+    private static ClientController headless() {
+        return new ClientController("localhost", 0, null) {
+            @Override
+            void processResponse(Response response) {
+                super.processResponse(response);
+                flushEdt();
+            }
+        };
+    }
+
+    private static void flushEdt() {
+        try {
+            SwingUtilities.invokeAndWait(() -> {});
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to flush EDT", e);
+        }
+    }
+
+    private static Response loginAlice() {
+        return new Response(ResponseType.LOGIN_RESULT,
+                new LoginResult(LoginStatus.SUCCESS,
+                        NetworkingSeedData.aliceInfo(),
+                        new ArrayList<>(),
+                        new ArrayList<>()));
+    }
+
+    /** Builds a fresh server-snapshot UserInfo for Alice with the given (convId,seq) entry. */
+    private static UserInfo aliceServerSnapshotWithRead(long convId, long seq) {
+        UserInfo u = NetworkingSeedData.aliceInfo();
+        u.setLastRead(convId, seq);
+        return u;
+    }
+
+    @Test
+    void merge_preservesLocalAdvanceForOtherConversation() {
+        ClientController c = headless();
+        c.processResponse(loginAlice());
+
+        // Optimistic local advance for two conversations.
+        c.getCurrentUserInfo().setLastRead(100L, 5L);
+        c.getCurrentUserInfo().setLastRead(200L, 7L);
+
+        // Server ack arrives for conv 100 only — server snapshot has no entry for 200.
+        Response ack = new Response(ResponseType.READ_MESSAGES_UPDATED,
+                new ReadMessagesUpdated(aliceServerSnapshotWithRead(100L, 5L)));
+        c.processResponse(ack);
+
+        UserInfo merged = c.getCurrentUserInfo();
+        assertEquals(5L, merged.getLastRead(100L), "ack value retained for the acked conversation");
+        assertEquals(7L, merged.getLastRead(200L), "local advance for unrelated conversation preserved");
+    }
+
+    @Test
+    void merge_serverAheadWins() {
+        ClientController c = headless();
+        c.processResponse(loginAlice());
+        c.getCurrentUserInfo().setLastRead(100L, 3L);
+
+        Response ack = new Response(ResponseType.READ_MESSAGES_UPDATED,
+                new ReadMessagesUpdated(aliceServerSnapshotWithRead(100L, 9L)));
+        c.processResponse(ack);
+
+        assertEquals(9L, c.getCurrentUserInfo().getLastRead(100L),
+                "server snapshot is ahead — local pointer must catch up");
+    }
+
+    @Test
+    void merge_localAheadWins() {
+        ClientController c = headless();
+        c.processResponse(loginAlice());
+        c.getCurrentUserInfo().setLastRead(100L, 12L);
+
+        Response ack = new Response(ResponseType.READ_MESSAGES_UPDATED,
+                new ReadMessagesUpdated(aliceServerSnapshotWithRead(100L, 10L)));
+        c.processResponse(ack);
+
+        assertEquals(12L, c.getCurrentUserInfo().getLastRead(100L),
+                "local advance must not regress when server snapshot is behind");
+    }
+
+    @Test
+    void merge_nullPayloadIsNoOp() {
+        ClientController c = headless();
+        c.processResponse(loginAlice());
+        UserInfo before = c.getCurrentUserInfo();
+
+        Response ack = new Response(ResponseType.READ_MESSAGES_UPDATED,
+                new ReadMessagesUpdated(null));
+        c.processResponse(ack);
+
+        assertSame(before, c.getCurrentUserInfo(),
+                "null updated UserInfo must leave currentUser untouched");
+    }
+
+    @Test
+    void merge_loggedOutDoesNotNpe() {
+        ClientController c = headless();
+        // No prior login — currentUser is null.
+        Response ack = new Response(ResponseType.READ_MESSAGES_UPDATED,
+                new ReadMessagesUpdated(aliceServerSnapshotWithRead(100L, 5L)));
+
+        assertDoesNotThrow(() -> c.processResponse(ack));
+    }
+}

--- a/test/client/ClientControllerTest.java
+++ b/test/client/ClientControllerTest.java
@@ -542,11 +542,11 @@ class ClientControllerTest {
     // =========================================================================
 
     @Test
-    void inboundMessage_openConv_windowActive_advancesLastReadAndEnqueuesUpdate() {
+    void inboundMessage_openConv_inputFocused_advancesLastReadAndEnqueuesUpdate() {
         ClientController c = headless();
         c.processResponse(loginSuccessAliceWithConv());
         c.setCurrentConversationId(100L);
-        assertTrue(c.isWindowActive(), "default windowActive=true");
+        assertTrue(c.isInputFocused(), "default inputFocused=true");
 
         int baseline = c.requestQueueDepthForTesting();
         c.processResponse(messageFor(100L, "hi"));
@@ -560,20 +560,20 @@ class ClientControllerTest {
     }
 
     @Test
-    void inboundMessage_openConv_windowInactive_doesNotEnqueueAndBuffersDeferred() {
+    void inboundMessage_openConv_inputUnfocused_doesNotEnqueueAndBuffersDeferred() {
         ClientController c = headless();
         c.processResponse(loginSuccessAliceWithConv());
         c.setCurrentConversationId(100L);
-        c.setWindowActive(false);
+        c.setInputFocused(false);
 
         long lastReadBefore = c.getCurrentUserInfo().getLastRead(100L);
         int baseline = c.requestQueueDepthForTesting();
         c.processResponse(messageFor(100L, "hi"));
 
         assertEquals(baseline, c.requestQueueDepthForTesting(),
-                "no UPDATE_READ_MESSAGES while window inactive");
+                "no UPDATE_READ_MESSAGES while input unfocused");
         assertEquals(lastReadBefore, c.getCurrentUserInfo().getLastRead(100L),
-                "lastRead must not advance while window inactive");
+                "lastRead must not advance while input unfocused");
     }
 
     @Test
@@ -581,7 +581,7 @@ class ClientControllerTest {
         ClientController c = headless();
         c.processResponse(loginSuccessAliceWithConv());
         c.setCurrentConversationId(100L);
-        c.setWindowActive(false);
+        c.setInputFocused(false);
 
         // 5 messages at seqs 1..5 buffer to a single max-seq=5 deferred entry.
         Message m1 = new Message("a", 1L, new Date(), NetworkingSeedData.BOB_ID, 100L);
@@ -596,7 +596,7 @@ class ClientControllerTest {
         c.processResponse(new Response(ResponseType.MESSAGE, m5));
 
         int baseline = c.requestQueueDepthForTesting();
-        c.setWindowActive(true);
+        c.setInputFocused(true);
         c.replayReadAdvanceIfNeeded();
 
         assertEquals(baseline + 1, c.requestQueueDepthForTesting(),
@@ -623,7 +623,7 @@ class ClientControllerTest {
         ClientController c = headless();
         c.processResponse(loginSuccessAliceWithConv());
         c.setCurrentConversationId(100L);
-        c.setWindowActive(false);
+        c.setInputFocused(false);
 
         // Buffer one inbound seq=2.
         Message m = new Message("x", 2L, new Date(), NetworkingSeedData.BOB_ID, 100L);
@@ -633,13 +633,78 @@ class ClientControllerTest {
         c.getCurrentUserInfo().setLastRead(100L, 99L);
 
         int baseline = c.requestQueueDepthForTesting();
-        c.setWindowActive(true);
+        c.setInputFocused(true);
         c.replayReadAdvanceIfNeeded();
 
         assertEquals(baseline, c.requestQueueDepthForTesting(),
                 "no request when lastRead already exceeds the deferred max");
         assertEquals(99L, c.getCurrentUserInfo().getLastRead(100L),
                 "lastRead must not regress");
+    }
+
+    @Test
+    void inputUnfocusedButWindowActive_doesNotAdvance() {
+        ClientController c = headless();
+        c.processResponse(loginSuccessAliceWithConv());
+        c.setCurrentConversationId(100L);
+        // Window active but input not focused — the regression guard for the
+        // original bug (sidebar/button has focus while conversation is open).
+        c.setWindowActive(true);
+        c.setInputFocused(false);
+
+        long lastReadBefore = c.getCurrentUserInfo().getLastRead(100L);
+        int baseline = c.requestQueueDepthForTesting();
+        c.processResponse(messageFor(100L, "hi"));
+
+        assertEquals(baseline, c.requestQueueDepthForTesting(),
+                "windowActive alone must not advance read-ack");
+        assertEquals(lastReadBefore, c.getCurrentUserInfo().getLastRead(100L),
+                "lastRead must not advance without input focus");
+    }
+
+    @Test
+    void activationRestoredFocus_keepsDeferred_afterUserClickedAway() {
+        // Regression for the focus-restoration bug: after the user clicks the
+        // input then clicks away, subsequent inbound peer messages call
+        // frame.toFront() which reactivates the window. Swing then auto-restores
+        // focus to messageInputField. The UI-level FocusListener filters this
+        // (Cause.ACTIVATION) so setInputFocused(true) is NOT called. This test
+        // is the controller-level contract: while inputFocused stays false,
+        // inbound messages must defer and the local lastRead must not advance.
+        ClientController c = headless();
+        c.processResponse(loginSuccessAliceWithConv());
+        c.setCurrentConversationId(100L);
+
+        // User clicks input then clicks away.
+        c.setInputFocused(true);
+        c.setInputFocused(false);
+        assertFalse(c.isInputFocused());
+
+        long lastReadBefore = c.getCurrentUserInfo().getLastRead(100L);
+        int baseline = c.requestQueueDepthForTesting();
+
+        // Inbound peer message arrives while input is unfocused.
+        c.processResponse(messageFor(100L, "1"));
+
+        assertEquals(baseline, c.requestQueueDepthForTesting(),
+                "no UPDATE_READ_MESSAGES while input unfocused");
+        assertEquals(lastReadBefore, c.getCurrentUserInfo().getLastRead(100L),
+                "lastRead must not advance while input unfocused");
+        assertFalse(c.isInputFocused(),
+                "controller-level flag stays false; UI filters ACTIVATION-cause focus events");
+    }
+
+    @Test
+    void logoutResetsInputFocused() {
+        ClientController c = headless();
+        c.processResponse(loginSuccessAliceWithConv());
+        c.setInputFocused(false);
+        assertFalse(c.isInputFocused());
+
+        c.logout();
+
+        assertTrue(c.isInputFocused(),
+                "logout must reset inputFocused to constructor default");
     }
 
     // =========================================================================

--- a/test/client/ClientControllerTest.java
+++ b/test/client/ClientControllerTest.java
@@ -444,4 +444,311 @@ class ClientControllerTest {
         c.processResponse(adminConversationResult());
         assertEquals(0, c.getFilteredAdminConversationSearch("nosuch99").size());
     }
+
+    // =========================================================================
+    // 13. isUnread (issue #209) — pure helper used by the conversation cell renderer
+    // =========================================================================
+
+    @Test
+    void isUnread_nullArguments_returnsFalse() {
+        assertFalse(ClientController.isUnread(null, alice()));
+        assertFalse(ClientController.isUnread(conv(1L, alice(), bob()), null));
+        assertFalse(ClientController.isUnread(null, null));
+    }
+
+    @Test
+    void isUnread_emptyConversation_returnsFalse() {
+        assertFalse(ClientController.isUnread(conv(1L, alice(), bob()), alice()));
+    }
+
+    @Test
+    void isUnread_lastReadMatchesLatest_returnsFalse() {
+        Conversation c = conv(1L, alice(), bob());
+        c.append(new Message("hi", 5L, new Date(), NetworkingSeedData.BOB_ID, 1L));
+        UserInfo viewer = alice();
+        viewer.setLastRead(1L, 5L);
+        assertFalse(ClientController.isUnread(c, viewer));
+    }
+
+    @Test
+    void isUnread_lastReadAheadOfLatest_returnsFalse() {
+        // Stale local cursor ahead of the latest known message; treat as read.
+        Conversation c = conv(1L, alice(), bob());
+        c.append(new Message("hi", 3L, new Date(), NetworkingSeedData.BOB_ID, 1L));
+        UserInfo viewer = alice();
+        viewer.setLastRead(1L, 99L);
+        assertFalse(ClientController.isUnread(c, viewer));
+    }
+
+    @Test
+    void isUnread_lastReadTrailsLatest_returnsTrue() {
+        Conversation c = conv(1L, alice(), bob());
+        c.append(new Message("hi", 5L, new Date(), NetworkingSeedData.BOB_ID, 1L));
+        UserInfo viewer = alice();
+        viewer.setLastRead(1L, 4L);
+        assertTrue(ClientController.isUnread(c, viewer));
+    }
+
+    @Test
+    void isUnread_noLastReadEntry_treatsAsZero() {
+        Conversation c = conv(1L, alice(), bob());
+        c.append(new Message("hi", 1L, new Date(), NetworkingSeedData.BOB_ID, 1L));
+        // alice() default lastRead map empty; getLastRead(1L) returns 0L; latestSeq=1 → unread
+        assertTrue(ClientController.isUnread(c, alice()));
+    }
+
+    // =========================================================================
+    // 15. isMessageUnread — per-message dot predicate paired with the open-conv
+    //     snapshot so the per-message renderer and sidebar (isUnread) stay aligned.
+    // =========================================================================
+
+    private static Message msg(long seq) {
+        return new Message("x", seq, new Date(), NetworkingSeedData.BOB_ID, 100L);
+    }
+
+    @Test
+    void isMessageUnread_nullMessage_returnsFalse() {
+        assertFalse(ClientController.isMessageUnread(null, 0L));
+        assertFalse(ClientController.isMessageUnread(null, 99L));
+    }
+
+    @Test
+    void isMessageUnread_seqAboveSnapshot_returnsTrue() {
+        assertTrue(ClientController.isMessageUnread(msg(5L), 4L));
+    }
+
+    @Test
+    void isMessageUnread_seqEqualsSnapshot_returnsFalse() {
+        // Boundary: snapshot pointer covers seqs <= it; exactly-equal means already read.
+        assertFalse(ClientController.isMessageUnread(msg(5L), 5L));
+    }
+
+    @Test
+    void isMessageUnread_seqBelowSnapshot_returnsFalse() {
+        assertFalse(ClientController.isMessageUnread(msg(3L), 5L));
+    }
+
+    @Test
+    void isMessageUnread_zeroSnapshot_unreadForAnyPositiveSeq() {
+        // Open-time snapshot is 0 (no prior read pointer); first message is unread.
+        assertTrue(ClientController.isMessageUnread(msg(1L), 0L));
+    }
+
+    // =========================================================================
+    // 16. Window-focus gate (Fix A) — inbound messages while the window is
+    //     inactive must NOT advance the read pointer or send UPDATE_READ_MESSAGES.
+    //     They are buffered per-conversation and replayed (coalesced to max seq)
+    //     on window activation.
+    // =========================================================================
+
+    @Test
+    void inboundMessage_openConv_windowActive_advancesLastReadAndEnqueuesUpdate() {
+        ClientController c = headless();
+        c.processResponse(loginSuccessAliceWithConv());
+        c.setCurrentConversationId(100L);
+        assertTrue(c.isWindowActive(), "default windowActive=true");
+
+        int baseline = c.requestQueueDepthForTesting();
+        c.processResponse(messageFor(100L, "hi"));
+
+        assertEquals(baseline + 1, c.requestQueueDepthForTesting());
+        Request last = c.peekLastRequestForTesting();
+        assertNotNull(last);
+        assertEquals(RequestType.UPDATE_READ_MESSAGES, last.getType());
+        // optimistic local advance
+        assertTrue(c.getCurrentUserInfo().getLastRead(100L) >= 1L);
+    }
+
+    @Test
+    void inboundMessage_openConv_windowInactive_doesNotEnqueueAndBuffersDeferred() {
+        ClientController c = headless();
+        c.processResponse(loginSuccessAliceWithConv());
+        c.setCurrentConversationId(100L);
+        c.setWindowActive(false);
+
+        long lastReadBefore = c.getCurrentUserInfo().getLastRead(100L);
+        int baseline = c.requestQueueDepthForTesting();
+        c.processResponse(messageFor(100L, "hi"));
+
+        assertEquals(baseline, c.requestQueueDepthForTesting(),
+                "no UPDATE_READ_MESSAGES while window inactive");
+        assertEquals(lastReadBefore, c.getCurrentUserInfo().getLastRead(100L),
+                "lastRead must not advance while window inactive");
+    }
+
+    @Test
+    void replayReadAdvance_drainsDeferredAndCoalescesToMaxSeq() {
+        ClientController c = headless();
+        c.processResponse(loginSuccessAliceWithConv());
+        c.setCurrentConversationId(100L);
+        c.setWindowActive(false);
+
+        // 5 messages at seqs 1..5 buffer to a single max-seq=5 deferred entry.
+        Message m1 = new Message("a", 1L, new Date(), NetworkingSeedData.BOB_ID, 100L);
+        Message m2 = new Message("b", 2L, new Date(), NetworkingSeedData.BOB_ID, 100L);
+        Message m3 = new Message("c", 3L, new Date(), NetworkingSeedData.BOB_ID, 100L);
+        Message m4 = new Message("d", 4L, new Date(), NetworkingSeedData.BOB_ID, 100L);
+        Message m5 = new Message("e", 5L, new Date(), NetworkingSeedData.BOB_ID, 100L);
+        c.processResponse(new Response(ResponseType.MESSAGE, m1));
+        c.processResponse(new Response(ResponseType.MESSAGE, m2));
+        c.processResponse(new Response(ResponseType.MESSAGE, m3));
+        c.processResponse(new Response(ResponseType.MESSAGE, m4));
+        c.processResponse(new Response(ResponseType.MESSAGE, m5));
+
+        int baseline = c.requestQueueDepthForTesting();
+        c.setWindowActive(true);
+        c.replayReadAdvanceIfNeeded();
+
+        assertEquals(baseline + 1, c.requestQueueDepthForTesting(),
+                "5-msg burst must coalesce into exactly one UPDATE_READ_MESSAGES");
+        Request last = c.peekLastRequestForTesting();
+        assertEquals(RequestType.UPDATE_READ_MESSAGES, last.getType());
+        assertEquals(5L, c.getCurrentUserInfo().getLastRead(100L),
+                "lastRead advances to max deferred seq");
+    }
+
+    @Test
+    void replayReadAdvance_emptyBuffer_isNoOp() {
+        ClientController c = headless();
+        c.processResponse(loginSuccessAliceWithConv());
+        c.setCurrentConversationId(100L);
+
+        int baseline = c.requestQueueDepthForTesting();
+        assertDoesNotThrow(c::replayReadAdvanceIfNeeded);
+        assertEquals(baseline, c.requestQueueDepthForTesting());
+    }
+
+    @Test
+    void replayReadAdvance_skipsConvsWhereLastReadAlreadyAhead() {
+        ClientController c = headless();
+        c.processResponse(loginSuccessAliceWithConv());
+        c.setCurrentConversationId(100L);
+        c.setWindowActive(false);
+
+        // Buffer one inbound seq=2.
+        Message m = new Message("x", 2L, new Date(), NetworkingSeedData.BOB_ID, 100L);
+        c.processResponse(new Response(ResponseType.MESSAGE, m));
+
+        // Independently push lastRead ahead of the buffered max.
+        c.getCurrentUserInfo().setLastRead(100L, 99L);
+
+        int baseline = c.requestQueueDepthForTesting();
+        c.setWindowActive(true);
+        c.replayReadAdvanceIfNeeded();
+
+        assertEquals(baseline, c.requestQueueDepthForTesting(),
+                "no request when lastRead already exceeds the deferred max");
+        assertEquals(99L, c.getCurrentUserInfo().getLastRead(100L),
+                "lastRead must not regress");
+    }
+
+    // =========================================================================
+    // 17. unreadCount (Fix D) — sidebar badge backing function
+    // =========================================================================
+
+    @Test
+    void unreadCount_nullArguments_returnZero() {
+        Conversation c = conv(100L, alice());
+        assertEquals(0, ClientController.unreadCount(null, alice()));
+        assertEquals(0, ClientController.unreadCount(c, null));
+        assertEquals(0, ClientController.unreadCount(null, null));
+    }
+
+    @Test
+    void unreadCount_emptyConversation_returnsZero() {
+        Conversation c = conv(100L, alice());
+        assertEquals(0, ClientController.unreadCount(c, alice()));
+    }
+
+    @Test
+    void unreadCount_lastReadAtLatest_returnsZero() {
+        Conversation c = conv(100L, alice());
+        c.append(new Message("a", 1L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.append(new Message("b", 2L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.append(new Message("c", 3L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        UserInfo me = alice();
+        me.setLastRead(100L, 3L);
+        assertEquals(0, ClientController.unreadCount(c, me));
+    }
+
+    @Test
+    void unreadCount_zeroLastRead_returnsAll() {
+        Conversation c = conv(100L, alice());
+        c.append(new Message("a", 1L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.append(new Message("b", 2L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.append(new Message("c", 3L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.append(new Message("d", 4L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.append(new Message("e", 5L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        // alice's lastRead map empty → getLastRead(100L) == 0L
+        assertEquals(5, ClientController.unreadCount(c, alice()));
+    }
+
+    @Test
+    void unreadCount_partialRead_returnsRemainder() {
+        Conversation c = conv(100L, alice());
+        c.append(new Message("a", 1L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.append(new Message("b", 2L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.append(new Message("c", 3L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.append(new Message("d", 4L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.append(new Message("e", 5L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        UserInfo me = alice();
+        me.setLastRead(100L, 2L);
+        assertEquals(3, ClientController.unreadCount(c, me));
+    }
+
+    @Test
+    void unreadCount_staleLastReadAhead_returnsZero() {
+        Conversation c = conv(100L, alice());
+        c.append(new Message("a", 1L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.append(new Message("b", 2L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        UserInfo me = alice();
+        me.setLastRead(100L, 99L); // stale pointer ahead of latest
+        assertEquals(0, ClientController.unreadCount(c, me));
+    }
+
+    // =========================================================================
+    // 18. getConversationSnapshotForOpen (Fix E2) — race-free open capture
+    // =========================================================================
+
+    @Test
+    void getConversationSnapshotForOpen_returnsAtomicPair() {
+        ClientController c = headless();
+        c.processResponse(loginSuccessAliceWithConv()); // conv id=100, no messages
+        c.setCurrentConversationId(100L);
+        // Stage one already-seen message and set lastRead to it.
+        Conversation live = c.getCurrentConversation();
+        assertNotNull(live);
+        live.append(new Message("seen", 5L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.getCurrentUserInfo().setLastRead(100L, 5L);
+
+        ClientController.ConversationOpenSnapshot snap =
+                c.getConversationSnapshotForOpen(100L);
+        assertNotNull(snap);
+        assertSame(live, snap.conversation, "snapshot exposes the live Conversation reference");
+        assertEquals(5L, snap.lastReadAtOpen);
+        assertEquals(1, snap.messages.size());
+        assertEquals(5L, snap.messages.get(0).getSequenceNumber());
+
+        // Mutate the underlying conversation AFTER capture; snapshot must not change.
+        live.append(new Message("after", 6L, new Date(), NetworkingSeedData.BOB_ID, 100L));
+        c.getCurrentUserInfo().setLastRead(100L, 6L);
+        assertEquals(5L, snap.lastReadAtOpen, "lastReadAtOpen is frozen at capture time");
+        assertEquals(1, snap.messages.size(), "messages list is a defensive copy");
+    }
+
+    @Test
+    void getConversationSnapshotForOpen_unknownConv_returnsNull() {
+        ClientController c = headless();
+        c.processResponse(loginSuccessAliceWithConv());
+        assertNull(c.getConversationSnapshotForOpen(99999L),
+                "snapshot for an unknown conversation id is null");
+    }
+
+    @Test
+    void getConversationSnapshotForOpen_notLoggedIn_returnsNull() {
+        ClientController c = headless();
+        // No login performed → currentUser is null.
+        assertNull(c.getConversationSnapshotForOpen(100L),
+                "snapshot before login is null");
+    }
 }

--- a/test/client/ClientControllerTest.java
+++ b/test/client/ClientControllerTest.java
@@ -707,11 +707,11 @@ class ClientControllerTest {
     }
 
     // =========================================================================
-    // 18. getConversationSnapshotForOpen (Fix E2) — race-free open capture
+    // 18. openConversationAtomically (Fix E2) — race-free open capture
     // =========================================================================
 
     @Test
-    void getConversationSnapshotForOpen_returnsAtomicPair() {
+    void openConversationAtomically_returnsAtomicPair() {
         ClientController c = headless();
         c.processResponse(loginSuccessAliceWithConv()); // conv id=100, no messages
         c.setCurrentConversationId(100L);
@@ -722,7 +722,7 @@ class ClientControllerTest {
         c.getCurrentUserInfo().setLastRead(100L, 5L);
 
         ClientController.ConversationOpenSnapshot snap =
-                c.getConversationSnapshotForOpen(100L);
+                c.openConversationAtomically(100L);
         assertNotNull(snap);
         assertSame(live, snap.conversation, "snapshot exposes the live Conversation reference");
         assertEquals(5L, snap.lastReadAtOpen);
@@ -737,18 +737,18 @@ class ClientControllerTest {
     }
 
     @Test
-    void getConversationSnapshotForOpen_unknownConv_returnsNull() {
+    void openConversationAtomically_unknownConv_returnsNull() {
         ClientController c = headless();
         c.processResponse(loginSuccessAliceWithConv());
-        assertNull(c.getConversationSnapshotForOpen(99999L),
+        assertNull(c.openConversationAtomically(99999L),
                 "snapshot for an unknown conversation id is null");
     }
 
     @Test
-    void getConversationSnapshotForOpen_notLoggedIn_returnsNull() {
+    void openConversationAtomically_notLoggedIn_returnsNull() {
         ClientController c = headless();
         // No login performed → currentUser is null.
-        assertNull(c.getConversationSnapshotForOpen(100L),
+        assertNull(c.openConversationAtomically(100L),
                 "snapshot before login is null");
     }
 }

--- a/test/server/DataManagerLoginConversationOrderTest.java
+++ b/test/server/DataManagerLoginConversationOrderTest.java
@@ -1,0 +1,210 @@
+package server;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import shared.enums.LoginStatus;
+import shared.enums.RegisterStatus;
+import shared.enums.RequestType;
+import shared.enums.ResponseType;
+import shared.enums.UserType;
+import shared.networking.Request;
+import shared.networking.Response;
+import shared.networking.User;
+import shared.payload.Conversation;
+import shared.payload.CreateConversationPayload;
+import shared.payload.LoginCredentials;
+import shared.payload.LoginResult;
+import shared.payload.Message;
+import shared.payload.RawMessage;
+import shared.payload.RegisterCredentials;
+import shared.payload.RegisterResult;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for issue #214 — verifies {@link DataManager#handleLogin} returns the
+ * caller's conversation list in a deterministic, most-recent-first order. The pre-fix path
+ * iterated a {@code Set<Long>} so order varied across JVM runs and across successive logins.
+ */
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+public class DataManagerLoginConversationOrderTest {
+
+    private static final String TEST_DATA_DIR_NAME = "test_data";
+
+    @TempDir
+    Path tempRoot;
+
+    private DataManager dm;
+
+    @BeforeEach
+    void initLayout() throws IOException {
+        Path testDataRoot = tempRoot.resolve(TEST_DATA_DIR_NAME);
+        prepareMinimalDataTree(testDataRoot);
+        dm = new DataManager(testDataRoot.toString());
+    }
+
+    @AfterEach
+    void shutdown() {
+        if (dm != null) {
+            dm.close();
+            dm = null;
+        }
+    }
+
+    private static void prepareMinimalDataTree(Path root) throws IOException {
+        Path serverData = root.resolve("server_data");
+        Path authorizedIds = serverData.resolve("authorized_ids");
+        Files.createDirectories(authorizedIds);
+        Files.writeString(authorizedIds.resolve("authorized_users.txt"), """
+                u1,Alice
+                u2,Bob
+                u3,Carol
+                u4,Dan
+                u5,Eve
+                """);
+        Files.writeString(authorizedIds.resolve("authorized_admins.txt"), "");
+        Files.writeString(serverData.resolve("server_config.txt"), "");
+        Files.createDirectories(root.resolve("conversation_data"));
+        Files.createDirectories(root.resolve("user_data"));
+    }
+
+    private static User.UserInfo ui(String userId, String displayName) {
+        return new User(userId, displayName, userId + "_login", "pw", UserType.USER).toUserInfo();
+    }
+
+    private static ArrayList<User.UserInfo> roster(User.UserInfo... parts) {
+        ArrayList<User.UserInfo> list = new ArrayList<>();
+        for (User.UserInfo u : parts) list.add(u);
+        return list;
+    }
+
+    private void registerAll() {
+        RegisterCredentials[] regs = new RegisterCredentials[]{
+                new RegisterCredentials("u1", "alice", "p1", "Alice"),
+                new RegisterCredentials("u2", "bob",   "p2", "Bob"),
+                new RegisterCredentials("u3", "carol", "p3", "Carol"),
+                new RegisterCredentials("u4", "dan",   "p4", "Dan"),
+                new RegisterCredentials("u5", "eve",   "p5", "Eve"),
+        };
+        for (RegisterCredentials rc : regs) {
+            Response r = dm.handleRegister(new Request(RequestType.REGISTER, rc, null));
+            assertEquals(RegisterStatus.SUCCESS,
+                    ((RegisterResult) r.getPayload()).getRegisterStatus(),
+                    "register " + rc.getUserId());
+        }
+    }
+
+    private LoginResult loginAlice() {
+        Response r = dm.handleLogin(new Request(RequestType.LOGIN,
+                new LoginCredentials("alice", "p1"), null));
+        assertEquals(ResponseType.LOGIN_RESULT, r.getType());
+        LoginResult lr = (LoginResult) r.getPayload();
+        assertEquals(LoginStatus.SUCCESS, lr.getLoginStatus());
+        return lr;
+    }
+
+    private long createGroup(User.UserInfo... members) {
+        Response r = dm.handleCreateConversation(new Request(RequestType.CREATE_CONVERSATION,
+                new CreateConversationPayload(roster(members)), members[0].getUserId()));
+        assertEquals(ResponseType.CONVERSATION, r.getType(), "create group");
+        return ((Conversation) r.getPayload()).getConversationId();
+    }
+
+    private long sendMessage(String senderId, long conversationId, String text) {
+        Response r = dm.handleSendMessage(new Request(RequestType.MESSAGE,
+                new RawMessage(text, conversationId), senderId));
+        assertEquals(ResponseType.MESSAGE, r.getType());
+        return ((Message) r.getPayload()).getSequenceNumber();
+    }
+
+    @Test
+    void login_returnsConversationsSortedByLatestMessageDesc() {
+        registerAll();
+
+        long c1 = createGroup(ui("u1", "Alice"), ui("u2", "Bob"),   ui("u3", "Carol"));
+        long s1 = sendMessage("u1", c1, "first in c1");
+
+        long c2 = createGroup(ui("u1", "Alice"), ui("u2", "Bob"),   ui("u4", "Dan"));
+        long s2 = sendMessage("u1", c2, "first in c2");
+
+        long c3 = createGroup(ui("u1", "Alice"), ui("u3", "Carol"), ui("u4", "Dan"));
+        long s3 = sendMessage("u1", c3, "first in c3");
+
+        // Sanity: counters monotonic, so s3 > s2 > s1 — c3 must come first, c1 last.
+        assertTrue(s3 > s2 && s2 > s1, "sequence numbers must be strictly increasing");
+
+        List<Conversation> list = loginAlice().getConversationList();
+        assertEquals(3, list.size(), "all three conversations returned");
+        assertEquals(c3, list.get(0).getConversationId(), "newest activity first");
+        assertEquals(c2, list.get(1).getConversationId(), "middle activity second");
+        assertEquals(c1, list.get(2).getConversationId(), "oldest activity last");
+    }
+
+    @Test
+    void login_emptyConversationsYieldsEmptyList() {
+        registerAll();
+        // Alice has no conversations.
+        LoginResult lr = loginAlice();
+        assertNotNull(lr.getConversationList(), "list never null");
+        assertTrue(lr.getConversationList().isEmpty(), "no conversations → empty list");
+    }
+
+    @Test
+    void login_messagelessConversations_orderedByConversationIdDesc() {
+        registerAll();
+
+        // Three groups, no messages sent. Tie-break is conversationId desc.
+        long c1 = createGroup(ui("u1", "Alice"), ui("u2", "Bob"),   ui("u3", "Carol"));
+        long c2 = createGroup(ui("u1", "Alice"), ui("u2", "Bob"),   ui("u4", "Dan"));
+        long c3 = createGroup(ui("u1", "Alice"), ui("u3", "Carol"), ui("u4", "Dan"));
+        assertTrue(c3 > c2 && c2 > c1, "conversation ids must be strictly increasing");
+
+        List<Conversation> list = loginAlice().getConversationList();
+        assertEquals(3, list.size());
+        assertEquals(c3, list.get(0).getConversationId(), "highest convId first");
+        assertEquals(c2, list.get(1).getConversationId());
+        assertEquals(c1, list.get(2).getConversationId(), "lowest convId last");
+    }
+
+    @Test
+    void login_isStableAcrossInvocations() {
+        registerAll();
+
+        long c1 = createGroup(ui("u1", "Alice"), ui("u2", "Bob"),   ui("u3", "Carol"));
+        sendMessage("u1", c1, "hello c1");
+        long c2 = createGroup(ui("u1", "Alice"), ui("u2", "Bob"),   ui("u4", "Dan"));
+        sendMessage("u1", c2, "hello c2");
+        long c3 = createGroup(ui("u1", "Alice"), ui("u3", "Carol"), ui("u4", "Dan"));
+        // c3 has no messages — exercise the mixed-tie path under repeated logins.
+
+        List<Long> first  = idsOf(loginAlice().getConversationList());
+        List<Long> second = idsOf(loginAlice().getConversationList());
+        List<Long> third  = idsOf(loginAlice().getConversationList());
+
+        assertEquals(first, second, "two successive logins must return identical order");
+        assertEquals(second, third, "three successive logins must return identical order");
+        assertEquals(3, first.size());
+        // Sanity: c2's last message seq > c1's last message seq, so c2 precedes c1.
+        assertTrue(first.indexOf(c2) < first.indexOf(c1), "c2 (newer activity) precedes c1");
+        assertTrue(first.contains(c3), "messageless c3 still appears in the list");
+    }
+
+    private static List<Long> idsOf(List<Conversation> convs) {
+        List<Long> ids = new ArrayList<>();
+        for (Conversation c : convs) ids.add(c.getConversationId());
+        return ids;
+    }
+}

--- a/test/server/DataManagerTest.java
+++ b/test/server/DataManagerTest.java
@@ -5,7 +5,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
@@ -308,5 +314,102 @@ public class DataManagerTest {
         // --- Participant query helper (used later by ServerController for fan-out)
         ArrayList<User.UserInfo> participants = dm.getParticipantList(convGroup);
         assertEquals(Integer.valueOf(4), Integer.valueOf(participants.size()), "participant list size");
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #210 — duplicate PRIVATE conversations should be rejected
+    // -------------------------------------------------------------------------
+
+    private long createPrivate(String aId, String aName, String bId, String bName, String requesterId) {
+        Response r = dm.handleCreateConversation(new Request(RequestType.CREATE_CONVERSATION,
+                new CreateConversationPayload(roster(ui(aId, aName), ui(bId, bName))),
+                requesterId));
+        assertEquals(ResponseType.CONVERSATION, r.getType());
+        return ((Conversation) r.getPayload()).getConversationId();
+    }
+
+    @Test
+    void handleCreateConversation_privateDuplicate_returnsSameConversationId() {
+        long first = createPrivate("u1", "Alice", "u2", "Bob", "u1");
+        long second = createPrivate("u1", "Alice", "u2", "Bob", "u1");
+        assertEquals(first, second, "duplicate PRIVATE create must reuse existing id");
+    }
+
+    @Test
+    void handleCreateConversation_privateOrderIndependent_returnsSameId() {
+        long first = createPrivate("u1", "Alice", "u2", "Bob", "u1");
+        // Reverse roster order — server should still match the existing PRIVATE.
+        long second = createPrivate("u2", "Bob", "u1", "Alice", "u2");
+        assertEquals(first, second, "PRIVATE dedupe must be order-independent");
+    }
+
+    @Test
+    void handleCreateConversation_privateAfterOneLeft_allocatesNewId() {
+        long first = createPrivate("u1", "Alice", "u2", "Bob", "u1");
+
+        Response leave = dm.handleLeaveConversation(new Request(RequestType.LEAVE_CONVERSATION,
+                new LeaveConversationPayload(first),
+                "u2"));
+        assertEquals(ResponseType.LEAVE_RESULT, leave.getType());
+
+        long second = createPrivate("u1", "Alice", "u2", "Bob", "u1");
+        assertNotEquals(first, second,
+                "after one party leaves, a fresh PRIVATE pair create must allocate a new id");
+    }
+
+    @Test
+    void handleCreateConversation_privateThenGroupSameMembers_distinctIds() {
+        long pvt = createPrivate("u1", "Alice", "u2", "Bob", "u1");
+        Response group = dm.handleCreateConversation(new Request(RequestType.CREATE_CONVERSATION,
+                new CreateConversationPayload(roster(ui("u1", "Alice"), ui("u2", "Bob"), ui("u3", "Carol"))),
+                "u1"));
+        assertEquals(ResponseType.CONVERSATION, group.getType());
+        long groupId = ((Conversation) group.getPayload()).getConversationId();
+        assertNotEquals(pvt, groupId, "PRIVATE dedupe must not match a GROUP");
+    }
+
+    @Test
+    void handleCreateConversation_groupTwice_distinctIds() {
+        // GROUP dedupe is intentionally out of scope: identical group rosters create distinct conversations.
+        Response g1 = dm.handleCreateConversation(new Request(RequestType.CREATE_CONVERSATION,
+                new CreateConversationPayload(roster(ui("u1", "Alice"), ui("u2", "Bob"), ui("u3", "Carol"))),
+                "u1"));
+        Response g2 = dm.handleCreateConversation(new Request(RequestType.CREATE_CONVERSATION,
+                new CreateConversationPayload(roster(ui("u1", "Alice"), ui("u2", "Bob"), ui("u3", "Carol"))),
+                "u1"));
+        long id1 = ((Conversation) g1.getPayload()).getConversationId();
+        long id2 = ((Conversation) g2.getPayload()).getConversationId();
+        assertNotEquals(id1, id2, "GROUP creation should remain non-deduped");
+    }
+
+    @Test
+    void handleCreateConversation_concurrentDuplicatePrivate_yieldsSingleConversation() throws Exception {
+        // Race two simultaneous CREATE_CONVERSATION calls for the same PRIVATE pair through a
+        // CountDownLatch barrier. The synchronized check-then-put inside handleCreateConversation
+        // must ensure exactly one Conversation is created and both responses share its id.
+        final int threads = 8;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            ArrayList<Future<Long>> futures = new ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                futures.add(pool.submit(() -> {
+                    start.await();
+                    Response r = dm.handleCreateConversation(new Request(RequestType.CREATE_CONVERSATION,
+                            new CreateConversationPayload(roster(ui("u1", "Alice"), ui("u2", "Bob"))),
+                            "u1"));
+                    return ((Conversation) r.getPayload()).getConversationId();
+                }));
+            }
+            start.countDown();
+            Set<Long> distinctIds = new HashSet<>();
+            for (Future<Long> f : futures) {
+                distinctIds.add(f.get(5, TimeUnit.SECONDS));
+            }
+            assertEquals(1, distinctIds.size(),
+                    "concurrent duplicate PRIVATE creates must collapse to a single conversation id");
+        } finally {
+            pool.shutdownNow();
+        }
     }
 }

--- a/test/server/DataManagerTest.java
+++ b/test/server/DataManagerTest.java
@@ -382,6 +382,129 @@ public class DataManagerTest {
         assertNotEquals(id1, id2, "GROUP creation should remain non-deduped");
     }
 
+    // -------------------------------------------------------------------------
+    // Issue #228 — Discord-style "close DM" reactivation on next message
+    // -------------------------------------------------------------------------
+
+    private void registerPair() {
+        dm.handleRegister(new Request(RequestType.REGISTER,
+                new RegisterCredentials("u1", "alice", "p1", "Alice"), null));
+        dm.handleRegister(new Request(RequestType.REGISTER,
+                new RegisterCredentials("u2", "bob", "p2", "Bob"), null));
+    }
+
+    private static boolean rosterContainsId(ArrayList<User.UserInfo> roster, String userId) {
+        for (User.UserInfo u : roster) {
+            if (u != null && userId.equals(u.getUserId())) return true;
+        }
+        return false;
+    }
+
+    @Test
+    void maybeReactivatePrivatePeerOnSend_afterLeave_reactivatesPeerAndRelinksIndex() {
+        registerPair();
+        long convId = createPrivate("u1", "Alice", "u2", "Bob", "u1");
+
+        dm.handleLeaveConversation(new Request(RequestType.LEAVE_CONVERSATION,
+                new LeaveConversationPayload(convId), "u2"));
+        // Sanity: u2 is removed from active roster but remains historical.
+        Conversation afterLeave = dm.getConversation(convId);
+        assertEquals(Integer.valueOf(1), Integer.valueOf(afterLeave.getParticipants().size()),
+                "leave drops u2 from active roster");
+        assertTrue(rosterContainsId(afterLeave.getHistoricalParticipants(), "u2"),
+                "historical roster preserves u2");
+
+        String reactivated = dm.maybeReactivatePrivatePeerOnSend(convId, "u1");
+        assertEquals("u2", reactivated, "u1 sending must reactivate hidden peer u2");
+
+        Conversation afterReactivate = dm.getConversation(convId);
+        assertEquals(Integer.valueOf(2), Integer.valueOf(afterReactivate.getParticipants().size()),
+                "active roster restored to size 2");
+        assertTrue(rosterContainsId(afterReactivate.getParticipants(), "u2"),
+                "u2 back in active roster");
+
+        // Index restoration: u2's login list must once again include this conversation.
+        Response u2Login = dm.handleLogin(new Request(RequestType.LOGIN,
+                new LoginCredentials("bob", "p2"), null));
+        LoginResult lr = (LoginResult) u2Login.getPayload();
+        assertEquals(LoginStatus.SUCCESS, lr.getLoginStatus());
+        boolean foundConv = false;
+        for (Conversation c : lr.getConversationList()) {
+            if (c.getConversationId() == convId) { foundConv = true; break; }
+        }
+        assertTrue(foundConv, "u2's login list must include the reactivated conversation");
+    }
+
+    @Test
+    void maybeReactivatePrivatePeerOnSend_groupConversation_returnsNull() {
+        // Group conversations are out of scope — even if one member leaves, no reactivation.
+        Response group = dm.handleCreateConversation(new Request(RequestType.CREATE_CONVERSATION,
+                new CreateConversationPayload(roster(ui("u1", "Alice"), ui("u2", "Bob"), ui("u3", "Carol"))),
+                "u1"));
+        long convId = ((Conversation) group.getPayload()).getConversationId();
+        dm.handleLeaveConversation(new Request(RequestType.LEAVE_CONVERSATION,
+                new LeaveConversationPayload(convId), "u2"));
+        dm.handleLeaveConversation(new Request(RequestType.LEAVE_CONVERSATION,
+                new LeaveConversationPayload(convId), "u3"));
+
+        assertNull(dm.maybeReactivatePrivatePeerOnSend(convId, "u1"),
+                "GROUP type must never trigger DM reactivation");
+    }
+
+    @Test
+    void maybeReactivatePrivatePeerOnSend_bothActive_returnsNull() {
+        long convId = createPrivate("u1", "Alice", "u2", "Bob", "u1");
+        assertNull(dm.maybeReactivatePrivatePeerOnSend(convId, "u1"),
+                "both still active → nothing to reactivate");
+    }
+
+    @Test
+    void maybeReactivatePrivatePeerOnSend_unknownConversation_returnsNull() {
+        assertNull(dm.maybeReactivatePrivatePeerOnSend(9_999_999L, "u1"));
+    }
+
+    @Test
+    void maybeReactivatePrivatePeerOnSend_nullSender_returnsNull() {
+        long convId = createPrivate("u1", "Alice", "u2", "Bob", "u1");
+        dm.handleLeaveConversation(new Request(RequestType.LEAVE_CONVERSATION,
+                new LeaveConversationPayload(convId), "u2"));
+        assertNull(dm.maybeReactivatePrivatePeerOnSend(convId, null));
+    }
+
+    @Test
+    void maybeReactivatePrivatePeerOnSend_senderIsTheOneWhoLeft_returnsNull() {
+        long convId = createPrivate("u1", "Alice", "u2", "Bob", "u1");
+        dm.handleLeaveConversation(new Request(RequestType.LEAVE_CONVERSATION,
+                new LeaveConversationPayload(convId), "u2"));
+        // u2 (the leaver) is not the lone active participant — u1 is.
+        assertNull(dm.maybeReactivatePrivatePeerOnSend(convId, "u2"),
+                "leaver sending into the conv does not trigger reactivation of themselves");
+    }
+
+    @Test
+    void maybeReactivatePrivatePeerOnSend_repeatedLeaveAndReactivate_idempotent() {
+        registerPair();
+        long convId = createPrivate("u1", "Alice", "u2", "Bob", "u1");
+
+        // First cycle.
+        dm.handleLeaveConversation(new Request(RequestType.LEAVE_CONVERSATION,
+                new LeaveConversationPayload(convId), "u2"));
+        assertEquals("u2", dm.maybeReactivatePrivatePeerOnSend(convId, "u1"));
+        assertEquals(Integer.valueOf(2),
+                Integer.valueOf(dm.getConversation(convId).getParticipants().size()));
+
+        // Second cycle: u2 leaves again, u1 sends again, peer should re-add cleanly without dup.
+        dm.handleLeaveConversation(new Request(RequestType.LEAVE_CONVERSATION,
+                new LeaveConversationPayload(convId), "u2"));
+        assertEquals("u2", dm.maybeReactivatePrivatePeerOnSend(convId, "u1"));
+        Conversation c = dm.getConversation(convId);
+        assertEquals(Integer.valueOf(2), Integer.valueOf(c.getParticipants().size()),
+                "second reactivation cycle must not create duplicate participant entries");
+        // Historical roster also must not have grown — addParticipants dedupes.
+        assertEquals(Integer.valueOf(2), Integer.valueOf(c.getHistoricalParticipants().size()),
+                "historical roster stays at 2 across multiple reactivations");
+    }
+
     @Test
     void handleCreateConversation_concurrentDuplicatePrivate_yieldsSingleConversation() throws Exception {
         // Race two simultaneous CREATE_CONVERSATION calls for the same PRIVATE pair through a

--- a/test/server/ServerControllerTest.java
+++ b/test/server/ServerControllerTest.java
@@ -371,6 +371,7 @@ class ServerControllerTest {
         @Override public Response handleLeaveConversation(Request request) { return hit(RequestType.LEAVE_CONVERSATION); }
         @Override public Response handleAdminConversationQuery(Request request) { return hit(RequestType.ADMIN_CONVERSATION_QUERY); }
         @Override public Response handleJoinConversation(Request request) { return hit(RequestType.JOIN_CONVERSATION); }
+        @Override public String maybeReactivatePrivatePeerOnSend(long conversationId, String senderId) { return null; }
         @Override public ArrayList<User.UserInfo> getParticipantList(long conversationId) {
             ArrayList<User.UserInfo> participants = participantsByConversationId.get(conversationId);
             if (participants == null) {

--- a/test/shared/payload/ConversationMetadataParticipantSortTest.java
+++ b/test/shared/payload/ConversationMetadataParticipantSortTest.java
@@ -1,0 +1,96 @@
+package shared.payload;
+
+import org.junit.jupiter.api.Test;
+import shared.enums.ConversationType;
+import shared.enums.UserType;
+import shared.networking.User;
+import shared.networking.User.UserInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #214 — verifies {@link ConversationMetadata} sorts both participant lists
+ * (active and historical) case-insensitively by name with userId tie-break, in both
+ * the base and full constructors.
+ */
+class ConversationMetadataParticipantSortTest {
+
+    private static UserInfo info(String userId, String name) {
+        return new User(userId, name, userId + "_login", "pw", UserType.USER).toUserInfo();
+    }
+
+    private static ArrayList<UserInfo> roster(UserInfo... members) {
+        ArrayList<UserInfo> list = new ArrayList<>();
+        for (UserInfo u : members) list.add(u);
+        return list;
+    }
+
+    private static List<String> namesOf(List<UserInfo> participants) {
+        ArrayList<String> names = new ArrayList<>();
+        for (UserInfo u : participants) names.add(u.getName());
+        return names;
+    }
+
+    @Test
+    void baseConstructor_reverseAlphabeticInput_sortsBothLists() {
+        ConversationMetadata meta = new ConversationMetadata(
+                10L,
+                roster(info("u3", "Zoe"), info("u1", "Alice"), info("u2", "Bob")),
+                roster(info("u3", "Zoe"), info("u1", "Alice"), info("u2", "Bob")),
+                ConversationType.GROUP);
+
+        assertEquals(List.of("Alice", "Bob", "Zoe"), namesOf(meta.getParticipants()));
+        assertEquals(List.of("Alice", "Bob", "Zoe"), namesOf(meta.getHistoricalParticipants()));
+    }
+
+    @Test
+    void fullConstructor_sortsBothLists() {
+        ConversationMetadata meta = new ConversationMetadata(
+                11L,
+                roster(info("u3", "Zoe"), info("u1", "Alice")),
+                roster(info("u3", "Zoe"), info("u1", "Alice"), info("u2", "Bob")),
+                ConversationType.GROUP,
+                "preview", 1234L, 5, "Group");
+
+        assertEquals(List.of("Alice", "Zoe"), namesOf(meta.getParticipants()));
+        assertEquals(List.of("Alice", "Bob", "Zoe"), namesOf(meta.getHistoricalParticipants()));
+        assertEquals("preview", meta.getLastMessagePreview());
+        assertEquals(5, meta.getUnreadCount());
+        assertEquals("Group", meta.getDisplayName());
+    }
+
+    @Test
+    void mixedCase_sortsCaseInsensitively() {
+        ConversationMetadata meta = new ConversationMetadata(
+                12L,
+                roster(info("u2", "bob"), info("u1", "ALICE"), info("u3", "Carol")),
+                roster(info("u2", "bob"), info("u1", "ALICE"), info("u3", "Carol")),
+                ConversationType.GROUP);
+        assertEquals(List.of("ALICE", "bob", "Carol"), namesOf(meta.getParticipants()));
+    }
+
+    @Test
+    void equalNames_tieBreakOnUserId() {
+        ConversationMetadata meta = new ConversationMetadata(
+                13L,
+                roster(info("u_b", "Sam"), info("u_a", "Sam")),
+                roster(info("u_b", "Sam"), info("u_a", "Sam")),
+                ConversationType.PRIVATE);
+        ArrayList<UserInfo> result = meta.getParticipants();
+        assertEquals("u_a", result.get(0).getUserId());
+        assertEquals("u_b", result.get(1).getUserId());
+    }
+
+    @Test
+    void nullParticipants_normalizedToEmpty() {
+        ConversationMetadata meta = new ConversationMetadata(
+                14L, null, null, ConversationType.GROUP);
+        assertNotNull(meta.getParticipants());
+        assertEquals(0, meta.getParticipants().size());
+        assertNotNull(meta.getHistoricalParticipants());
+        assertEquals(0, meta.getHistoricalParticipants().size());
+    }
+}

--- a/test/shared/payload/ConversationParticipantSortTest.java
+++ b/test/shared/payload/ConversationParticipantSortTest.java
@@ -1,0 +1,155 @@
+package shared.payload;
+
+import org.junit.jupiter.api.Test;
+import shared.enums.ConversationType;
+import shared.enums.UserType;
+import shared.networking.User;
+import shared.networking.User.UserInfo;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #214 — verifies that {@link Conversation} keeps participants and historical participants
+ * ordered case-insensitively by name, with userId as tie-breaker, regardless of insertion order
+ * (constructor, {@link Conversation#addParticipants}, deserialization of pre-existing files).
+ */
+class ConversationParticipantSortTest {
+
+    private static UserInfo info(String userId, String name) {
+        return new User(userId, name, userId + "_login", "pw", UserType.USER).toUserInfo();
+    }
+
+    private static ArrayList<UserInfo> roster(UserInfo... members) {
+        ArrayList<UserInfo> list = new ArrayList<>();
+        for (UserInfo u : members) list.add(u);
+        return list;
+    }
+
+    private static List<String> namesOf(List<UserInfo> participants) {
+        ArrayList<String> names = new ArrayList<>();
+        for (UserInfo u : participants) names.add(u.getName());
+        return names;
+    }
+
+    @Test
+    void constructor_reverseAlphabeticInput_sortedOutput() {
+        Conversation c = new Conversation(1L, roster(
+                info("u3", "Zoe"),
+                info("u1", "Alice"),
+                info("u2", "Bob")));
+        assertEquals(List.of("Alice", "Bob", "Zoe"), namesOf(c.getParticipants()));
+        assertEquals(List.of("Alice", "Bob", "Zoe"), namesOf(c.getHistoricalParticipants()));
+    }
+
+    @Test
+    void constructor_mixedCase_sortsCaseInsensitively() {
+        Conversation c = new Conversation(2L, roster(
+                info("u2", "bob"),
+                info("u1", "ALICE"),
+                info("u3", "Carol")));
+        assertEquals(List.of("ALICE", "bob", "Carol"), namesOf(c.getParticipants()));
+    }
+
+    @Test
+    void constructor_equalNames_tieBreakOnUserId() {
+        Conversation c = new Conversation(3L, roster(
+                info("u_b", "Sam"),
+                info("u_a", "Sam")));
+        ArrayList<UserInfo> result = c.getParticipants();
+        assertEquals("u_a", result.get(0).getUserId());
+        assertEquals("u_b", result.get(1).getUserId());
+    }
+
+    @Test
+    void addParticipants_interleavesAlphabeticallyAndHistoryMatches() {
+        Conversation c = new Conversation(4L, roster(
+                info("u1", "Alice"),
+                info("u3", "Carol")));
+        ArrayList<UserInfo> toAdd = roster(info("u2", "Bob"));
+        c.addParticipants(toAdd);
+
+        assertEquals(List.of("Alice", "Bob", "Carol"), namesOf(c.getParticipants()));
+        assertEquals(List.of("Alice", "Bob", "Carol"), namesOf(c.getHistoricalParticipants()));
+    }
+
+    @Test
+    void addParticipants_skipsExistingUserIdAndKeepsSorted() {
+        Conversation c = new Conversation(5L, roster(
+                info("u1", "Alice"),
+                info("u2", "Bob")));
+        c.addParticipants(roster(info("u2", "Bob"), info("u3", "Carol")));
+        assertEquals(List.of("Alice", "Bob", "Carol"), namesOf(c.getParticipants()));
+        // Original Alice+Bob historical plus newly added Carol; duplicate u2 not re-added.
+        assertEquals(List.of("Alice", "Bob", "Carol"), namesOf(c.getHistoricalParticipants()));
+    }
+
+    @Test
+    void toMetadata_lists_areSorted() {
+        Conversation c = new Conversation(6L, roster(
+                info("u3", "Zoe"),
+                info("u1", "Alice"),
+                info("u2", "Bob")));
+        ConversationMetadata meta = c.toMetadata();
+        assertEquals(List.of("Alice", "Bob", "Zoe"), namesOf(meta.getParticipants()));
+        assertEquals(List.of("Alice", "Bob", "Zoe"), namesOf(meta.getHistoricalParticipants()));
+        assertEquals(ConversationType.GROUP, meta.getType());
+    }
+
+    @Test
+    void deserialize_legacyUnsortedConversation_resortsOnRead() throws Exception {
+        // Build a legacy-state Conversation: bypass the constructor (which sorts) by mutating
+        // the internal lists via reflection so the on-disk shape simulates pre-fix data.
+        Conversation legacy = new Conversation(7L, roster(info("u1", "Alice"), info("u2", "Bob")));
+        Field participantsField = Conversation.class.getDeclaredField("participants");
+        participantsField.setAccessible(true);
+        Field historicalField = Conversation.class.getDeclaredField("historicalParticipants");
+        historicalField.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        ArrayList<UserInfo> liveParts = (ArrayList<UserInfo>) participantsField.get(legacy);
+        liveParts.clear();
+        liveParts.add(info("u3", "Zoe"));
+        liveParts.add(info("u1", "Alice"));
+        liveParts.add(info("u2", "Bob"));
+
+        @SuppressWarnings("unchecked")
+        ArrayList<UserInfo> liveHist = (ArrayList<UserInfo>) historicalField.get(legacy);
+        liveHist.clear();
+        liveHist.add(info("u3", "Zoe"));
+        liveHist.add(info("u1", "Alice"));
+        liveHist.add(info("u2", "Bob"));
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(legacy);
+        }
+        Conversation rehydrated;
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            rehydrated = (Conversation) in.readObject();
+        }
+
+        assertEquals(List.of("Alice", "Bob", "Zoe"), namesOf(rehydrated.getParticipants()));
+        assertEquals(List.of("Alice", "Bob", "Zoe"), namesOf(rehydrated.getHistoricalParticipants()));
+    }
+
+    @Test
+    void getParticipants_returnsDefensiveCopy_externalSortDoesNotAffectModel() {
+        Conversation c = new Conversation(8L, roster(
+                info("u1", "Alice"),
+                info("u2", "Bob"),
+                info("u3", "Carol")));
+        ArrayList<UserInfo> snapshot = c.getParticipants();
+        snapshot.sort(Comparator.comparing(UserInfo::getName).reversed());
+        // model state intact
+        assertEquals(List.of("Alice", "Bob", "Carol"), namesOf(c.getParticipants()));
+    }
+}

--- a/utils/SeedSerializedData.java
+++ b/utils/SeedSerializedData.java
@@ -1,0 +1,145 @@
+import shared.enums.UserType;
+import shared.networking.User;
+import shared.networking.User.UserInfo;
+import shared.payload.Conversation;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Seeds serialized .user and .conversation files under a DataManager-compatible data root.
+ *
+ * Usage:
+ *   java -cp out SeedSerializedData [dataRoot] [bottomUserCount]
+ *
+ * Defaults:
+ *   dataRoot = "data"
+ *   bottomUserCount = 80
+ */
+public class SeedSerializedData {
+
+    public static void main(String[] args) throws Exception {
+        String dataRoot = args.length > 0 ? args[0] : "data";
+        int bottomUserCount = args.length > 1 ? Integer.parseInt(args[1]) : 80;
+
+        Path root = Path.of(dataRoot);
+        Path authUsersPath = root.resolve("server_data/authorized_ids/authorized_users.txt");
+        Path authAdminsPath = root.resolve("server_data/authorized_ids/authorized_admins.txt");
+        Path userDataPath = root.resolve("user_data");
+        Path convDataPath = root.resolve("conversation_data");
+        Path serverConfigPath = root.resolve("server_data/server_config.txt");
+
+        List<String> allAuthorizedUsers = Files.readAllLines(authUsersPath, StandardCharsets.UTF_8).stream()
+                .map(String::trim)
+                .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                .toList();
+        if (allAuthorizedUsers.size() < bottomUserCount) {
+            throw new IllegalStateException("authorized_users has only " + allAuthorizedUsers.size()
+                    + " entries, cannot take bottom " + bottomUserCount);
+        }
+        List<String> selected = allAuthorizedUsers.subList(allAuthorizedUsers.size() - bottomUserCount, allAuthorizedUsers.size());
+
+        Set<String> adminIds = new HashSet<>(Files.readAllLines(authAdminsPath, StandardCharsets.UTF_8).stream()
+                .map(String::trim)
+                .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                .toList());
+
+        Files.createDirectories(userDataPath);
+        Files.createDirectories(convDataPath);
+        Files.createDirectories(serverConfigPath.getParent());
+
+        clearSerializedFiles(userDataPath, ".user");
+        clearSerializedFiles(convDataPath, ".conversation");
+
+        ArrayList<User> users = new ArrayList<>();
+        ArrayList<UserInfo> userInfos = new ArrayList<>();
+
+        int loginCounter = 1;
+        for (String row : selected) {
+            String[] parts = row.split(",", 2);
+            if (parts.length != 2) {
+                continue;
+            }
+            String userId = parts[0].trim();
+            String name = parts[1].trim();
+            if (userId.isEmpty() || name.isEmpty()) {
+                continue;
+            }
+
+            String loginName = "seed" + String.format("%03d", loginCounter++);
+            String password = "seedpass";
+            UserType userType = adminIds.contains(userId) ? UserType.ADMIN : UserType.USER;
+            User user = new User(userId, name, loginName, password, userType);
+            users.add(user);
+            userInfos.add(user.toUserInfo());
+
+            writeObject(new File(userDataPath.toFile(), userId + ".user"), user);
+        }
+
+        long conversationId = 1L;
+
+        // 30 private conversations across the first 60 selected users.
+        for (int i = 0; i + 1 < Math.min(userInfos.size(), 60); i += 2) {
+            ArrayList<UserInfo> participants = new ArrayList<>();
+            participants.add(userInfos.get(i));
+            participants.add(userInfos.get(i + 1));
+            Conversation c = new Conversation(conversationId, participants);
+            writeObject(new File(convDataPath.toFile(), conversationId + ".conversation"), c);
+            conversationId++;
+        }
+
+        // 10 group conversations (5 participants each) over all selected users.
+        int groupCount = 10;
+        int groupSize = 5;
+        for (int g = 0; g < groupCount; g++) {
+            ArrayList<UserInfo> participants = new ArrayList<>();
+            for (int j = 0; j < groupSize; j++) {
+                int idx = (g * groupSize + j) % userInfos.size();
+                participants.add(userInfos.get(idx));
+            }
+            Conversation c = new Conversation(conversationId, participants);
+            writeObject(new File(convDataPath.toFile(), conversationId + ".conversation"), c);
+            conversationId++;
+        }
+
+        Properties props = new Properties();
+        props.setProperty("conversationIdCounter", Long.toString(conversationId - 1));
+        props.setProperty("messageSequenceCounter", "0");
+        try (FileOutputStream out = new FileOutputStream(serverConfigPath.toFile())) {
+            props.store(out, "Server counters (message sequence and conversation id)");
+        }
+
+        System.out.println("Seed complete.");
+        System.out.println("Users seeded: " + users.size());
+        System.out.println("Conversations seeded: " + (conversationId - 1));
+        System.out.println("User source: bottom " + bottomUserCount + " entries of authorized_users.txt");
+    }
+
+    private static void clearSerializedFiles(Path dir, String extension) throws Exception {
+        File[] files = dir.toFile().listFiles((d, name) -> name.endsWith(extension));
+        if (files == null) {
+            return;
+        }
+        for (File f : files) {
+            if (!f.delete()) {
+                throw new IllegalStateException("Failed to delete existing seed file: " + f.getAbsolutePath());
+            }
+        }
+    }
+
+    private static void writeObject(File path, Object value) throws Exception {
+        try (FileOutputStream fos = new FileOutputStream(path);
+             ObjectOutputStream oos = new ObjectOutputStream(fos)) {
+            oos.writeObject(value);
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary

Fixes five issues affecting the in-chat **New messages** divider, the conversation sidebar, and server-side message broadcasting.

| # | Symptom | Where |
|---|---|---|
| 1 | A client occasionally stops receiving broadcasts with no error in any log | `ConnectionHandler.ResponseSender` |
| 2 | Sidebar selection is lost after every inbound message (for conversation IDs > 127) | `ClientUI` reselect path |
| 3 | Divider sometimes never appears when opening a conversation with new messages | `ClientController.handleMessageResponse` race |
| 4 | Divider doesn't appear for messages arriving while alt-tabbed away | `ClientUI.appendMessageToConversationView` gate |
| 5 | Once shown, divider stays pinned forever, even after reading/replying | no removal path in `ClientUI` |

### Bug 1 — Server broadcast reliability
The writer thread (`ResponseSender`) exited on `IOException` without tearing the handler down. The session stayed in `ServerController.activeSessions`, so `enqueueMessageBroadcast` kept routing broadcasts to a dead handler — they piled up in `responseQueue` undrained until the read side noticed EOF or the heartbeat timed out (up to `HEARTBEAT_TIMEOUT_MS = 5 min`). Now `ResponseSender.run()` calls `close()` on exit, deregistering the session immediately.

### Bug 2 — Sidebar selection lost on inbound
The reselect path compared a primitive `long` against a boxed `Long` with `==`, which only works for IDs in the autobox cache (-128 to 127). Replaced with `.longValue()` so selection survives for any ID.

### Bug 3 — Divider race on open
The EDT click-to-open did `setCurrentConversationId` then snapshotted `(lastRead, messages)` in two steps. A concurrent inbound between them advanced `lastRead` past the new message, making the divider check `seq > lastReadAtOpen` false for every message. Introduced `openConversationAtomically(id)` that captures `(lastRead, messages)` and publishes `currentConversationId` under the same `conversations` monitor that `handleMessageResponse` uses to decide read-advance.

### Bug 4 — Divider missing while alt-tabbed
Insert gate was `!userIsAtBottom`, but `userIsAtBottom` defaults to `true`. So the most common case — window not focused, user idle at bottom — silently suppressed the divider. New gate: `fromOther && !(frame.isActive() && userIsAtBottom) && !modelHasDivider`.

### Bug 5 — Divider stuck forever
There was insertion logic but no removal logic, and a `modelHasDivider` flag blocked any reposition. Added `removeDividerIfCaughtUp()` (called from `markDisplayedReadUpTo` after read-advance / scroll-replay / inbound-while-visible) and `removeDividerNow()` (called from `doSend` since sending implies the user has read what's on screen).

## Files Changed

- `src/shared/networking/ConnectionHandler.java` — Bug 1
- `src/client/ClientController.java` — Bug 3
- `src/client/ClientUI.java` — Bugs 2, 3, 4, 5

---

## Manual Test Plan

Spin up a server and three clients (`A`, `B`, `C`) on different accounts, with conversation IDs >127 to surface the autobox bug.

### Test 1 — Sidebar selection survives inbound (Bug 2)
- [x] On `A`, click a conversation with id > 127 so it's selected (highlighted).
- [x] On `B`, send a message into that conversation.
- [x] Expected: on `A`, the conversation rises to the top of the list AND remains visually selected (highlighted) — the chat pane stays open.
- [x] Pre-fix behavior: highlight disappears, chat pane appears to "deselect" itself.

### Test 2 — Divider appears when window is alt-tabbed (Bug 4)
- [x] On `A`, open conversation with `B`. Stay parked at the bottom.
- [x] Switch focus to another app (`A`'s chat window is no longer active, but still visible).
- [x] On `B`, send a message.
- [x] Bring `A` back into focus.
- [ ] Expected: a "—— New messages ——" divider appears immediately above `B`'s new message.
- [ ] Pre-fix behavior: no divider appears.

### Test 3 — Divider does NOT appear when actively viewing (Bug 4 contrapositive)
- [ ] On `A`, open conversation with `B`, window focused, scrolled to bottom.
- [ ] On `B`, send a message.
- [ ] Expected: message appears, NO divider (you're plainly reading it live).

### Test 4 — Divider does NOT appear above your own message
- [x] On `A`, open any conversation and send a message.
- [x] Expected: no divider above your own outgoing message.

### Test 5 — Divider disappears after reply (Bug 5)
- [ ] Trigger a divider via Test 2.
- [ ] On `A`, type a reply and send.
- [ ] Expected: divider is removed immediately on send.

### Test 6 — Divider disappears after scroll-to-bottom (Bug 5)
- [ ] Trigger a divider, but instead of replying, scroll up so the divider is visible mid-list.
- [ ] Scroll back to the bottom (and keep the window focused).
- [ ] Expected: as the read-advance fires, the divider is removed.

### Test 7 — Divider disappears once read catches up (Bug 5)
- [ ] Trigger a divider, then leave the window inactive.
- [ ] Bring the window back to focus while parked at bottom.
- [ ] Expected: read-advance fires, `markDisplayedReadUpTo` runs, `removeDividerIfCaughtUp` removes the divider.

### Test 8 — Divider on click-to-open with concurrent inbound (Bug 3)
- [ ] On `A`, have several conversations. Make sure the conversation with `C` is NOT selected.
- [ ] On `C`, send 3-4 messages in rapid succession.
- [ ] On `A`, while messages are still arriving (or right after they finish), click the conversation with `C`.
- [ ] Expected: divider appears above `C`'s unread batch.
- [ ] Pre-fix behavior: divider sometimes never appears even though you can see the unread messages.

### Test 9 — Server broadcast reliability under churn (Bug 1)
- [ ] Open `A`, `B`, `C`, all in a shared group conversation.
- [ ] Have `A` and `B` send ~30 messages each, alternating, over a couple of minutes.
- [ ] Expected: `C` receives every message in order. No silent gaps.
- [ ] Verify: `client3.log` MESSAGE response count == `client1.log` + `client2.log` MESSAGE send count.
- [ ] Pre-fix evidence (from `logs/`): client1=17, client2=4, client3=16 — client2 silently dropped most broadcasts with empty `.err` log.

### Test 10 — Server broadcast reliability across forced disconnect (Bug 1)
- [x] Open `A`, `B`, `C` in a shared conversation.
- [x] Force-kill `A`'s process (so the socket dies but the client never sends a clean LOGOUT).
- [x] On `B`, send several messages.
- [x] Expected: `C` receives every message normally. Server logs should NOT show indefinite routing to `A`'s dead handler.
- [x] Pre-fix behavior: depending on timing, broadcasts to `B` and `C` could also be affected because the dead writer thread back-pressured nothing while messages piled up in its undrained queue.

---

## Follow-up fixes (added in this push)

Four further commits land on the same branch. Same code areas — conversation list / unread story — but distinct root causes from Bugs 1-5 above.

| # | Issue | Symptom | Where |
|---|---|---|---|
| 6 | #209 | Sidebar unread badge / divider flickers back on after a read ack | `ClientController.handleReadMessagesUpdatedResponse` |
| 7 | #214 | Conversation order in the sidebar reshuffles across logins | `DataManager.handleLogin` |
| 8 | #210 | Two simultaneous CREATE for the same PRIVATE pair could produce duplicates | `DataManager.handleCreateConversation` |
| 9 | #214 (b) | Participant rows render in different orders for different clients viewing the same conversation | `Conversation` / `ConversationMetadata` payloads |

### Bug 6 — lastRead wiped by single-conv ack
`handleReadMessagesUpdatedResponse` previously replaced the entire `currentUser` snapshot with the server's UserInfo whenever any READ_MESSAGES_UPDATED arrived. An ack for one conversation therefore wiped optimistic lastRead advances the EDT had recorded for OTHER conversations whose acks were still in flight. The merge is now per-conversation: server value is the floor, take `max(server, local)` for every conversation already in the local map. The login flow also routes the conversation list through a defensive copy + re-sort so a direct consumer of the controller's `conversations` field sees a deterministic order regardless of what the server sent (defence-in-depth for Bug 7).

### Bug 7 — Sidebar reshuffles across logins
`handleLogin` iterated the user's conversation-id `Set<String>` in `HashSet` insertion order, so the wire payload's order varied across JVM runs and across successive logins. Now sorted most-recent-first by latest message sequence number, with a tie-break on `conversationId` desc so messageless conversations keep stable positions. `handleLogin` also null-skips the lookup so a stale id in the index does not NPE the entire login.

### Bug 8 — Concurrent PRIVATE create race
`handleCreateConversation` did a check-then-put with no synchronization, so two concurrent creates for the same two-user PRIVATE pair could both pass the "does it already exist?" scan and both create new conversations. The check-then-put is now serialized through a dedicated lock, and the dedupe scan short-circuits on the first existing PRIVATE with the same active members. Group dedupe is intentionally out of scope.

### Bug 9 — Participant order drift across clients
`Conversation` and `ConversationMetadata` held participants in whatever order the constructor caller passed in, so two clients viewing the same conversation could render different participant rows depending on which CREATE / ADD path produced their snapshot. Sort participants and historicalParticipants by case-insensitive name then userId in: the public ctor, `addParticipants`, and `readObject` (covers wire-snapshot rehydration and `.conv` file reload).

### Tests added
- `test/client/ClientControllerLastReadMergeTest.java` — 5 cases covering Bug 6 merge semantics
- `test/server/DataManagerLoginConversationOrderTest.java` — 4 cases covering Bug 7 sort path
- `test/server/DataManagerTest.java` (extended) — 5 cases covering Bug 8 dedupe (sequential, order-independent, after-leave, PRIVATE/GROUP coexistence, 8-thread concurrent race)
- `test/shared/payload/ConversationParticipantSortTest.java` and `ConversationMetadataParticipantSortTest.java` — Bug 9 ordering invariants
- `test/client/ClientControllerTest.java` (extended) — `isUnread`, `isMessageUnread`, and the inactive-window read gate the divider story relies on

### Manual verification for follow-up fixes
- [ ] **Bug 6**: with three conversations open and at least one new message in each, click into one to fire the read ack and confirm the other two still show their unread badges.
- [ ] **Bug 7**: log in, send a message in one conversation to bump it, log out, log back in — the bumped conversation should be at the top, and the order should not change between successive logins.
- [ ] **Bug 8**: from two clients, near-simultaneously create a private conversation with the same counterpart; both should resolve to the same conversation id (no duplicate row).
- [ ] **Bug 9**: open the same group conversation on two clients — participant rows should appear in identical order on both.

---

## Notes

- Six commits total: two on the original Bugs 1-5 (server vs client split), four on the follow-up fixes (one per concern).
- The branch was rebuilt locally, all 4 processes (1 server + 3 clients) restarted from `out/` against the new build.


---

## In-place cleanup of `ClientUI.java`

Behavior-preserving refactor pass on the same file as Bugs 2-5. No public API change, no behavior change, no file split.

### Encapsulation
- **Intent methods on inner views.** `ClientUI` no longer pokes inner-class fields directly. `suppressSelectionEvents` / `selecting` / focus calls go through `beginExternalUpdate` / `endExternalUpdate` / `clearSelecting` / `focusInput`. The selection-suppression guard around `updateConversationListModel` runs through a `withSuppressedSelection(Runnable)` helper so the flag cannot leak if the body throws.
- **Dialog-ref helpers.** The `dialog != null && dialog.isVisible()` pattern (seven sites — login/admin disposal, three "bring-to-front" short-circuits, two state predicates) collapses to `isDialogShowing(d)`, `disposeIfVisible(d)`, and `focusExistingDialog(d)`.
- **`MessageRow` view-model.** A private nested record-style class precomputes header text, body, and sender resolution. `MessageCellRenderer` and `AdminMessageCellRenderer` consume `MessageRow.forConversation` / `MessageRow.forAdmin` and drop their duplicated `formatMessageTimestamp` / `resolveHistoricalSenderName` plumbing.
- **`IdleWatcher` inner class.** Idle plumbing (poll constants, timer field, AWT listener install, idle-logout threshold, tick handler) moves out of the `ClientUI` shell into a single private inner class. `ClientUI` holds one `idleWatcher` field.

### Cosmetic
- Dialog/frame sizes and bubble-wrap fraction promoted to named constants (`MAIN_FRAME_MIN_SIZE`, `SELECT_USER_DIALOG_SIZE`, `ADMIN_SEARCH_DIALOG_SIZE`, `BUBBLE_WRAP_FRACTION`).
- Private nested `Theme` holder names the dark-mode RGB palette so `UIManager.put` calls read against named colors, not inline `new Color(...)` literals. Values unchanged.
- `private final` on every constructor-assigned-only field.
- `login_idField` → `loginIdField`.
- Tabs → 4 spaces across the file.
- Comment sweep: dropped `// Fix N:` / `// #N:` tag prefixes (kept the substantive sentences after the colons); deleted pure narration (GridBag column-width labels, "list is located on the middle of the window", etc.). Section dividers, EDT/Swing-quirk explanations, and the "Actively viewing requires BOTH window focused AND parked at bottom" gotcha kept verbatim.

### Verification
- Full `javac` clean.
- 65/65 client tests pass (`ClientControllerTest`, `ClientControllerLastReadMergeTest`).
- Single file touched (`src/client/ClientUI.java`), net -- ~6 lines.


---

## In-place cleanup of `ClientController.java`

Behavior-preserving refactor on the same file behind Bugs 1, 3, 6. No public API change, no behavior change, no file split. Method signatures pinned by `ClientControllerTest`, `ClientControllerLastReadMergeTest`, and `ClientUI` are preserved.

### Tier 1 — correctness / concurrency
- **`conversations` made `final`.** Previously reassigned on login to a fresh synchronized list, which silently invalidated every `synchronized(conversations)` block on the older reference. Login now does `clear()` + `addAll(sorted)` under the same monitor.
- **Memory-visibility fixes.** `connectionStatus`, `loggedIn`, and `currentConversationId` are now `volatile`. The publish of `currentConversationId` still happens inside the conversations monitor where inbound-decision ordering matters.
- **`UserInfo` mutation moved to EDT.** `handleMessageResponse` previously called `currentUser.setLastRead(...)` on the response listener thread, violating the publication contract documented in `shared/networking/User.java`. Mutation now runs on the EDT in the same `invokeLater` already used for the GUI append.
- **Socket I/O out of `synchronized(this)` teardown.** `disconnectSocket` no longer writes a LOGOUT request while holding the monitor. LOGOUT is enqueued before disconnect; the drain thread sends it on its way out.
- **Directory / admin-search state marshalled to EDT** and the admin-search getter returns a defensive copy.
- **`deferredReadAdvance` access serialized.** Drain in `replayReadAdvanceIfNeeded` now happens under `synchronized(conversations)`, matching the writer at `handleMessageResponse`.
- **`handleConversationMetadataResponse` no-op merge** flagged with a `TODO(meta-merge):` so it stops re-rendering without applying the payload.

### Tier 2 — robustness
- **`authInFlight` is now `AtomicBoolean`.** Two rapid EDT events can no longer both pass the guard. A 15-second watchdog clears the flag and toasts a network error if the server never replies, so the login button cannot stay disabled forever.
- **`logout()` ordering corrected** — clear `requestQueue` before `disconnectSocket()` so any in-flight `take()` observes `NOT_CONNECTED` cleanly.
- **`ConnectionStatus.CONNECTING`** assignment removed (state was set but never observed).

### Tier 3 — encapsulation / duplication
- **Constructor chain** — both constructors now route through a private `initState()` helper instead of duplicating field init.
- **`requireSession()` / `requireAdminSession()`** collapse 15+ guard prologues (`if (!loggedIn || currentUser == null) return;` and the admin variant) to a single line.
- **Filter helpers** — `userMatches(UserInfo, lowerQuery)` and `anyUserMatches(Collection<UserInfo>, lowerQuery)` route the three filter methods through one shared predicate path. Two helpers, not one — single user vs. list of users are different abstraction levels.
- **`ReadCalc` nested class** groups the static unread predicates (`isUnread`, `isMessageUnread`, `unreadCount`) under a private static class as pure functions; original static names retained as test-pinned delegates. `latestSequenceNumber` made static.
- **`final`** on `gui`, `hostIp`, `hostPort`, `requestQueue`, and (post-Tier 1) `conversations`.

### Tier 4 — hygiene / dead code
- **Tunables block** at the top of the class hoists `CONNECT_TIMEOUT_MS`, `PING_INTERVAL_MS`, `INACTIVITY_LIMIT_MS`, `RECONNECT_POLL_MS`, `RETRY_BACKOFF_MS` so the magic numbers in the three daemon threads are named and adjustable in one place.
- **Dead code removed.** `runRequestLoop()` (zero callers) and `getConversationSnapshotForOpen()` (superseded by `openConversationAtomically`) deleted; three tests in `ClientControllerTest` migrated to the surviving method.
- **Duplicate write removed.** PONG case no longer writes `lastServerActivityMillis` twice (the entry-point write at the top of the response handler already covers it).
- **Per-response `System.out.println`** removed.
- **Ticket archaeology culled.** All ticket/fix tags (`#193`, `#139B`, `#140`, `#142`, `#214`, `#209`, `#138`, `#139`, `#55/#124`, `#128`, `Fix A`, `Fix E1`, `Fix E2`) removed; the substantive invariants those comments named are kept in the prose without the cross-references.

### Verification
- Full `javac` clean.
- 65/65 tests pass (`ClientControllerTest` + `ClientControllerLastReadMergeTest`) under `junit-platform-console-standalone` 1.10.5.
- Files touched: `src/client/ClientController.java` (net +90 lines after delta), `src/client/ClientUI.java` (one Javadoc reference updated), `test/client/ClientControllerTest.java` (three test methods migrated), `docs/SRS.md` (one stale method line removed).

### Follow-up: comment cleanup pass on `ClientController.java`
- All `#NNN` / `Fix X` tag prefixes stripped; the substantive sentences after them are retained.
- `Matches DataManager.handleX — payload: Y` Javadocs removed from public action methods.
- Caller-reference Javadocs and what-style narration removed where well-named identifiers already convey intent.
- Verbose `main()` usage block and redundant Javadoc on trivial accessors / test seams removed.
- Concurrency and lock-order rationale, the `outputStream.reset()` memory-leak note, and real TODOs are kept.
- Comment-only changes; no behavior or signatures touched. 65/65 tests still pass.




---

## Second cleanup pass on `ClientUI.java` (commit `ba510d5`)

Same single-file scope as the previous in-place pass. No behavior or signature changes.

### Constants holder
- Private nested `Constants` class for the LAF FQCN, card name strings (`CARD_LOGIN` / `CARD_REGISTER` / `CARD_MAIN`), dialog titles (`DLG_SELECT_USER`, `DLG_ADMIN_SEARCH`), DM/Group/empty-participant prefixes (`DM_PREFIX`, `GROUP_PREFIX`, `EMPTY_PARTICIPANT_PLACEHOLDER`), `UNREAD_BADGE_CAP`, and layout pixel literals (HTML wrap min, bubble width min, scroll bottom-tolerance, admin split divider, app icon size, divider panel dim). Call sites now reference `Constants.X` instead of inline literals.

### View-state consolidation
- Drop the three top-level `DefaultListModel` fields (`directoryModel`, `conversationMessageModel`, `conversationListModel`) that duplicated state already owned by the views. Each `*View` now keeps its own private `listModel`; `ClientUI` accesses it directly via `cards.main.<view>.listModel`.
- Remove the `setListModel(...)` overrides on `DirectoryView` and `ConversationListView` (no callers).
- Cache the open `ConversationView` in a `volatile ClientUI` field at frame init. `userIsViewingBottom()` now reads the cached reference instead of a four-hop null-guard chain through `cards.main`.

### `IdleWatcher` lifecycle
- Add `stop()` and `uninstallAwtListener()`; hold the `AWTEventListener` reference so it can be deregistered.
- `windowClosing` now tears the watcher down symmetrically with the `WindowAdapter` install path so the listener can't outlive the frame on explicit close.
- Remove the dead `LOGOUT_AFTER_MS > 0` short-circuit in `onTick` (constant is always positive).

### Helpers
- `filteringListener(Runnable)` — `DirectoryView`, `ConversationListView`, and `AdminConversationSearchWindow` no longer hand-roll their own 3-method `DocumentListener`.
- `buildModalDialog(title, content, size)` — the three "Select User" / "Searching Conversations" `JDialog` constructions converge.
- `excludeSelf` / `buildParticipantSummary` / `displayParticipants` deduplicate the participant-name munging that was repeated across `setListModel`, `ConversationCellRenderer`, `AdminConversationCellRenderer`, and `ViewerPanel.loadConversation`.

### Renderer caching
- `MessageCellRenderer` memoizes `MessageRow` per `(currentConversation, sequenceNumber)` and rebuilds only when the open conversation changes.
- `AdminMessageCellRenderer` memoizes the wrapped HTML per `(sequenceNumber, wrapPx)`.
- Both invalidate on conversation or wrap-width change.

### `ViewerPanel`
- Replace the manual `remove`/`add` of placeholder vs. scroll with a `CardLayout` swap, removing the `populated` boolean and the `revalidate`/`repaint` pair at the end of `loadConversation`.

### Field encapsulation / naming
- Privatize fields on `DirectoryView`, `ConversationView`, and `ScreenCards`.
- Rename `DirectoryView.selecting` -> `selectedDirectoryUser` and `ConversationView.text` -> `messageInputField`.
- Add `ConversationView.propagateAddUserSelection` so `DirectoryView` no longer reaches into `addUserWindow` directly.

### Misc
- Hoist the two `DateTimeFormatter` instances in `formatMessageTimestamp` to static fields (`FMT_SAME_YEAR` / `FMT_OTHER_YEAR`).
- Drop the `if (cards == null) return` guard in `setLoginInFlight` (`cards` is set in the constructor before any EDT task can fire).
- Add a `scrollPending` debounce in `appendMessageToConversationView` so a burst of inbound messages doesn't queue a stacked `invokeLater` per message.

### Verification
- Full `javac` clean.
- 118/118 tests pass under `junit-platform-console-standalone` 1.10.5.

---

## Merge with `main` (commit `6c0b524`)

Branch was rebased on top of the latest `main` after PR #218 landed (Eclipse project files, `.gitignore` un-ignores, README, `ConnectionListener` no-arg-host ctor removal, `#NNN` comment-tag stripping).

- Conflicts in `src/client/ClientUI.java` and `src/client/ClientController.java` resolved in favor of this branch — its in-place cleanup is a strict superset of main's tag/divider edits, and the divider-lifecycle work depends on field renames and renderer signatures (`ListCellRenderer<Object>` to accommodate the `NewMessagesDivider` sentinel) that main's lines reach past.
- Three lingering `#NNN` comment tags in `ClientUI.java` were also stripped to match main's intent.
- `.classpath`, `.project`, `.settings/`, `README.md`, `.gitignore`, and `src/shared/networking/ConnectionListener.java` come through clean from main.

### Verification
- Full `javac` clean (79 classes).
- 118/118 tests still pass under `junit-platform-console-standalone` 1.10.5 — matches the pre-merge baseline exactly.



---

## Follow-up: Send-button read-ack hole (commit `1b7bc5f`)

The earlier read-ack rebase (commit `ebae03f`) gated `lastRead` advance in `handleMessageResponse` on `inputFocused && userIsAtBottom`. That gate is correct for Enter-to-send (focus stays on the input) but breaks for **Send-button clicks**: the click shifts focus from the input to the button, the input's `focusLost` listener flips `inputFocused` to `false`, and by the time the server echoes the new `Message` back the gate is already closed. The echo lands in `deferredReadAdvance` instead of advancing `lastRead`, so the user's own outbound message is counted by `unreadCount(...)` — a badge appears on the user's own conversation in their own sidebar. Because `deferredReadAdvance` only replays on input-focus regain, repeated Send-button clicks compound the count and it never clears until the user re-clicks the input field.

### Fix
- `ClientController.handleMessageResponse` short-circuits the read-ack gate when the echoed message's `senderId` equals `currentUser.getUserId()`. Sending is, by definition, attention; the user's own echo should always advance `lastRead` regardless of focus or scroll state at the moment the echo arrives.
- `ClientUI.doSend` calls `replayReadAdvanceIfNeeded()` immediately after `removeDividerNow()` so any prior incoming message that was deferred while the input was unfocused is drained at send time. The replay is already public and idempotent on an empty buffer; no new API surface.

### Files changed
- `src/client/ClientController.java` — `fromSelf` short-circuit in `handleMessageResponse`
- `src/client/ClientUI.java` — flush `deferredReadAdvance` from `doSend`

### Manual verification
- [ ] Open the A↔B conversation in both clients. From `B`, send a message; `A` shows divider + badge=1.
- [ ] On `A`, reply by clicking the **Send button** (not Enter). Send a few times. Pre-fix: `A`'s sidebar badge climbs on `A`'s own messages. Post-fix: `A`'s badge stays at `0`.
- [ ] On `A`, click the sidebar (away from the input). From `B`, send a message. On `A`, click Send button without re-clicking the input. Pre-fix: deferred ack never replays, badge persists. Post-fix: `doSend` drains the deferral, badge clears.
