### PR TITLE
fix: disabled leave conversation button for DM

### DIFF
--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -989,6 +989,7 @@ public class ClientUI {
             // Fix 10: gate buttons — disabled until a conversation is selected
             addButton.setEnabled(false);
             leaveButton.setEnabled(false);
+            leaveButton.setVisible(false);
             sendButton.setEnabled(false);
 
             setLayout(new BorderLayout());
@@ -1204,7 +1205,12 @@ public class ClientUI {
                 text.setEnabled(true);
                 // Fix 10: enable buttons when a conversation is selected
                 addButton.setEnabled(true);
-                leaveButton.setEnabled(true);
+                boolean canLeave = currConv.getType() != shared.enums.ConversationType.PRIVATE;
+                leaveButton.setVisible(canLeave);
+                leaveButton.setEnabled(canLeave);
+                if (leaveButton.getParent() != null) {
+                    leaveButton.getParent().revalidate();
+                }
                 sendButton.setEnabled(!text.getText().trim().isEmpty());
                 // Fix 8: hide placeholder once a conversation is loaded
                 placeholderLabel.setVisible(false);
@@ -1229,9 +1235,13 @@ public class ClientUI {
                 // Fix 10: disable buttons when no conversation is active
                 addButton.setEnabled(false);
                 leaveButton.setEnabled(false);
+                leaveButton.setVisible(false);
                 sendButton.setEnabled(false);
                 // Fix 8: show placeholder again
                 placeholderLabel.setVisible(true);
+                if (leaveButton.getParent() != null) {
+                    leaveButton.getParent().revalidate();
+                }
             });
         }
 


### PR DESCRIPTION
##Summary
Hides and disables Leave for private DMs in the client conversation view so users cannot easily put a private thread into a state the app cannot recover.

##Context
While working on [[Data Manager] abandoned DM not reactivated upon activity · Issue #234](https://github.com/YoonJon/CS401-Communications/issues/234), it became clear we do not have a reliable way to bring back a private conversation once it is fully abandoned in a way that leaves no active participant and no viable re-entry path. In other words: there is no implemented recovery for a doubly abandoned (or otherwise unowned) private DM under the current design.

Rather than implying a server-side “revive” that we don’t actually have end-to-end, this change avoids the failure mode at the UI layer by not offering Leave on private conversations.

##Changes
ClientUI (ConversationView)
When a conversation is loaded: Leave is shown and enabled only if the thread is not PRIVATE.
For private DMs: Leave is hidden and disabled.
When no conversation is selected: Leave stays hidden/disabled; initial construction matches that.
##Testing
- [ ] Manual: select a private DM → Leave absent; select a group thread → Leave present and behaves as before.

##Follow-ups (optional)
Enforce the same rule in DataManager (reject or no-op leave on PRIVATE) so behavior cannot be bypassed by another client.
If product needs “leave private” later, spec an explicit recovery model (e.g. who may resurrect, id stability, fork vs same id) before re-enabling the control.

closes #234