### PR TITLE
chore: Fix Eclipse project, gitignore, README, and client cleanup

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="test"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="utils"/>
+	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/6">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.classpath
 # =========================
 # Java compiled output
 # =========================
@@ -20,14 +19,6 @@ target/
 *.iws
 *.ipr
 
-# Eclipse
-.project
-.classpath
-.settings/
-
-# VS Code
-.vscode/
-
 # =========================
 # Logs
 # =========================
@@ -42,7 +33,6 @@ Thumbs.db
 # =========================
 # Java packaging artifacts
 # =========================
-*.jar
 *.war
 *.ear
 

--- a/.project
+++ b/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>CS401-Communications</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1777671479118</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.source=17

--- a/README.md
+++ b/README.md
@@ -1,23 +1,181 @@
 # Communication System Application (CSA)
 
-This is a project of the course CS401. The project is building an application communication system using Java.
+Communication System Application is a Java client/server messaging platform built for CS401.  
+It provides a desktop client UI, a TCP server, and shared networking/payload contracts.
 
-## How to run
-1. Open the project in Eclipse
-2. Run Main.java
+## Table of Contents
+- [System Overview](#system-overview)
+- [Core Features](#core-features)
+- [Architecture](#architecture)
+- [Repository Layout](#repository-layout)
+- [Prerequisites](#prerequisites)
+- [Quick Start (Eclipse)](#quick-start-eclipse)
+- [Run from Command Line](#run-from-command-line)
+- [Runtime Configuration](#runtime-configuration)
+- [IP Finder Utility (JAR)](#ip-finder-utility-jar)
+- [Data and Persistence](#data-and-persistence)
+- [Testing](#testing)
+- [Troubleshooting](#troubleshooting)
+- [Documentation](#documentation)
 
-## Features
-- Create an account
-- Log in to the account
-- Search users
-- Create conversations
-- View messages
-- Select the conversation
-- Leave the conversation
-- For Admin, join existing conversations
+## System Overview
+Based on `docs/SRS.md` section 2, this project is a standalone internal communications platform for a large organization using a centralized client-server model.
 
-## Technologies
+- The **server** is the authoritative source of truth for user accounts, sessions, conversations, and message logs.
+- The **client** is a desktop GUI interface for authentication, conversation management, and text-based messaging.
+- Communication is done over TCP/IP using serialized request/response objects.
+- Persistence is server-managed and file-based (text/config + serialized data), with no external database or third-party service dependencies.
+- Administrative users are granted elevated oversight privileges aligned with organizational requirements.
+
+## Core Features
+- Account registration and login
+- User directory search
+- One-to-one and group conversation support
+- Message viewing and conversation history
+- Leave conversation support
+- Admin support for joining existing conversations
+
+## Architecture
+- **Client Layer**: `ClientController` and `ClientUI` manage GUI events and server requests.
+- **Server Layer**: `ServerController` and `DataManager` handle request processing, validation, and persistence.
+- **Shared Layer**: enums, payload objects, and networking classes in `src/shared`.
+- **Transport**: TCP/IP sockets with request/response objects.
+
+## Tech Stack
 - Java
-- Swing (GUI)
-- TCP/IP connection
-- OOP (MVC architecture)
+- Java Swing (GUI)
+- TCP/IP socket communication
+- MVC-style separation (client controller/UI, server controller, shared payloads)
+
+## Repository Layout
+- `src/client`: client UI and controller
+- `src/server`: server-side controller and data management
+- `src/shared`: shared enums, payloads, and networking contracts
+- `test`: JUnit tests
+- `data`: server-side data files
+- `docs`: design and analysis documents
+
+## Prerequisites
+- Java 17+ (recommended)
+- Eclipse IDE (optional, but easiest for this project)
+- Terminal access for command-line execution (optional)
+
+## Quick Start (Eclipse)
+1. Import the repository as a Java project.
+2. Run `src/server/ServerController.java`.
+3. Run `src/client/ClientController.java` in a second launch.
+4. Use the client UI to register/login and start messaging.
+
+## Run from Command Line
+From repository root:
+
+1. Compile all source files:
+   ```bash
+   mkdir -p out
+   find src -name "*.java" > sources.txt
+   javac -d out @sources.txt
+   ```
+2. Start the server (default: data root `./data`, port `8080`, bind `localhost`):
+   ```bash
+   java -cp out server.ServerController
+   ```
+3. Start client(s) in separate terminal(s):
+   ```bash
+   java -cp out client.ClientController
+   ```
+4. Optional: connect to a custom host/port:
+   ```bash
+   java -cp out client.ClientController 127.0.0.1 8080
+   ```
+
+## Runtime Configuration
+### Server
+`ServerController` supports:
+```text
+java -cp out server.ServerController [dataRootPath] [port] [ipv4]
+```
+- `dataRootPath` (optional): root directory for persistence (default `data`)
+- `port` (optional): listening port (default `8080`)
+- `ipv4` (optional): bind address (default `localhost` in local mode)
+
+Example:
+```bash
+java -cp out server.ServerController data 9090 0.0.0.0
+```
+
+### Client
+`ClientController` supports:
+```text
+java -cp out client.ClientController [host] [port]
+```
+- `host` (optional): server host (default `localhost`)
+- `port` (optional): server port (default `8080`)
+
+## IP Finder Utility (JAR)
+The project includes an IP helper utility source at `utils/IP_Finder.java`.  
+When packaged as a JAR, launch it with:
+
+```bash
+java -jar IP_Finder.jar
+```
+
+What it does:
+- Prints the primary non-loopback IPv4 address.
+- Lists all non-loopback IPv4 addresses grouped by interface.
+- Helps identify the host IP that clients should use when connecting to a remote server.
+
+If you only have source code (no prebuilt JAR), run:
+```bash
+javac -d out utils/IP_Finder.java
+java -cp out IP_Finder
+```
+
+## Data and Persistence
+Important data files live under `data/`:
+- `data/server_data/server_config.txt`: server counters
+- `data/server_data/authorized_ids/authorized_users.txt`: valid user IDs + names
+- `data/server_data/authorized_ids/authorized_admins.txt`: IDs with admin privileges
+
+The server reads/writes these files through `DataManager`.
+
+### Externally Supplied Management Files
+The authorization `.txt` files are **externally supplied by company management** (not generated by clients):
+- `authorized_users.txt` is the managed employee roster used for account ownership verification.
+- `authorized_admins.txt` is the managed list of employee IDs granted admin privileges.
+
+These files should be placed under the server data root exactly as:
+
+```text
+<dataRootPath>/
+  server_data/
+    authorized_ids/
+      authorized_users.txt
+      authorized_admins.txt
+```
+
+For default startup (`dataRootPath = data`), place them at:
+- `data/server_data/authorized_ids/authorized_users.txt`
+- `data/server_data/authorized_ids/authorized_admins.txt`
+
+Expected content format:
+- `authorized_users.txt`: one `userId,name` record per line (CSV-style)
+- `authorized_admins.txt`: one `userId` per line
+- Employee ID format is not hard-restricted by the system; however, company management should standardize on **alphanumeric IDs of 8-10 characters** for consistency.
+- Blank lines and lines beginning with `#` are ignored
+
+## Testing
+Tests are located under `test/` and use JUnit.
+
+If you are running in Eclipse, use **Run As > JUnit Test** on specific test classes or the test package.
+
+## Troubleshooting
+- **Client cannot connect**: make sure server is running first and host/port match.
+- **Port already in use**: run server on a different port, then launch client with that same port.
+- **Login/registration rejects valid data**: verify `authorized_users.txt` format and entries.
+- **Admin behavior missing**: confirm the user ID exists in `authorized_admins.txt`.
+
+## Documentation
+Additional design artifacts and reports are in `docs/`, including:
+- Sequence diagrams
+- Class diagrams
+- SRS document

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -54,9 +54,9 @@ public class ClientController {
 
     private boolean loggedIn;
     private UserInfo currentUser;
-    /** #140/#142: true while a LOGIN or REGISTER request is enqueued and unresolved. */
+    /** True while a LOGIN or REGISTER request is enqueued and unresolved. */
     private volatile boolean authInFlight = false;
-    /** #139: cached on register() so handleRegisterResultResponse can pre-fill the login screen. */
+    /** Cached on register() so handleRegisterResultResponse can pre-fill the login screen. */
     private volatile String lastRegisteredLoginName = null;
 
     // -------------------------------------------------------------------------
@@ -114,26 +114,7 @@ public class ClientController {
         startInactivityDetectorThread();
     }
 
-    /** Runs the request loop in the current thread (blocking). For tests / headless use. */
-    void runRequestLoop() {
-        try {
-            ensureConnected();
-        } catch (IOException e) {
-            connectionStatus = ConnectionStatus.NOT_CONNECTED;
-            e.printStackTrace();
-            return;
-        }
-        try {
-            while (!Thread.currentThread().isInterrupted()) {
-                Request r = requestQueue.take();
-                sendRequest(r);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    /** Package-private test seam: accepts a pre-built (or null) GUI; no Swing window opened. */
+    /** Test-only seam (non-production flow): accepts a pre-built (or null) GUI; no Swing window opened. */
     ClientController(String hostIp, int hostPort, ClientUI guiOverride) {
         this.hostIp = hostIp;
         this.hostPort = hostPort;
@@ -252,7 +233,7 @@ public class ClientController {
 
     private void handleLoginResultResponse(Response response) {
         LoginResult lr = (LoginResult) response.getPayload();
-        // #193: coalesce field reset + UI updates into a single EDT task so the in-flight
+        // Coalesce field reset + UI updates into a single EDT task so the in-flight
         // flag and visible button state can never be observed out-of-order with each other.
         SwingUtilities.invokeLater(() -> {
             authInFlight = false;
@@ -280,13 +261,13 @@ public class ClientController {
 
     private void handleRegisterResultResponse(Response response) {
         RegisterResult rr = (RegisterResult) response.getPayload();
-        // #193: same EDT coalescing as handleLoginResultResponse.
+        // Same EDT coalescing as handleLoginResultResponse.
         SwingUtilities.invokeLater(() -> {
             authInFlight = false;
             if (gui != null) gui.setLoginInFlight(false);
             switch (rr.getRegisterStatus()) {
                 case SUCCESS:
-                    // #139B: pre-fill the just-registered loginName on the login screen.
+                    // Pre-fill the just-registered loginName on the login screen.
                     if (gui != null) gui.showLoginView(lastRegisteredLoginName);
                     break;
                 case USER_ID_TAKEN:
@@ -342,7 +323,7 @@ public class ClientController {
                 // Auto-open the newly created conversation in the center panel.
                 setCurrentConversationId(conv.getConversationId());
                 SwingUtilities.invokeLater(() -> gui.updateMessageListModel(conv));
-                // TODO: call gui.selectConversationInList(conv) once that method exists on ClientUI
+                // Follow-up enhancement: call gui.selectConversationInList(conv) when UI support is added.
             }
         }
     }
@@ -440,7 +421,7 @@ public class ClientController {
     private synchronized void ensureConnected() throws IOException {
         if (connectionStatus == ConnectionStatus.CONNECTED) return;
         connectionStatus = ConnectionStatus.CONNECTING;
-        // #138: bounded connect timeout so unreachable server fails fast instead of hanging ~75s.
+        // Bounded connect timeout so unreachable server fails fast instead of hanging ~75s.
         socket = new Socket();
         socket.connect(new InetSocketAddress(hostIp, hostPort), CONNECT_TIMEOUT_MS);
         // OOS must be created and flushed BEFORE OIS on both sides to avoid header deadlock
@@ -460,7 +441,7 @@ public class ClientController {
 
     /** Matches DataManager.handleRegister — payload: RegisterCredentials(userId, loginName, password, name). */
     public void register(String userId, String realName, String loginName, char[] password) {
-        if (authInFlight) return; // #140: drop rapid duplicate clicks
+        if (authInFlight) return; // Drop rapid duplicate clicks.
         authInFlight = true;
         lastRegisteredLoginName = loginName;
         if (gui != null) gui.setLoginInFlight(true);
@@ -470,7 +451,7 @@ public class ClientController {
 
     /** Matches DataManager.handleLogin — payload: LoginCredentials(loginName, password). */
     public void login(String loginName, char[] password) {
-        if (authInFlight) return; // #140: drop rapid duplicate clicks
+        if (authInFlight) return; // Drop rapid duplicate clicks.
         authInFlight = true;
         if (gui != null) gui.setLoginInFlight(true);
         LoginCredentials creds = new LoginCredentials(loginName, new String(password));
@@ -495,13 +476,13 @@ public class ClientController {
         if (gui != null) gui.showLoginView();
     }
 
-    /** #55/#124: read the cached admin search results so the dialog can seed itself on open
+    /** Read the cached admin search results so the dialog can seed itself on open
      *  even if the response arrived before the dialog finished constructing. */
     public ArrayList<ConversationMetadata> getCurrentAdminConversationSearch() {
         return currentAdminConversationSearch;
     }
 
-    /** #128: clear the cached admin search results so reopening the dialog starts fresh. */
+    /** Clear the cached admin search results so reopening the dialog starts fresh. */
     public void clearAdminConversationSearch() {
         currentAdminConversationSearch.clear();
     }
@@ -591,7 +572,7 @@ public class ClientController {
     public UserInfo getCurrentUserInfo() { return currentUser; }
     public boolean isLoggedIn()           { return loggedIn; }
 
-    /** Package-private: seeds the directory list for unit tests without a live server. */
+    /** Test-only seam (non-production flow): seeds the directory list for unit tests without a live server. */
     void setCurrentDirectoryForTesting(ArrayList<UserInfo> dir) {
         this.currentDirectory = new ArrayList<>(dir);
     }
@@ -721,7 +702,7 @@ public class ClientController {
                 } catch (IOException e) {
                     connectionStatus = ConnectionStatus.NOT_CONNECTED;
                     if (authInFlight) {
-                        // #138: drop the queued auth request and notify the user instead of
+                        // Drop the queued auth request and notify the user instead of
                         // silently retrying the unreachable server forever.
                         authInFlight = false;
                         if (gui != null) {

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -152,7 +152,7 @@ public class ClientUI {
         showLoginView(null);
     }
 
-    /** #139B: pre-fill login id (e.g. with the just-registered loginName) before showing the screen. */
+    /** Pre-fill login id (e.g. with the just-registered loginName) before showing the screen. */
     public void showLoginView(String prefilledLoginId) {
         SwingUtilities.invokeLater(() -> {
             // Fix 5: dispose any open dialogs before switching to login
@@ -246,7 +246,7 @@ public class ClientUI {
         return "<html><body style='width:" + safe + "px'>" + sb + "</body></html>";
     }
 
-    /** #141: wrap a password field with a Show/Hide toggle button. The wrapper JPanel takes the
+    /** Wrap a password field with a Show/Hide toggle button. The wrapper JPanel takes the
      *  field's place in any layout; the field reference itself is unchanged. */
     private static JPanel passwordFieldWithToggle(JPasswordField field) {
         JPanel wrap = new JPanel(new BorderLayout(2, 0));
@@ -306,7 +306,7 @@ public class ClientUI {
 
     public void showLoginError(LoginStatus loginStatus) {
         SwingUtilities.invokeLater(() -> {
-            // #139A: always clear the password on login failure.
+            // Always clear the password on login failure.
             cards.login.passwordField.setText("");
             String msg;
             String title = "Login Error";
@@ -318,7 +318,7 @@ public class ClientUI {
                     msg = "No account exists. Please create an account.";
                     break;
                 case DUPLICATE_SESSION:
-                    // #144: coherent, actionable copy that doesn't contradict itself.
+                    // Keep copy coherent and actionable without contradictions.
                     title = "Session Already Active";
                     msg = "You are already logged in from another location. Please log out of "
                         + "that session first, then try again. If you closed the app without "
@@ -331,7 +331,7 @@ public class ClientUI {
         });
     }
 
-    /** #138: shown when the server is unreachable so the user isn't stuck staring at a hung UI. */
+    /** Shown when the server is unreachable so the user isn't stuck staring at a hung UI. */
     public void showNetworkError() {
         SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(
                 frame,
@@ -340,7 +340,7 @@ public class ClientUI {
                 JOptionPane.ERROR_MESSAGE));
     }
 
-    /** #140/#142: drives the visible "submit in flight" state for both login and register. */
+    /** Drives the visible "submit in flight" state for both login and register. */
     public void setLoginInFlight(boolean inFlight) {
         SwingUtilities.invokeLater(() -> {
             if (cards == null) return; // pre-EDT init guard
@@ -415,7 +415,7 @@ public class ClientUI {
             // Route through ConversationView so auto-switch flows (first conversation,
             // leave-to-next conversation, etc.) also enable input and action buttons.
             cards.main.conversationView.setListModel(conversation);
-            // Issue #189: auto-switch should hand focus to message input, not leave it on
+            // Auto-switch should hand focus to message input, not leave it on
             // a stale directory selection.
             cards.main.directoryView.list.clearSelection();
             cards.main.directoryView.selecting = null;
@@ -441,7 +441,7 @@ public class ClientUI {
                 int last = cards.main.conversationView.list.getModel().getSize() - 1;
                 if (last >= 0) cards.main.conversationView.list.ensureIndexIsVisible(last);
             });
-            // Issue #176: notify user when window is not active
+            // Notify user when window is not active.
             UserInfo me = controller.getCurrentUserInfo();
             boolean fromOther = me != null && !message.getSenderId().equals(me.getUserId());
             if (fromOther && !frame.isActive()) {
@@ -543,7 +543,7 @@ public class ClientUI {
         }
     }
 
-    // =========================================================================
+    // -------------------------------------------------------------------------
     class ScreenCards extends JPanel {
         CardLayout layout;
         MainView main;
@@ -562,7 +562,7 @@ public class ClientUI {
         }
     }
 
-    // =========================================================================
+    // -------------------------------------------------------------------------
     class RegisterView extends JPanel {
         JTextField userId;
         JTextField loginName;
@@ -585,11 +585,11 @@ public class ClientUI {
         	createButton = new JButton("Create Account");
         	backButton = new JButton("Back");
 
-        	// #143: tooltips clarify which ID is which.
+        	// Tooltips clarify which ID is which.
         	userId.setToolTipText("Your organization-assigned employee ID. Must be pre-authorized.");
         	loginName.setToolTipText("Choose a username for logging in. Letters, numbers, hyphens, or underscores only.");
 
-        	// #146: heading at the top of the form.
+        	// Heading at the top of the form.
         	JLabel heading = new JLabel("Register / Create Account", SwingConstants.CENTER);
         	heading.setFont(heading.getFont().deriveFont(Font.BOLD, heading.getFont().getSize() + 6f));
         	heading.setBorder(BorderFactory.createEmptyBorder(20, 0, 10, 0));
@@ -605,7 +605,7 @@ public class ClientUI {
             gridConst.insets = new Insets(5, 5, 5, 5);
             gridConst.fill = GridBagConstraints.HORIZONTAL;
 
-            // #143: "User ID" → "Employee ID" (organization-assigned, validated against authorized list).
+            // "User ID" -> "Employee ID" (organization-assigned, validated against authorized list).
             gridConst.gridx = 0;
             gridConst.gridy = 0;
             inputPanel.add(new JLabel("Employee ID"), gridConst);
@@ -639,7 +639,7 @@ public class ClientUI {
             gridConst.gridy = 3;
             inputPanel.add(new JLabel("Password"), gridConst);
 
-            // #141: password text field with Show/Hide toggle on the right side of the label
+            // Password text field with Show/Hide toggle on the right side of the label.
             gridConst.gridx = 1;
             inputPanel.add(passwordFieldWithToggle(password), gridConst);
 
@@ -648,7 +648,7 @@ public class ClientUI {
             gridConst.gridy = 4;
             inputPanel.add(new JLabel("Confirm Password"), gridConst);
 
-            // #141: confirmation password field also gets a toggle
+            // Confirmation password field also gets a toggle.
             gridConst.gridx = 1;
             inputPanel.add(passwordFieldWithToggle(passwordAgain), gridConst);
 
@@ -660,7 +660,7 @@ public class ClientUI {
             // locate these parts at the center of the window
             add(inputPanel, BorderLayout.CENTER);
 
-            // #137: extract submit lambda so Enter on any field also fires it.
+            // Shared submit lambda so Enter on any field also fires it.
             ActionListener createAction = e -> {
                 char[] pwd1 = password.getPassword();
                 char[] pwd2 = passwordAgain.getPassword();
@@ -680,12 +680,12 @@ public class ClientUI {
             password.addActionListener(createAction);
             passwordAgain.addActionListener(createAction);
 
-            // #148: route through showLoginView so clearLoginAndRegisterFields() is called.
+            // Route through showLoginView so clearLoginAndRegisterFields() is called.
             backButton.addActionListener(e -> showLoginView());
         }
     }
 
-    // =========================================================================
+    // -------------------------------------------------------------------------
     class LoginView extends JPanel {
         JTextField login_idField;
         JPasswordField passwordField;
@@ -702,10 +702,10 @@ public class ClientUI {
             loginButton = new JButton("Login");
             createButton = new JButton("Create Account");
 
-            // #143: tooltip clarifies the field is the login username, not the Employee ID.
+            // Tooltip clarifies the field is the login username, not the Employee ID.
             login_idField.setToolTipText("Your chosen login username (not your Employee ID).");
 
-            // #146: heading at the top of the form.
+            // Heading at the top of the form.
             JLabel heading = new JLabel("Login", SwingConstants.CENTER);
             heading.setFont(heading.getFont().deriveFont(Font.BOLD, heading.getFont().getSize() + 6f));
             heading.setBorder(BorderFactory.createEmptyBorder(20, 0, 10, 0));
@@ -728,7 +728,7 @@ public class ClientUI {
             gridConst.gridx = 0;
             gridConst.gridy = 1;
             inputPanel.add(new JLabel("Password"), gridConst);
-            // #141: password text field with Show/Hide toggle on the right side of the label
+            // Password text field with Show/Hide toggle on the right side of the label.
             gridConst.gridx = 1;
             inputPanel.add(passwordFieldWithToggle(passwordField), gridConst);
             // add login button next to the fields
@@ -757,12 +757,12 @@ public class ClientUI {
             login_idField.addActionListener(loginAction);
             passwordField.addActionListener(loginAction);
 
-            // #148 (symmetric): route through showRegisterView so fields are cleared.
+            // Symmetric behavior: route through showRegisterView so fields are cleared.
             createButton.addActionListener(e -> showRegisterView());
         }
     }
 
-    // =========================================================================
+    // -------------------------------------------------------------------------
     class MainView extends JPanel {
         private static final int MIN_CONVERSATION_LIST_WIDTH = 240;
         ConversationView conversationView;
@@ -800,7 +800,7 @@ public class ClientUI {
 
     }
 
-    // =========================================================================
+    // -------------------------------------------------------------------------
     class ConversationView extends JPanel {
         JLabel participantsLabel;
         DefaultListModel<Message> conversationMessageListModel = new DefaultListModel<>();
@@ -819,7 +819,7 @@ public class ClientUI {
         // Fix 8: placeholder label shown when no conversation is selected
         private final JLabel placeholderLabel = new JLabel("Select a conversation to start chatting", SwingConstants.CENTER);
 
-        // Fix 6/#196: use JTextArea-based bubbles for deterministic wrapping.
+        // Use JTextArea-based bubbles for deterministic wrapping.
         private final class MessageCellRenderer extends JPanel implements ListCellRenderer<Message> {
             private final JPanel bubble = new JPanel(new BorderLayout(0, 2));
             private final JTextArea headerArea = new JTextArea();
@@ -1015,7 +1015,7 @@ public class ClientUI {
             // Fix 6: install the reusable cell renderer
             list.setCellRenderer(new MessageCellRenderer());
 
-            // Fix #183/#196: re-invalidate cached row heights whenever either the list or
+            // Re-invalidate cached row heights whenever either the list or
             // its viewport changes size so wrap width updates with window resizing.
             ComponentAdapter wrapResizeAdapter = new ComponentAdapter() {
                 @Override public void componentResized(ComponentEvent e) {
@@ -1075,7 +1075,7 @@ public class ClientUI {
                     public void windowClosed(WindowEvent e) {
                         addDialog = null;
                     }
-                    // #149: focus the list on open so Tab order is correct and Delete works.
+                    // Focus the list on open so Tab order is correct and Delete works.
                     @Override
                     public void windowOpened(WindowEvent e) {
                         addUserWindow.list.requestFocusInWindow();
@@ -1262,7 +1262,7 @@ public class ClientUI {
         }
     }
 
-    // =========================================================================
+    // -------------------------------------------------------------------------
     class DirectoryView extends JPanel {
         JLabel profileUserIdLabel;
         JLabel profileNameLabel;
@@ -1297,7 +1297,7 @@ public class ClientUI {
             createConversationButton.setEnabled(false);
 
             // construct admin button unconditionally and enable later if the user is admin
-            // #127: tooltip explains the prerequisite (a user must be selected). Label kept
+            // Tooltip explains the prerequisite (a user must be selected). Label kept
             // as "Admin" per the silent-viewer feature; the dialog itself shows what the
             // admin is doing.
             adminButton = new JButton("Admin");
@@ -1384,7 +1384,7 @@ public class ClientUI {
                 }
 
             	createConversationUserWindow = new SelectUserWindow(users -> controller.createConversation(users));
-                // Issue #192: seed the picker with the current directory selection
+                // Seed the picker with the current directory selection.
                 // so the first selection is honored without requiring reselection.
                 if (selecting != null) {
                     createConversationUserWindow.addUser(selecting);
@@ -1401,7 +1401,7 @@ public class ClientUI {
                     public void windowClosed(WindowEvent e) {
                         createDialog = null;
                     }
-                    // #149: focus the list on open so Tab order is correct and Delete works.
+                    // Focus the list on open so Tab order is correct and Delete works.
                     @Override
                     public void windowOpened(WindowEvent e) {
                         createConversationUserWindow.list.requestFocusInWindow();
@@ -1442,7 +1442,7 @@ public class ClientUI {
                 adminDialog.addWindowListener(new WindowAdapter() {
                     @Override
                     public void windowClosed(WindowEvent e) {
-                    	// #128: clear all admin-dialog state so reopening shows a fresh empty list.
+                    	// Clear all admin-dialog state so reopening shows a fresh empty list.
                     	// Do NOT disable adminButton here — the directory selection listener
                     	// owns its enable/disable state, and disabling on close traps the
                     	// button in a dead state when the same user is still selected (the
@@ -1513,7 +1513,7 @@ public class ClientUI {
 
     }
 
-    // =========================================================================
+    // -------------------------------------------------------------------------
     class ConversationListView extends JPanel {
         JTextField searchField;
         DefaultListModel<Conversation> listModel = new DefaultListModel<>();
@@ -1590,8 +1590,7 @@ public class ClientUI {
                 }
             });
 
-            // TODO: label the conversation
-            // TODO: unread markers
+            // Planned UX follow-up: richer conversation row labels and unread badges.
             // add action for selecting an item from the list
             list.addListSelectionListener(e-> {
                 if (suppressSelectionEvents) {
@@ -1627,7 +1626,7 @@ public class ClientUI {
         }
     }
 
-    // =========================================================================
+    // -------------------------------------------------------------------------
     class SelectUserWindow extends JPanel {
         DefaultListModel<UserInfo> model = new DefaultListModel<>();
         JList<UserInfo> list = new JList<>(model);
@@ -1698,7 +1697,7 @@ public class ClientUI {
 			    }
             });
 
-            // #149: Delete key on the list invokes Remove (so the button is reachable by keyboard).
+            // Delete key on the list invokes Remove (so the button is reachable by keyboard).
             list.getInputMap(JComponent.WHEN_FOCUSED)
                     .put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), "removeSelected");
             list.getInputMap(JComponent.WHEN_FOCUSED)
@@ -1723,7 +1722,7 @@ public class ClientUI {
 
     }
 
-    // =========================================================================
+    // -------------------------------------------------------------------------
     class AdminConversationSearchWindow extends JPanel {
         JTextField searchField;
         DefaultListModel<ConversationMetadata> model = new DefaultListModel<>();
@@ -1731,7 +1730,7 @@ public class ClientUI {
         JButton closeButton;
         ViewerPanel viewerPanel;
 
-        // #126: render each search result as "[ID: N] TYPE • K participant(s) • last active <ts>"
+        // Render each search result as "[ID: N] TYPE • K participant(s) • last active <ts>".
         // (or "no messages yet"). Modeled on ConversationCellRenderer above.
         private final class AdminConversationCellRenderer extends DefaultListCellRenderer {
             @Override
@@ -1922,7 +1921,7 @@ public class ClientUI {
             // LEFT pane — search field + conversation list
             JPanel leftPanel = new JPanel(new BorderLayout());
             leftPanel.add(searchField, BorderLayout.NORTH);
-            // #126: install the custom cell renderer so each row shows ID, type, count, recency.
+            // Install the custom cell renderer so each row shows ID, type, count, recency.
             list.setCellRenderer(new AdminConversationCellRenderer());
             leftPanel.add(new JScrollPane(list), BorderLayout.CENTER);
 
@@ -1940,7 +1939,7 @@ public class ClientUI {
             buttonPane.add(closeButton);
             add(buttonPane, BorderLayout.SOUTH);
 
-            // #55/#124: seed from the controller's cache. If the ADMIN_CONVERSATION_RESULT
+            // Seed from the controller's cache. If the ADMIN_CONVERSATION_RESULT
             // response arrived before this window was constructed (race on fast loopback),
             // the data is already in the cache and we render it immediately. The async
             // updateAdminConversationSearchModel callback path stays for late responses.
@@ -1984,7 +1983,7 @@ public class ClientUI {
         	return model;
         }
 
-        /** #193 entry point — called from ClientUI.showAdminConversationView. */
+        /** Entry point called from ClientUI.showAdminConversationView. */
         public void loadConversation(Conversation conv) {
             viewerPanel.loadConversation(conv);
         }

--- a/src/shared/networking/ConnectionListener.java
+++ b/src/shared/networking/ConnectionListener.java
@@ -35,10 +35,6 @@ public class ConnectionListener {
     private volatile boolean running = false;
     private volatile ServerSocket serverSocket;
 
-    public ConnectionListener(ServerController serverController) {
-        this("localhost", 8080, serverController);
-    }
-
     public ConnectionListener(String hostAddress, int hostPort, ServerController serverController) {
         this.hostPort = hostPort;
         this.hostAddress = hostAddress;
@@ -82,7 +78,7 @@ public class ConnectionListener {
     /**
      * Returns the TCP port the server socket is actually bound to.
      * Blocks up to 5 seconds for {@link #listen()} to bind the socket.
-     * Useful for tests that use port 0 (OS-assigned port).
+     * Primarily a test-support seam (non-production flow), especially for port 0 (OS-assigned port).
      *
      * @return bound port number, or -1 on timeout / bind failure
      */


### PR DESCRIPTION
- Add Eclipse .project, .classpath, and Java 17 compiler prefs for import
- Track Eclipse metadata: stop ignoring .project and .classpath in .gitignore
- Expand README (setup, IP Finder, management .txt layout, troubleshooting)
- Remove GitHub-issue-style comments; normalize section dividers in ClientUI
- Remove unused ConnectionListener overload and ClientController.runRequestLoop
- Document test-oriented ConnectionListener.getLocalPort