### PR TITLE
Conversation list sorting by recency in ClientController

### DIFF
--- a/scripts/write-build-info.sh
+++ b/scripts/write-build-info.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Updates embedded VERSION and GIT_REVISION in src/shared/BuildInfo.java from the Git checkout
+# at scripts/write-build-info.sh run time (fallback values when runtime Git is unavailable).
+# VERSION = git rev-list --count HEAD; GIT_REVISION = short hash plus -dirty when needed.
+# Run before javac, or wire into a compile alias / git pre-commit hook.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$ROOT/src/shared/BuildInfo.java"
+
+if git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  COUNT="$(git -C "$ROOT" rev-list --count HEAD)"
+  SHORT="$(git -C "$ROOT" rev-parse --short HEAD)"
+  DIRTY=""
+  if ! git -C "$ROOT" diff-index --quiet HEAD -- 2>/dev/null; then
+    DIRTY="-dirty"
+  fi
+else
+  COUNT="0"
+  SHORT="nogit"
+  DIRTY=""
+fi
+
+REV="${SHORT}${DIRTY}"
+
+if [[ ! -f "$OUT" ]]; then
+  echo "ERROR: $OUT not found — create shared/BuildInfo.java first." >&2
+  exit 1
+fi
+
+# BSD/macOS and GNU sed: in-place edit of only the two constant lines (class body otherwise hand-maintained).
+if sed --version >/dev/null 2>&1; then
+  sed -i 's/public static final int VERSION = [0-9][0-9]*/public static final int VERSION = '"$COUNT"'/' "$OUT"
+  sed -i 's|public static final String GIT_REVISION = "[^"]*"|public static final String GIT_REVISION = "'"$REV"'"|' "$OUT"
+else
+  sed -i '' 's/public static final int VERSION = [0-9][0-9]*/public static final int VERSION = '"$COUNT"'/' "$OUT"
+  sed -i '' 's|public static final String GIT_REVISION = "[^"]*"|public static final String GIT_REVISION = "'"$REV"'"|' "$OUT"
+fi
+
+echo "Updated $OUT (VERSION=$COUNT, GIT_REVISION=$REV)"

--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -10,6 +10,7 @@ import java.net.SocketException;
 import java.util.*;
 import java.util.concurrent.LinkedBlockingDeque;
 import javax.swing.SwingUtilities;
+import shared.BuildInfo;
 import shared.enums.*;
 import shared.networking.*;
 import shared.networking.User.UserInfo;
