### PR TITLE
fix(client): sort conversation list by recency on login

### DIFF
--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -242,8 +242,10 @@ public class ClientController {
                 case SUCCESS:
                     loggedIn = true;
                     currentUser = lr.getUserInfo();
-                    conversations = Collections.synchronizedList(
-                            lr.getConversationList() != null ? lr.getConversationList() : new ArrayList<>());
+                    List<Conversation> initial = lr.getConversationList() != null
+                            ? lr.getConversationList() : new ArrayList<>();
+                    initial.sort((a, b) -> Long.compare(latestSequenceNumber(b), latestSequenceNumber(a)));
+                    conversations = Collections.synchronizedList(initial);
                     currentDirectory = lr.getDirectoryUserInfoList() != null
                             ? lr.getDirectoryUserInfoList() : new ArrayList<>();
                     if (gui != null) {


### PR DESCRIPTION
## Summary
On login, the client was assigning the server's conversation list verbatim. The server builds it by iterating a `ConcurrentHashMap.newKeySet()`, so the order is undefined. The display layer sorted only a copy, but the backing field stayed unsorted — silently breaking the "index 0 = most recent" invariant that `handleMessageResponse` and `handleConversationResponse` rely on (`add(0, ...)`).

## Fix
Sort the incoming list once in `handleLoginResultResponse` using the existing `latestSequenceNumber` comparator before wrapping it in `synchronizedList`. 3 lines, character-identical to the comparator already used in `getFilteredConversationList`.

## Test plan
- [x] Compiles clean (`src` + `utils` + `test`)
- [ ] Manual: log in as a user with multiple conversations of varying recency → list renders top-to-bottom in descending recency immediately on login (not only after a new event arrives)
- [ ] Manual: from another client, send a message into the bottom conversation → it jumps to index 0 in the logged-in user's list (regression check on the existing bump invariant)

Closes #226