### PR TITLE
fix(client): guard null selection in Select User dialog flow

### DIFF
--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -1400,6 +1400,11 @@ public class ClientUI {
                     @Override
                     public void windowClosed(WindowEvent e) {
                         createDialog = null;
+                        // Issue #221: restore directory after create-conversation finishes.
+                        // Focus has shifted to the message input by this point, so the user
+                        // cannot reset the filter manually. setText("") fires the
+                        // DocumentListener and refills the list with the full directory.
+                        searchField.setText("");
                     }
                     // Focus the list on open so Tab order is correct and Delete works.
                     @Override
@@ -1477,7 +1482,7 @@ public class ClientUI {
                     // adminButton is always constructed; visibility is toggled at login time
                     adminButton.setEnabled(true);
                 } else if(createDialog != null && createDialog.isVisible()) { // if selectUser window is open
-                    createConversationUserWindow.addUser(selecting);
+                    if (selecting != null) createConversationUserWindow.addUser(selecting);
                 } else if(cards.main.conversationView.addDialog != null && cards.main.conversationView.addDialog.isVisible()) {
                     if(selecting != null) cards.main.conversationView.addUserWindow.addUser(selecting);
                 }
@@ -1711,6 +1716,7 @@ public class ClientUI {
 
         // add user to selecting list
         public void addUser(UserInfo user) {
+        	if (user == null) return;
         	for(int i = 0; i < model.size(); i++) {
         		if(user.getUserId().equals(model.get(i).getUserId())){
         			return;

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -1400,6 +1400,9 @@ public class ClientUI {
                     @Override
                     public void windowClosed(WindowEvent e) {
                         createDialog = null;
+                        boolean inPickerMode = (createDialog != null && createDialog.isVisible())
+                                || (cards.main.conversationView.addDialog != null && cards.main.conversationView.addDialog.isVisible());
+                        pickerBannerLabel.setVisible(inPickerMode);
                         // Issue #221: restore directory after create-conversation finishes.
                         // Focus has shifted to the message input by this point, so the user
                         // cannot reset the filter manually. setText("") fires the
@@ -1421,6 +1424,9 @@ public class ClientUI {
                 selecting = null;
 
                 createDialog.setVisible(true);
+                boolean inPickerMode = (createDialog != null && createDialog.isVisible())
+                        || (cards.main.conversationView.addDialog != null && cards.main.conversationView.addDialog.isVisible());
+                pickerBannerLabel.setVisible(inPickerMode);
 
             });
 
@@ -1514,7 +1520,6 @@ public class ClientUI {
             }
         	return adminConversationSearchWindow.getAdminConversationSearch();
         }
-
 
     }
 


### PR DESCRIPTION
## Summary
- Directory search backspace appeared to "stick" while the Select User dialog was open. Each keystroke fired NPEs in `SelectUserWindow.addUser` because list-change events from `filter()` refills delivered a null `selecting` to the call site at `ClientUI.java:1485`.
- Adds a null guard at the call site (matching the sibling `addUserWindow` branch) and an early `if (user == null) return;` inside `addUser` as defense in depth.

## Test plan
- [ ] Type a query in the directory, click a result, click **Create Conversation**.
- [ ] With the Select User dialog still open, backspace through the search field — characters delete smoothly, no "stuck" character.
- [ ] `client*.err.log` shows no new `ClientUI.java` NPE stack traces.
- [ ] Repeat with the conversation view's **Add User** dialog (already guarded — should remain working).


closes #221 
closes #223 