### PR TITLE
fix: show display names in add-participant system message

### DIFF
--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -887,7 +887,8 @@ public class ClientUI {
                 String ts = zdt.format(dtf);
                 String rawText = msg.getText() == null ? "" : msg.getText();
                 boolean isOwnMessage = msg.getSenderId().equals(controller.getCurrentUserInfo().getUserId());
-                String header = isOwnMessage ? ts : (ts + " " + senderName + ":");
+                boolean isSystem = "SYSTEM".equals(msg.getSenderId());
+                String header = (isOwnMessage || isSystem) ? ts : (ts + " " + senderName + ":");
 
                 long lastReadSeq = displayedLastReadSeq;
 

--- a/src/server/DataManager.java
+++ b/src/server/DataManager.java
@@ -484,13 +484,20 @@ public class DataManager {
     private Message appendAddParticipantSystemMessage(Conversation conversation,
                                                      String requesterId,
                                                      ArrayList<UserInfo> added) {
+        String requesterName = requesterId;
+        for (UserInfo p : conversation.getHistoricalParticipants()) {
+            if (requesterId.equals(p.getUserId())) {
+                requesterName = p.getName();
+                break;
+            }
+        }
         StringBuilder names = new StringBuilder();
         for (int i = 0; i < added.size(); i++) {
             if (i > 0) names.append(i == added.size() - 1 ? " and " : ", ");
-            names.append(added.get(i).getUserId());
+            names.append(added.get(i).getName());
         }
         Message systemMessage = new Message(
-                requesterId + " added " + names,
+                requesterName + " added " + names,
                 nextMessageSequenceNumber(),
                 new Date(),
                 "SYSTEM",


### PR DESCRIPTION
## Summary

When a user adds someone to a group conversation, the system bubble previously read like:
```
● May 04, 13:16 (former participant):
V3P6L0WQ9D added Q7M2X9K4LP
```

Now it reads:
```
May 04, 13:16
Alex added Bob
```

For a multi-add it reads `Alex added Bob, Charlie and Dana`.

- **Server** (`DataManager.appendAddParticipantSystemMessage`): resolves the requester's display name from the conversation roster and uses `UserInfo.getName()` for added participants when constructing the system message body.
- **Client** (`MessageCellRenderer` header): special-cases `senderId == "SYSTEM"` to render the timestamp alone, bypassing the senderName lookup that previously fell through to `(former participant)`.

## Test plan

- [ ] In a group conversation, add one user → bubble shows `Alex added Bob`, no `(former participant):` text.
- [ ] Add two users in one operation → `Alex added Bob and Charlie`.
- [ ] Add three+ users in one operation → `Alex added Bob, Charlie and Dana`.
- [ ] Header shows only the timestamp for the system bubble.
- [ ] Normal user messages continue to show `<timestamp> <Name>:` as before.
- [ ] Build + existing tests pass.