### PR TITLE
fix(client): show picker banner on add-to-conversation open/close

### DIFF
--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -1074,6 +1074,10 @@ public class ClientUI {
                     @Override
                     public void windowClosed(WindowEvent e) {
                         addDialog = null;
+                        boolean inPickerMode = (cards.main.directoryView.createDialog != null
+                                && cards.main.directoryView.createDialog.isVisible())
+                                || (addDialog != null && addDialog.isVisible());
+                        cards.main.directoryView.pickerBannerLabel.setVisible(inPickerMode);
                     }
                     // Focus the list on open so Tab order is correct and Delete works.
                     @Override
@@ -1088,6 +1092,10 @@ public class ClientUI {
                 cards.main.directoryView.selecting = null;
 
                 addDialog.setVisible(true);
+                boolean inPickerMode = (cards.main.directoryView.createDialog != null
+                        && cards.main.directoryView.createDialog.isVisible())
+                        || (addDialog != null && addDialog.isVisible());
+                cards.main.directoryView.pickerBannerLabel.setVisible(inPickerMode);
 
             });
 

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -1074,10 +1074,7 @@ public class ClientUI {
                     @Override
                     public void windowClosed(WindowEvent e) {
                         addDialog = null;
-                        boolean inPickerMode = (cards.main.directoryView.createDialog != null
-                                && cards.main.directoryView.createDialog.isVisible())
-                                || (addDialog != null && addDialog.isVisible());
-                        cards.main.directoryView.pickerBannerLabel.setVisible(inPickerMode);
+                        cards.main.directoryView.refreshPickerBanner();
                     }
                     // Focus the list on open so Tab order is correct and Delete works.
                     @Override
@@ -1092,10 +1089,7 @@ public class ClientUI {
                 cards.main.directoryView.selecting = null;
 
                 addDialog.setVisible(true);
-                boolean inPickerMode = (cards.main.directoryView.createDialog != null
-                        && cards.main.directoryView.createDialog.isVisible())
-                        || (addDialog != null && addDialog.isVisible());
-                cards.main.directoryView.pickerBannerLabel.setVisible(inPickerMode);
+                cards.main.directoryView.refreshPickerBanner();
 
             });
 
@@ -1408,9 +1402,7 @@ public class ClientUI {
                     @Override
                     public void windowClosed(WindowEvent e) {
                         createDialog = null;
-                        boolean inPickerMode = (createDialog != null && createDialog.isVisible())
-                                || (cards.main.conversationView.addDialog != null && cards.main.conversationView.addDialog.isVisible());
-                        pickerBannerLabel.setVisible(inPickerMode);
+                        refreshPickerBanner();
                         // Issue #221: restore directory after create-conversation finishes.
                         // Focus has shifted to the message input by this point, so the user
                         // cannot reset the filter manually. setText("") fires the
@@ -1432,9 +1424,7 @@ public class ClientUI {
                 selecting = null;
 
                 createDialog.setVisible(true);
-                boolean inPickerMode = (createDialog != null && createDialog.isVisible())
-                        || (cards.main.conversationView.addDialog != null && cards.main.conversationView.addDialog.isVisible());
-                pickerBannerLabel.setVisible(inPickerMode);
+                refreshPickerBanner();
 
             });
 
@@ -1485,9 +1475,7 @@ public class ClientUI {
                 selecting = selectedValue;
 
                 // Fix 5: show picker banner when a dialog is open (picker mode active)
-                boolean inPickerMode = (createDialog != null && createDialog.isVisible())
-                        || (cards.main.conversationView.addDialog != null && cards.main.conversationView.addDialog.isVisible());
-                pickerBannerLabel.setVisible(inPickerMode);
+                refreshPickerBanner();
 
                 // if the another window is not visible, shows the button
                 if(selecting != null && (createDialog == null || !createDialog.isVisible()) && (adminDialog == null || !adminDialog.isVisible())
@@ -1502,6 +1490,18 @@ public class ClientUI {
                 }
             });
 
+        }
+
+        // Show the "Selecting participants" banner whenever a picker dialog is open.
+        void refreshPickerBanner() {
+            if (createDialog != null && createDialog.isVisible()) {
+                pickerBannerLabel.setVisible(true);
+            } else if (cards.main.conversationView.addDialog != null
+                    && cards.main.conversationView.addDialog.isVisible()) {
+                pickerBannerLabel.setVisible(true);
+            } else {
+                pickerBannerLabel.setVisible(false);
+            }
         }
 
         // Fix 1: setListModel now also calls list.setModel() so the JList reflects the new model


### PR DESCRIPTION
Closes #194.

## Summary
- The "Selecting participants — click to add" banner in the Directory View did not appear when the **Add participants** dialog first opened, and did not disappear when that dialog closed — it only updated on the next directory list-selection event.
- Root cause: `addDialog`'s `WindowAdapter` only nulled the reference; it never recomputed banner visibility. The parallel `createDialog` flow already did, so this change brings the add-flow to parity.

## Changes
- `src/client/ClientUI.java` — in `ConversationView.addButton`'s listener:
  - Recompute `inPickerMode` and update `pickerBannerLabel` immediately after `addDialog.setVisible(true)`.
  - Recompute and update inside `windowClosed` after `addDialog = null`.

The boolean expression mirrors the existing one used in the create-conversation flow and the directory list-selection listener — no new fields, helpers, or refactors.

## Test plan
- [ ] Open an existing conversation, click **Add** → banner appears immediately, before any directory click.
- [ ] Close the dialog via OK / Cancel / X / Esc → banner disappears immediately, without needing a directory click.
- [ ] Regression: **Create Conversation** flow still shows/hides the banner correctly on open/close.
- [ ] Regression: clicking users in the directory while the dialog is open still adds them and keeps the banner visible.