@@ -99,6 +100,7 @@ public class ClientController {
     }
 
     public ClientController(String hostIp, int hostPort) {
+        System.out.println("[ClientController] version " + BuildInfo.formatVersionForLog());
         this.hostIp = hostIp;
         this.hostPort = hostPort;
         this.connectionStatus = ConnectionStatus.NOT_CONNECTED;
@@ -242,8 +244,9 @@ public class ClientController {
                 case SUCCESS:
                     loggedIn = true;
                     currentUser = lr.getUserInfo();
-                    conversations = Collections.synchronizedList(
-                            lr.getConversationList() != null ? lr.getConversationList() : new ArrayList<>());
+                    ArrayList<Conversation> fromLogin = new ArrayList<>(lr.getConversationList());
+                    sortConversationsByLastSequenceNumber(fromLogin);
+                    conversations = Collections.synchronizedList(fromLogin);
                     currentDirectory = lr.getDirectoryUserInfoList() != null
                             ? lr.getDirectoryUserInfoList() : new ArrayList<>();
                     if (gui != null) {
@@ -281,19 +284,17 @@ public class ClientController {
     }
 
     private void handleMessageResponse(Response response) {
-        // Move the matching conversation to front (most recent), then refresh the list view.
         Message msg = (Message) response.getPayload();
         ArrayList<Conversation> snapshot;
         boolean isCurrentConv;
         synchronized (conversations) {
             for (int i = 0; i < conversations.size(); i++) {
                 if (conversations.get(i).getConversationId() == msg.getConversationId()) {
-                    Conversation c = conversations.remove(i);
-                    c.append(msg);
-                    conversations.add(0, c);
+                    conversations.get(i).append(msg);
                     break;
                 }
             }
+            sortConversationsByLastSequenceNumber(conversations);
             snapshot = new ArrayList<>(conversations);
             isCurrentConv = msg.getConversationId() == currentConversationId;
         }
@@ -309,14 +310,13 @@ public class ClientController {
     }
 
     private void handleConversationResponse(Response response) {
-        // Move to front regardless of whether it is new or an update (recency sort).
-        // Track whether this conversation was already known so we can auto-open new ones.
         Conversation conv = (Conversation) response.getPayload();
         boolean isNew;
         ArrayList<Conversation> snapshot;
         synchronized (conversations) {
             isNew = conversations.removeIf(c -> c.getConversationId() == conv.getConversationId()) == false;
-            conversations.add(0, conv);
+            conversations.add(conv);
+            sortConversationsByLastSequenceNumber(conversations);
             snapshot = new ArrayList<>(conversations);
         }
         if (gui != null) {
@@ -595,13 +595,15 @@ public class ClientController {
         return filtered;
     }
 
-    /** Returns conversations where any participant's id or name matches {@code query}. */
+    /**
+     * Returns conversations where any participant's id or name matches {@code query}.
+     * Order matches {@link #conversations}: sorted by last message sequence (see login,
+     * {@link #handleMessageResponse}, {@link #handleConversationResponse}).
+     */
     public ArrayList<Conversation> getFilteredConversationList(String query) {
         synchronized (conversations) {
             if (query == null || query.isBlank()) {
-                ArrayList<Conversation> all = new ArrayList<>(conversations);
-                all.sort((a, b) -> Long.compare(latestSequenceNumber(b), latestSequenceNumber(a)));
-                return all;
+                return new ArrayList<>(conversations);
             }
             ArrayList<Conversation> filtered = new ArrayList<>();
             String q = query.toLowerCase();
@@ -613,19 +615,23 @@ public class ClientController {
                     }
                 }
             }
-            filtered.sort((a, b) -> Long.compare(latestSequenceNumber(b), latestSequenceNumber(a)));
             return filtered;
         }
     }
 
-    private long latestSequenceNumber(Conversation c) {
-        if (c == null) return 0L;
-        if (c.getMessages().isEmpty()) {
-            // Empty conversations have no message sequence yet; use conversationId as a
-            // creation-recency fallback.
-            return c.getConversationId();
+    /**
+     * Sorts in place: conversations with the highest last-message sequence number appear first.
+     * Threads with no messages use {@link Conversation#getSortSequenceSentinel()} (sequence allocated at creation).
+     */
+    private static void sortConversationsByLastSequenceNumber(List<Conversation> list) {
+        if (list == null || list.size() <= 1) {
+            return;
         }
-        return c.getMessages().get(c.getMessages().size() - 1).getSequenceNumber();
+        list.sort(Comparator.comparingLong((Conversation c) -> {
+            var msgs = c.getMessages();
+            return msgs.isEmpty() ? c.getSortSequenceSentinel()
+                    : msgs.get(msgs.size() - 1).getSequenceNumber();
+        }).reversed());
     }
 
     /** Returns admin search results filtered by participant id or name,

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -360,19 +360,7 @@ public class ClientUI {
             Conversation selected = convList.getSelectedValue();
             Long selectedId = (selected != null) ? selected.getConversationId() : null;
 
-            // Sort by highest latest sequence number descending (most recent first),
-            // which also keeps offline-received updates ordered correctly on initial paint.
-            conversations.sort((a, b) -> {
-                ArrayList<Message> aMsgs = a.getMessages();
-                ArrayList<Message> bMsgs = b.getMessages();
-                long aSeq = aMsgs.isEmpty()
-                        ? a.getConversationId()
-                        : aMsgs.get(aMsgs.size() - 1).getSequenceNumber();
-                long bSeq = bMsgs.isEmpty()
-                        ? b.getConversationId()
-                        : bMsgs.get(bMsgs.size() - 1).getSequenceNumber();
-                return Long.compare(bSeq, aSeq);
-            });
+            // Order is defined in ClientController (last message sequence); do not re-sort here.
 
             conversationListModel.clear();
             for (Conversation conversation : conversations) {

--- a/src/server/DataManager.java
+++ b/src/server/DataManager.java
@@ -333,7 +333,13 @@ public class DataManager {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        
+
+        try {
+            loadServerCounters();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
         // rehydrate Conversations (*.conversation — serialized Conversation per file)
         File[] listOfConversationFiles = conversationDataDir.listFiles(
             f -> f.isFile() && f.getName().endsWith(".conversation"));
@@ -354,7 +360,7 @@ public class DataManager {
         }catch(ClassNotFoundException e) {
         	e.printStackTrace();
         }
-        
+
         // rehydrate Users (*.user — serialized User per file)
         File[] listOfUserFiles = userDataDir.listFiles(
             f -> f.isFile() && f.getName().endsWith(".user"));
@@ -373,12 +379,6 @@ public class DataManager {
             e.printStackTrace();
         }
         buildDirectoryAtStartup();
-
-        try {
-            loadServerCounters();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
     }
 
     /**
@@ -698,7 +698,7 @@ public class DataManager {
         }
         long conversationId = nextConversationId();
         // Derives PRIVATE vs GROUP from participant count; seeds historicalParticipants from this list.
-        Conversation conversation = new Conversation(conversationId, participants);
+        Conversation conversation = new Conversation(conversationId, participants, nextMessageSequenceNumber());
         conversationsByConversationID.put(conversationId, conversation);
         linkParticipantsToConversation(conversationId, conversation.getParticipants());
         persistConversation(conversation);
@@ -742,7 +742,7 @@ public class DataManager {
             ArrayList<UserInfo> merged = new ArrayList<>(existing.getParticipants());
             merged.addAll(netNew);
             long forkId = nextConversationId();
-            Conversation forked = new Conversation(forkId, merged);
+            Conversation forked = new Conversation(forkId, merged, nextMessageSequenceNumber());
             conversationsByConversationID.put(forkId, forked);
             linkParticipantsToConversation(forkId, forked.getParticipants());
             appendAddParticipantSystemMessage(forked, request.getSenderId(), netNew);

--- a/src/server/ServerController.java
+++ b/src/server/ServerController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import shared.BuildInfo;
 import shared.enums.RequestType;
 import shared.enums.RegisterStatus;
 import shared.enums.ResponseType;
@@ -75,6 +76,7 @@ public class ServerController {
     }
 
     public ServerController(String bindIPv4, int port, String dataRootPath) {
+        System.out.println("[ServerController] version " + BuildInfo.formatVersionForLog());
         this.activeSessions = new ConcurrentHashMap<>();
         this.dataManager = new DataManager(dataRootPath);
         this.connectionListener = new ConnectionListener(bindIPv4, port, this);

--- a/src/shared/BuildInfo.java
+++ b/src/shared/BuildInfo.java
@@ -1,0 +1,64 @@
+package shared;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Embedded {@link #VERSION} and {@link #GIT_REVISION} are updated by {@code scripts/write-build-info.sh}
+ * (fallback when Git is unavailable at runtime). {@link #formatVersionForLog()} prefers live {@code git}
+ * from the process working directory when you run from a checkout.
+ */
+public final class BuildInfo {
+    private static final int GIT_WAIT_SEC = 5;
+
+    private BuildInfo() {}
+
+    public static final int VERSION = 185;
+    public static final String GIT_REVISION = "030a08a-dirty";
+
+    /** Same shape as the embedded log segment: {@code "<count> (<hash>[-dirty])"}. */
+    public static String formatVersionForLog() {
+        String rev = gitDescribeAlwaysDirtyOrNull();
+        Integer count = gitRevListCountOrNull();
+        int versionNum = count != null ? count : VERSION;
+        String revStr = rev != null ? rev : GIT_REVISION;
+        return versionNum + " (" + revStr + ")";
+    }
+
+    private static String gitDescribeAlwaysDirtyOrNull() {
+        return runGitStdoutOrNull("git", "describe", "--always", "--dirty");
+    }
+
+    private static Integer gitRevListCountOrNull() {
+        String out = runGitStdoutOrNull("git", "rev-list", "--count", "HEAD");
+        if (out == null) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(out.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static String runGitStdoutOrNull(String... command) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder(command);
+            pb.directory(new File(System.getProperty("user.dir")));
+            pb.redirectErrorStream(true);
+            Process p = pb.start();
+            if (!p.waitFor(GIT_WAIT_SEC, TimeUnit.SECONDS)) {
+                p.destroyForcibly();
+                return null;
+            }
+            if (p.exitValue() != 0) {
+                return null;
+            }
+            String out = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+            return out.isEmpty() ? null : out;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/shared/payload/Conversation.java
+++ b/src/shared/payload/Conversation.java
@@ -16,6 +16,13 @@ public class Conversation implements ResponsePayload {
     private final ConversationType type;
 
     /**
+     * Sequence number allocated from the server's global counter at conversation creation (same allocation path as
+     * messages). Used when ordering threads that still have no messages; avoids ties from unrelated streams sharing
+     * the same peek value.
+     */
+    private final long sortSequenceSentinel;
+
+    /**
      * @param conversationId stable numeric id (from server counter)
      * @param participants initial members; copied defensively. If the size is 2, {@link ConversationType#PRIVATE}
      * is used; otherwise {@link ConversationType#GROUP}. The same initial snapshot is stored in
@@ -23,13 +30,19 @@ public class Conversation implements ResponsePayload {
      * do not remove entries from historical participants; use {@link #addParticipants(ArrayList)} so new
      * members are recorded in both lists. {@link #getType()} is fixed for the lifetime of this object;
      * adding people to a {@link ConversationType#PRIVATE} thread is done by forking (see server) into a new conversation.
+     * @param sortSequenceSentinel next global message sequence issued when this conversation is created (consumes one number from the server counter)
      */
-    public Conversation(long conversationId, ArrayList<UserInfo> participants) {
+    public Conversation(long conversationId, ArrayList<UserInfo> participants, long sortSequenceSentinel) {
         this.conversationId = conversationId;
         this.messages = new ArrayList<>();
         this.participants = new ArrayList<>(participants != null ? participants : new ArrayList<>());
         this.historicalParticipants = new ArrayList<>(this.participants);
         this.type = this.participants.size() == 2 ? ConversationType.PRIVATE : ConversationType.GROUP;
+        this.sortSequenceSentinel = sortSequenceSentinel;
+    }
+
+    public long getSortSequenceSentinel() {
+        return sortSequenceSentinel;
     }
 
     /**

--- a/test/client/ClientControllerTest.java
+++ b/test/client/ClientControllerTest.java
@@ -40,7 +40,7 @@ class ClientControllerTest {
     private static Conversation conv(long id, UserInfo... members) {
         ArrayList<UserInfo> p = new ArrayList<>();
         for (UserInfo u : members) p.add(u);
-        return new Conversation(id, p);
+        return new Conversation(id, p, 0L);
     }
 
     /** LOGIN_RESULT/SUCCESS for Alice, containing one conversation (id=100). */

--- a/test/server/ServerControllerTest.java
+++ b/test/server/ServerControllerTest.java
@@ -202,8 +202,8 @@ class ServerControllerTest {
     void enqueueBroadcastCandidates() throws Exception {
         StubDataManager stub = new StubDataManager(testDataRoot().toString());
         Response messageResp = new Response(ResponseType.MESSAGE, new Message("hi", 7L, new java.util.Date(), "u1", 11L));
-        Response createResp = new Response(ResponseType.CONVERSATION, new Conversation(22L, participants("u1", "u2", "u3")));
-        Response addResp = new Response(ResponseType.CONVERSATION, new Conversation(33L, participants("u1", "u2", "u3", "u4")));
+        Response createResp = new Response(ResponseType.CONVERSATION, new Conversation(22L, participants("u1", "u2", "u3"), 0L));
+        Response addResp = new Response(ResponseType.CONVERSATION, new Conversation(33L, participants("u1", "u2", "u3", "u4"), 0L));
         stub.responses.put(RequestType.MESSAGE, messageResp);
         stub.responses.put(RequestType.CREATE_CONVERSATION, createResp);
         stub.responses.put(RequestType.ADD_PARTICIPANT, addResp);
@@ -261,7 +261,7 @@ class ServerControllerTest {
         // because existing participants of the original PRIVATE thread have never seen
         // the new id and would silently drop a CONVERSATION_METADATA frame.
         StubDataManager stub = new StubDataManager(testDataRoot().toString());
-        Conversation forked = new Conversation(202L, participants("u1", "u2", "u3"));
+        Conversation forked = new Conversation(202L, participants("u1", "u2", "u3"), 0L);
         stub.responses.put(RequestType.ADD_PARTICIPANT, new Response(ResponseType.CONVERSATION, forked));
         stub.participantsByConversationId.put(101L, participants("u1", "u2"));
         stub.participantsByConversationId.put(202L, participants("u1", "u2", "u3"));
@@ -297,7 +297,7 @@ class ServerControllerTest {
         // for the SYSTEM "added" message, so their lastMessageSequenceNumber bumps and the
         // conversation reorders to 1st place.
         StubDataManager stub = new StubDataManager(testDataRoot().toString());
-        Conversation grown = new Conversation(55L, participants("u1", "u2", "u3", "u4"));
+        Conversation grown = new Conversation(55L, participants("u1", "u2", "u3", "u4"), 0L);
         grown.append(new Message("u1 added u4", 999L, new java.util.Date(), "SYSTEM", 55L));
         stub.responses.put(RequestType.ADD_PARTICIPANT, new Response(ResponseType.CONVERSATION, grown));
         stub.participantsByConversationId.put(55L, participants("u1", "u2", "u3", "u4"));

--- a/utils/SeedSerializedData.java
+++ b/utils/SeedSerializedData.java
@@ -172,7 +172,9 @@ public class SeedSerializedData {
             maxConvId = Math.max(maxConvId, cid);
             nextConvId += rnd.nextInt(2, 22);
             ConvSeed s = pending.get(i);
-            Conversation c = new Conversation(cid, s.participants);
+            long sentinelAtCreation = nextMessageSeq[0];
+            nextMessageSeq[0] = sentinelAtCreation + 1;
+            Conversation c = new Conversation(cid, s.participants, sentinelAtCreation);
             lastMessageSeq = appendMessagesOrganic(c, s, nextMessageSeq);
             writeObject(new File(convDataPath.toFile(), cid + ".conversation"), c);
         }


### PR DESCRIPTION
Add scripts/write-build-info.sh and shared.BuildInfo so client/server log git revision (commit hash) and commit count at startup.

Conversation refactor: immutable sortSequenceSentinel allocates one global message sequence at creation (next issued number); DataManager create/fork paths, SeedSerializedData, and tests updated accordingly.

Centralize conversation list ordering in ClientController (sort by last message sequence, sentinel when empty); ClientUI relies on controller-provided order only.

Include accompanying adjustments for the refactor (fixtures, ServerController version print).