### PR TITLE
fix(server): move conversation to top for all members on add-participant

### DIFF
--- a/src/server/DataManager.java
+++ b/src/server/DataManager.java
@@ -479,6 +479,29 @@ public class DataManager {
         }
     }
 
+    // Builds and appends a SYSTEM "X added Y, Z" event so existing members' GUI sort
+    // (by lastMessageSequenceNumber) reorders the conversation to the top.
+    private Message appendAddParticipantSystemMessage(Conversation conversation,
+                                                     String requesterId,
+                                                     ArrayList<UserInfo> added) {
+        StringBuilder names = new StringBuilder();
+        for (int i = 0; i < added.size(); i++) {
+            if (i > 0) names.append(i == added.size() - 1 ? " and " : ", ");
+            names.append(added.get(i).getUserId());
+        }
+        Message systemMessage = new Message(
+                requesterId + " added " + names,
+                nextMessageSequenceNumber(),
+                new Date(),
+                "SYSTEM",
+                conversation.getConversationId());
+        synchronized (conversation) {
+            conversation.append(systemMessage);
+            persistConversation(conversation);
+        }
+        return systemMessage;
+    }
+
     // --- User ↔ conversation membership index ---
 
     /**
@@ -703,7 +726,7 @@ public class DataManager {
         if (existing.getType() == ConversationType.GROUP) {
             existing.addParticipants(netNew);
             linkParticipantsToConversation(targetConversationId, netNew);
-            persistConversation(existing);
+            appendAddParticipantSystemMessage(existing, request.getSenderId(), netNew);
             return new Response(ResponseType.CONVERSATION, existing);
         }
 
@@ -715,7 +738,7 @@ public class DataManager {
             Conversation forked = new Conversation(forkId, merged);
             conversationsByConversationID.put(forkId, forked);
             linkParticipantsToConversation(forkId, forked.getParticipants());
-            persistConversation(forked);
+            appendAddParticipantSystemMessage(forked, request.getSenderId(), netNew);
             return new Response(ResponseType.CONVERSATION, forked);
         }
 

--- a/src/server/ServerController.java
+++ b/src/server/ServerController.java
@@ -260,6 +260,23 @@ public class ServerController {
         Conversation conversation = (Conversation) response.getPayload();
         AddToConversationPayload payload = (AddToConversationPayload) request.getPayload();
         ArrayList<UserInfo> participantsToAdd = payload.getParticipants();
+
+        // PRIVATE-fork case: server minted a new conversation id, so existing participants
+        // of the original thread have never seen this id and would silently drop a metadata
+        // frame for it. Send the full Conversation to every roster member except the
+        // requester (the requester gets it via the direct processRequest return path).
+        if (conversation.getConversationId() != payload.getTargetConversationId()) {
+            String requesterId = request.getSenderId();
+            ArrayList<UserInfo> recipients = new ArrayList<>();
+            for (UserInfo p : conversation.getParticipants()) {
+                if (p == null || p.getUserId() == null) continue;
+                if (p.getUserId().equals(requesterId)) continue;
+                recipients.add(p);
+            }
+            enqueueToActiveParticipants(recipients, response);
+            return;
+        }
+
         Response metadataResponse = new Response(ResponseType.CONVERSATION_METADATA, conversation.toMetadata());
         ArrayList<UserInfo> existingParticipants = new ArrayList<>();
         for (UserInfo participant : conversation.getParticipants()) {
@@ -279,6 +296,20 @@ public class ServerController {
             }
         }
         enqueueToActiveParticipants(existingParticipants, metadataResponse);
+
+        // Also broadcast the SYSTEM "X added Y" message so existing members'
+        // handleMessageResponse appends it, bumping lastMessageSequenceNumber and moving
+        // the conversation to 1st place. The added participants and the requester already
+        // see it inside the full Conversation payload they receive.
+        ArrayList<Message> messages = conversation.getMessages();
+        if (!messages.isEmpty()) {
+            Message systemMessage = messages.get(messages.size() - 1);
+            if ("SYSTEM".equals(systemMessage.getSenderId())) {
+                Response systemMessageResponse = new Response(ResponseType.MESSAGE, systemMessage);
+                enqueueToActiveParticipants(existingParticipants, systemMessageResponse);
+            }
+        }
+
         if (participantsToAdd != null) {
             enqueueToActiveParticipants(participantsToAdd, response);
         }

--- a/test/server/DataManagerTest.java
+++ b/test/server/DataManagerTest.java
@@ -196,6 +196,56 @@ public class DataManagerTest {
         assertNull(r);
     }
 
+    @Test
+    void handleAddToConversation_privateForkAppendsSystemMessage() {
+        // Seed a PRIVATE u1+u2 conversation, then add u3. The forked GROUP must contain
+        // exactly one Message whose sender is "SYSTEM" — this bumps lastMessageSequenceNumber
+        // so the GUI sort puts it at 1st place for everyone.
+        Response create = dm.handleCreateConversation(new Request(RequestType.CREATE_CONVERSATION,
+                new CreateConversationPayload(roster(ui("u1", "Alice"), ui("u2", "Bob"))),
+                "u1"));
+        long privateId = ((Conversation) create.getPayload()).getConversationId();
+
+        Response forkResp = dm.handleAddToConversation(new Request(RequestType.ADD_PARTICIPANT,
+                new AddToConversationPayload(roster(ui("u3", "Carol")), privateId),
+                "u1"));
+        Conversation forked = (Conversation) forkResp.getPayload();
+        assertNotEquals(privateId, forked.getConversationId(), "fork minted a new id");
+        ArrayList<Message> messages = forked.getMessages();
+        assertEquals(1, messages.size(), "forked conversation has exactly one message (SYSTEM)");
+        assertEquals("SYSTEM", messages.get(0).getSenderId());
+        assertTrue(messages.get(0).getText().contains("u3"), "system message names the added user");
+    }
+
+    @Test
+    void handleAddToConversation_groupAddAppendsSystemMessage() {
+        // Seed a GROUP u1+u2+u3, send a normal message, then add u4. The grown GROUP
+        // must contain a SYSTEM message AS THE LAST entry whose sequence number is
+        // strictly greater than the previously-sent normal message — this is what
+        // ServerController.enqueueAddParticipantBroadcast extracts and forwards to
+        // existing members so their list reorders to 1st place.
+        Response create = dm.handleCreateConversation(new Request(RequestType.CREATE_CONVERSATION,
+                new CreateConversationPayload(roster(ui("u1", "Alice"), ui("u2", "Bob"), ui("u3", "Carol"))),
+                "u1"));
+        long groupId = ((Conversation) create.getPayload()).getConversationId();
+
+        Response sent = dm.handleSendMessage(new Request(RequestType.MESSAGE,
+                new RawMessage("hi", groupId), "u1"));
+        long priorSeq = ((Message) sent.getPayload()).getSequenceNumber();
+
+        Response addResp = dm.handleAddToConversation(new Request(RequestType.ADD_PARTICIPANT,
+                new AddToConversationPayload(roster(ui("u4", "Dan")), groupId),
+                "u1"));
+        Conversation grown = (Conversation) addResp.getPayload();
+        assertEquals(groupId, grown.getConversationId(), "GROUP add does not fork");
+        ArrayList<Message> messages = grown.getMessages();
+        Message last = messages.get(messages.size() - 1);
+        assertEquals("SYSTEM", last.getSenderId(), "last message is SYSTEM");
+        assertTrue(last.getSequenceNumber() > priorSeq,
+                "SYSTEM seq (" + last.getSequenceNumber() + ") > prior seq (" + priorSeq + ")");
+        assertTrue(last.getText().contains("u4"), "system message names the added user");
+    }
+
     // -------------------------------------------------------------------------
     // End-to-end smoke: walks every handler once in a realistic order
     // -------------------------------------------------------------------------

--- a/test/server/ServerControllerTest.java
+++ b/test/server/ServerControllerTest.java
@@ -254,6 +254,99 @@ class ServerControllerTest {
     }
 
     @Test
+    void enqueueAddParticipantBroadcastForkSendsFullConversationToAll() throws Exception {
+        // PRIVATE-fork case: server returns a NEW conversation id (202L) that differs from
+        // the request's targetConversationId (101L). The broadcast layer must detect this
+        // and send the full Conversation to every roster member except the requester,
+        // because existing participants of the original PRIVATE thread have never seen
+        // the new id and would silently drop a CONVERSATION_METADATA frame.
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        Conversation forked = new Conversation(202L, participants("u1", "u2", "u3"));
+        stub.responses.put(RequestType.ADD_PARTICIPANT, new Response(ResponseType.CONVERSATION, forked));
+        stub.participantsByConversationId.put(101L, participants("u1", "u2"));
+        stub.participantsByConversationId.put(202L, participants("u1", "u2", "u3"));
+
+        server = buildServerWithStub(stub);
+        LinkedBlockingQueue<Map.Entry<String, Response>> queue = getResponseQueue(server);
+        server.addSession("u1", noOpHandler());
+        server.addSession("u2", noOpHandler());
+        server.addSession("u3", noOpHandler());
+
+        assertEquals(ResponseType.CONVERSATION, server.processRequest(
+                new Request(RequestType.ADD_PARTICIPANT,
+                        new AddToConversationPayload(participants("u3"), 101L),
+                        "u1")).getType());
+
+        Map.Entry<String, Response> a = queue.poll();
+        Map.Entry<String, Response> b = queue.poll();
+        assertNotNull(a);
+        assertNotNull(b);
+        assertNull(queue.poll());
+        Map<String, Response> deliveries = Map.of(a.getKey(), a.getValue(), b.getKey(), b.getValue());
+        assertEquals(Set.of("u2", "u3"), deliveries.keySet());
+        assertTrue(deliveries.get("u2").getPayload() instanceof Conversation);
+        assertTrue(deliveries.get("u3").getPayload() instanceof Conversation);
+        assertEquals(202L, ((Conversation) deliveries.get("u2").getPayload()).getConversationId());
+        assertEquals(202L, ((Conversation) deliveries.get("u3").getPayload()).getConversationId());
+    }
+
+    @Test
+    void enqueueAddParticipantBroadcastGroupAddSendsMetadataPlusSystemMessage() throws Exception {
+        // GROUP path: existing GROUP gets a new member. Existing members (not the requester,
+        // not the added) must receive BOTH a CONVERSATION_METADATA frame AND a MESSAGE frame
+        // for the SYSTEM "added" message, so their lastMessageSequenceNumber bumps and the
+        // conversation reorders to 1st place.
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        Conversation grown = new Conversation(55L, participants("u1", "u2", "u3", "u4"));
+        grown.append(new Message("u1 added u4", 999L, new java.util.Date(), "SYSTEM", 55L));
+        stub.responses.put(RequestType.ADD_PARTICIPANT, new Response(ResponseType.CONVERSATION, grown));
+        stub.participantsByConversationId.put(55L, participants("u1", "u2", "u3", "u4"));
+
+        server = buildServerWithStub(stub);
+        LinkedBlockingQueue<Map.Entry<String, Response>> queue = getResponseQueue(server);
+        server.addSession("u1", noOpHandler()); // requester
+        server.addSession("u2", noOpHandler()); // existing
+        server.addSession("u3", noOpHandler()); // existing
+        server.addSession("u4", noOpHandler()); // added
+
+        assertEquals(ResponseType.CONVERSATION, server.processRequest(
+                new Request(RequestType.ADD_PARTICIPANT,
+                        new AddToConversationPayload(participants("u4"), 55L),
+                        "u1")).getType());
+
+        Map<String, ArrayList<Response>> byRecipient = new HashMap<>();
+        Map.Entry<String, Response> entry;
+        while ((entry = queue.poll()) != null) {
+            byRecipient.computeIfAbsent(entry.getKey(), k -> new ArrayList<>()).add(entry.getValue());
+        }
+
+        // u1 (requester) receives a CONVERSATION_METADATA via the existing (unfiltered) bucket.
+        // This is the pre-existing benign quirk noted in the plan's "Out of scope" section.
+        // u4 (added) gets exactly one full CONVERSATION.
+        assertEquals(1, byRecipient.get("u4").size());
+        assertEquals(ResponseType.CONVERSATION, byRecipient.get("u4").get(0).getType());
+
+        // u2 and u3 each get exactly: one CONVERSATION_METADATA AND one MESSAGE (the SYSTEM msg).
+        for (String existing : new String[]{"u2", "u3"}) {
+            ArrayList<Response> got = byRecipient.get(existing);
+            assertNotNull(got, existing + " should receive broadcasts");
+            assertEquals(2, got.size(), existing + " should receive 2 frames");
+            boolean sawMetadata = false;
+            boolean sawSystemMessage = false;
+            for (Response r : got) {
+                if (r.getType() == ResponseType.CONVERSATION_METADATA) {
+                    sawMetadata = true;
+                } else if (r.getType() == ResponseType.MESSAGE) {
+                    sawSystemMessage = true;
+                    assertEquals("SYSTEM", ((Message) r.getPayload()).getSenderId());
+                }
+            }
+            assertTrue(sawMetadata, existing + " should see CONVERSATION_METADATA");
+            assertTrue(sawSystemMessage, existing + " should see SYSTEM MESSAGE");
+        }
+    }
+
+    @Test
     void logoutRemovesSession() throws Exception {
         server = buildServerWithStub();
         server.addSession("u1", noOpHandler());


### PR DESCRIPTION
## Summary

When a user adds a new participant to a chat, append a SYSTEM "X added Y" message to the conversation. This bumps `lastMessageSequenceNumber` so every recipient's client reorders the conversation to position 0.

## What this fixes

- [ ] **PRIVATE -> GROUP fork:** A has 1-1 with B; A adds C. New A+B+C group lands at position 0 for A, B, **and** C.
- [ ] **Existing GROUP add:** A+B+C group exists; A adds D. Group jumps to position 0 for A, B, C, **and** D.

Previously the GROUP-add path only sent `CONVERSATION_METADATA` to existing members, which does not mutate the client's conversation list — so B and C never reordered. The fork path appeared to work only by accident (sort fell back to `conversationId`, which is an independent counter from `messageSequenceNumber`).

## Changes

- [ ] `DataManager.handleAddToConversation` appends a SYSTEM message in both branches via new helper `appendAddParticipantSystemMessage`
- [ ] `ServerController.enqueueAddParticipantBroadcast` additionally broadcasts the SYSTEM message as a `MESSAGE` response to existing members on the GROUP-add path (their `handleMessageResponse` does the `removeIf + add(0, c)` reorder)
- [ ] Fork branch on the broadcast side is unchanged — the SYSTEM message rides inside the full `Conversation` payload that is already broadcast to all
- [ ] System message persists with the conversation, so it shows in scrollback after restart

## Test plan

- [ ] `DataManagerTest.handleAddToConversation_privateForkAppendsSystemMessage`
- [ ] `DataManagerTest.handleAddToConversation_groupAddAppendsSystemMessage`
- [ ] `ServerControllerTest.enqueueAddParticipantBroadcastGroupAddSendsMetadataPlusSystemMessage`
- [ ] Full suite: 69/69 pass (66 prior + 3 new)
- [ ] Manual smoke: PRIVATE -> GROUP fork with 3 logged-in clients, verify position 0 for all
- [ ] Manual smoke: GROUP add with 4 logged-in clients, verify position 0 for all
- [ ] Manual smoke: restart server, verify SYSTEM message persists in scrollback