### PR TITLE
fix(admin-join): auth gate, idempotency, scrubbed broadcasts, persistence

### DIFF
--- a/src/client/ClientController.java
+++ b/src/client/ClientController.java
@@ -311,6 +311,7 @@ public class ClientController {
 
     private void handleConversationResponse(Response response) {
         Conversation conv = (Conversation) response.getPayload();
+        if (conv == null) return;
         boolean isNew;
         ArrayList<Conversation> snapshot;
         synchronized (conversations) {
@@ -319,37 +320,59 @@ public class ClientController {
             sortConversationsByLastSequenceNumber(conversations);
             snapshot = new ArrayList<>(conversations);
         }
-        if (gui != null) {
-            gui.updateConversationListModel(snapshot);
-            if (isNew) {
-                // Auto-open the newly created conversation in the center panel.
-                setCurrentConversationId(conv.getConversationId());
-                SwingUtilities.invokeLater(() -> gui.updateMessageListModel(conv));
-                // Follow-up enhancement: call gui.selectConversationInList(conv) when UI support is added.
+        boolean isActiveParticipant = false;
+        if (currentUser != null) {
+            for (UserInfo p : conv.getParticipants()) {
+                if (p != null && currentUser.getUserId().equals(p.getUserId())) {
+                    isActiveParticipant = true;
+                    break;
+                }
             }
+        }
+        final boolean autoOpen = isNew && isActiveParticipant;
+        if (autoOpen) {
+            // Auto-open only when the caller is an actual participant (CREATE / ADD),
+            // never on silent admin JOIN where the admin is in historicalParticipants only.
+            setCurrentConversationId(conv.getConversationId());
+        }
+        if (gui != null) {
+            final ArrayList<Conversation> snap = snapshot;
+            SwingUtilities.invokeLater(() -> {
+                gui.updateConversationListModel(snap);
+                if (autoOpen) {
+                    gui.updateMessageListModel(conv);
+                }
+            });
         }
     }
 
     private void handleConversationMetadataResponse(Response response) {
         ConversationMetadata meta = (ConversationMetadata) response.getPayload();
+        if (meta == null) return;
+        Conversation matched = null;
         ArrayList<Conversation> snapshot;
+        boolean isCurrentConv;
         synchronized (conversations) {
-            boolean found = false;
             for (Conversation c : conversations) {
-                if (c.getConversationId() == meta.getConversationId()) {
-                    found = true;
-                    break;
-                }
+                if (c.getConversationId() == meta.getConversationId()) { matched = c; break; }
             }
-            if (!found) {
+            if (matched == null) {
                 System.err.println("CONVERSATION_METADATA: no matching conversation for id=" + meta.getConversationId());
                 return;
             }
+            matched.applyMetadata(meta);
             snapshot = new ArrayList<>(conversations);
+            isCurrentConv = matched.getConversationId() == currentConversationId;
         }
         if (gui != null) {
+            final Conversation toRefresh = matched;
             final ArrayList<Conversation> snap = snapshot;
-            SwingUtilities.invokeLater(() -> gui.updateConversationListModel(snap));
+            SwingUtilities.invokeLater(() -> {
+                gui.updateConversationListModel(snap);
+                if (isCurrentConv) {
+                    gui.updateMessageListModel(toRefresh);
+                }
+            });
         }
     }
 
@@ -556,6 +579,26 @@ public class ClientController {
         if (!loggedIn || currentUser == null || currentUser.getUserType() != UserType.ADMIN) return;
         enqueueRequest(new Request(RequestType.JOIN_CONVERSATION,
                 new JoinConversationPayload(conversationId), currentUser.getUserId()));
+    }
+
+    /** Opens an already-known conversation in the main chat view. Used by the admin Join
+     *  button when the admin is already an active participant — no JOIN_CONVERSATION needed. */
+    public void openConversationInMainView(long conversationId) {
+        Conversation target = null;
+        synchronized (conversations) {
+            for (Conversation c : conversations) {
+                if (c.getConversationId() == conversationId) { target = c; break; }
+            }
+        }
+        if (target == null) return;
+        setCurrentConversationId(conversationId);
+        if (gui != null) {
+            final Conversation toOpen = target;
+            SwingUtilities.invokeLater(() -> {
+                gui.updateMessageListModel(toOpen);
+                gui.selectConversationInList(toOpen);
+            });
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/client/ClientUI.java
+++ b/src/client/ClientUI.java
@@ -380,6 +380,28 @@ public class ClientUI {
         });
     }
 
+    /** Selects the row in the sidebar that matches {@code target}'s conversation id, suppressing
+     *  the selection listener so it does not re-fire setCurrentConversationId. */
+    public void selectConversationInList(Conversation target) {
+        if (target == null) return;
+        SwingUtilities.invokeLater(() -> {
+            JList<Conversation> convList = cards.main.conversationListView.list;
+            long targetId = target.getConversationId();
+            cards.main.conversationListView.suppressSelectionEvents = true;
+            try {
+                for (int i = 0; i < conversationListModel.getSize(); i++) {
+                    if (conversationListModel.getElementAt(i).getConversationId() == targetId) {
+                        convList.setSelectedIndex(i);
+                        convList.ensureIndexIsVisible(i);
+                        break;
+                    }
+                }
+            } finally {
+                cards.main.conversationListView.suppressSelectionEvents = false;
+            }
+        });
+    }
+
     public void updateMessageListModel(Conversation conversation) {
         SwingUtilities.invokeLater(() -> {
             if (conversation == null) {
@@ -842,6 +864,7 @@ public class ClientUI {
                         for (UserInfo p : conv.getHistoricalParticipants()) {
                             if (p.getUserId().equals(msg.getSenderId())) {
                                 senderName = p.getName();
+                                if (p.getUserType() == UserType.ADMIN) senderName += " [ADMIN]";
                                 break;
                             }
                         }
@@ -1712,6 +1735,7 @@ public class ClientUI {
         JTextField searchField;
         DefaultListModel<ConversationMetadata> model = new DefaultListModel<>();
         JList<ConversationMetadata> list = new JList<>(model);
+        JButton joinButton;
         JButton closeButton;
         ViewerPanel viewerPanel;
 
@@ -1898,6 +1922,8 @@ public class ClientUI {
 
         AdminConversationSearchWindow() {
             searchField = makePlaceholderField("Search conversations...", 15);
+            joinButton = new JButton("Join");
+            joinButton.setEnabled(false);
             closeButton = new JButton("Close");
 
             setLayout(new BorderLayout());
@@ -1919,8 +1945,9 @@ public class ClientUI {
             split.setResizeWeight(0.0);
             add(split, BorderLayout.CENTER);
 
-            // Close at the bottom right
+            // Buttons at the bottom right (Join | Close)
             JPanel buttonPane = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+            buttonPane.add(joinButton);
             buttonPane.add(closeButton);
             add(buttonPane, BorderLayout.SOUTH);
 
@@ -1948,13 +1975,43 @@ public class ClientUI {
                 }
             });
 
-            // Selecting a row pulls the full conversation silently — no Join button.
+            // Selecting a row pulls the full conversation silently and enables the Join button.
             list.addListSelectionListener(e -> {
                 if (e.getValueIsAdjusting()) return;
                 ConversationMetadata sel = list.getSelectedValue();
+                joinButton.setEnabled(sel != null);
                 if (sel != null) {
                     controller.adminViewConversation(sel.getConversationId());
                 }
+            });
+
+            // Join: if admin is already an active participant, just open the conversation locally;
+            // otherwise send JOIN_CONVERSATION (silent index-only link on the server).
+            joinButton.addActionListener(e -> {
+                ConversationMetadata sel = list.getSelectedValue();
+                if (sel == null) return;
+                joinButton.setEnabled(false);
+                long convId = sel.getConversationId();
+                UserInfo me = controller.getCurrentUserInfo();
+                String myId = me != null ? me.getUserId() : null;
+                boolean alreadyMember = false;
+                if (myId != null) {
+                    for (UserInfo p : sel.getParticipants()) {
+                        if (p != null && myId.equals(p.getUserId())) { alreadyMember = true; break; }
+                    }
+                    if (!alreadyMember) {
+                        for (UserInfo p : sel.getHistoricalParticipants()) {
+                            if (p != null && myId.equals(p.getUserId())) { alreadyMember = true; break; }
+                        }
+                    }
+                }
+                Window window = SwingUtilities.getWindowAncestor(this);
+                if (alreadyMember) {
+                    controller.openConversationInMainView(convId);
+                } else {
+                    controller.joinConversation(convId);
+                }
+                if (window != null) window.dispose();
             });
 
             // Close button just disposes the dialog; existing windowClosed handler does cleanup.

--- a/src/server/DataManager.java
+++ b/src/server/DataManager.java
@@ -354,6 +354,7 @@ public class DataManager {
 	        	Conversation newConversation = (Conversation) in.readObject();
 	        	conversationsByConversationID.put(newConversation.getConversationId(),newConversation);
 	        	linkParticipantsToConversation(newConversation.getConversationId(), newConversation.getParticipants());
+	        	linkParticipantsToConversation(newConversation.getConversationId(), newConversation.getHistoricalParticipants());
 	        }
         }catch(IOException e) {
         	e.printStackTrace();
@@ -413,21 +414,26 @@ public class DataManager {
      * Blank lines and lines starting with {@code #} are ignored.
      */
     private void loadAuthorizedAdminsCsv(File file) throws IOException {
-        authorizedAdminIds.clear();
+        ArrayList<String> loaded = new ArrayList<>();
+        boolean firstLine = true;
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), java.nio.charset.StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
+                if (firstLine && !line.isEmpty() && line.charAt(0) == '﻿') {
+                    line = line.substring(1);
+                }
+                firstLine = false;
                 line = line.trim();
                 if (line.isEmpty() || line.startsWith("#")) {
                     continue;
                 }
-                if (!line.isEmpty()) {
-                    if (!authorizedAdminIds.contains(line)) {
-                        authorizedAdminIds.add(line);
-                    }
+                if (!loaded.contains(line)) {
+                    loaded.add(line);
                 }
             }
         }
+        authorizedAdminIds.clear();
+        authorizedAdminIds.addAll(loaded);
     }
 
     /**
@@ -761,8 +767,15 @@ public class DataManager {
     }
 
     public Response handleAdminConversationQuery(Request request) {
+        User caller = usersByUserID.get(request.getSenderId());
+        if (caller == null || caller.getUserType() != UserType.ADMIN) {
+            return new Response(ResponseType.ADMIN_CONVERSATION_RESULT, null);
+        }
         AdminConversationQuery adminConversationQuery = (AdminConversationQuery) request.getPayload();
         String userId = adminConversationQuery.getUserId();
+        if (userId == null || userId.isEmpty()) {
+            return new Response(ResponseType.ADMIN_CONVERSATION_RESULT, new AdminConversationResult(new ArrayList<>()));
+        }
         // Scan historicalParticipants instead of the active conversationIDsByUserID index
         // so orphaned conversations (everyone has left) and conversations the user has
         // since left still surface for the admin viewer.
@@ -783,12 +796,37 @@ public class DataManager {
         return new Response(ResponseType.ADMIN_CONVERSATION_RESULT, new AdminConversationResult(metas));
     }
 
+    /**
+     * Silent admin join: links the caller to the conversation in the index and records them
+     * in {@link Conversation#getHistoricalParticipants()} (so other clients' message renderers
+     * can resolve their name/[ADMIN] tag), but does NOT add them to the active
+     * {@link Conversation#getParticipants()} roster — so other users see no participant-list
+     * change. Idempotent when the caller is already a real active participant.
+     */
     public Response handleJoinConversation(Request request) {
         JoinConversationPayload joinConversationPayload = (JoinConversationPayload) request.getPayload();
         long conversationId = joinConversationPayload.getTargetConversationId();
         String userId = request.getSenderId();
-        linkUserToConversation(userId, conversationId);
-        return new Response(ResponseType.CONVERSATION, conversationsByConversationID.get(conversationId));
+        Conversation conversation = conversationsByConversationID.get(conversationId);
+        if (conversation == null) {
+            return new Response(ResponseType.CONVERSATION, null);
+        }
+        User caller = usersByUserID.get(userId);
+        if (caller == null || caller.getUserType() != UserType.ADMIN) {
+            return new Response(ResponseType.CONVERSATION, null);
+        }
+        synchronized (conversation) {
+            if (containsParticipant(conversation.getParticipants(), userId)
+                    || containsParticipant(conversation.getHistoricalParticipants(), userId)) {
+                return new Response(ResponseType.CONVERSATION, conversation);
+            }
+            linkUserToConversation(userId, conversationId);
+            boolean historicalChanged = conversation.addToHistoricalOnly(caller.toUserInfo());
+            if (historicalChanged) {
+                persistConversation(conversation);
+            }
+        }
+        return new Response(ResponseType.CONVERSATION, conversation);
     }
 
     /**
@@ -819,6 +857,17 @@ public class DataManager {
             return new ArrayList<>();
         }
         return c.getParticipants();
+    }
+
+    /**
+     * Returns all user ids linked to {@code conversationId} in the index. After silent admin
+     * joins this is a superset of {@link Conversation#getParticipants()} by exactly the
+     * silent observers; broadcast paths use it to fan out to those observers without
+     * touching the active roster. Defensive copy.
+     */
+    public Set<String> getLinkedUserIds(long conversationId) {
+        Set<String> ids = userIDsByConversationID.get(conversationId);
+        return ids == null ? Collections.emptySet() : new HashSet<>(ids);
     }
 
     public boolean userExists(String loginName) {

--- a/src/server/ServerController.java
+++ b/src/server/ServerController.java
@@ -2,7 +2,9 @@ package server;
 
 import java.util.ArrayList;
 import java.util.AbstractMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -174,8 +176,11 @@ public class ServerController {
             case ADMIN_VIEW_CONVERSATION:
                 // Silent admin read — no broadcast, no participant mutation.
                 return dataManager.handleAdminViewConversation(request);
-            case JOIN_CONVERSATION:
-                return dataManager.handleJoinConversation(request);
+            case JOIN_CONVERSATION: {
+                Response response = dataManager.handleJoinConversation(request);
+                broadcastResponse(request, response);
+                return response;
+            }
             case LOGOUT:
                 removeSession(request.getSenderId());
                 // Null is intentional: ConnectionHandler.handleSessionTransition owns LOGOUT
@@ -200,6 +205,9 @@ public class ServerController {
             case ADD_PARTICIPANT:
                 enqueueAddParticipantBroadcast(request, response);
                 break;
+            case JOIN_CONVERSATION:
+                enqueueSilentJoinBroadcast(request, response);
+                break;
             default:
                 break;
         }
@@ -215,11 +223,36 @@ public class ServerController {
         }
     }
 
+    /**
+     * Fans out {@code response} to silent admin observers — user ids linked to {@code conversationId}
+     * in the index but absent from {@code conv.getParticipants()}. {@code excludeId} is the
+     * sender/requester whose direct return path already covers them; pass {@code null} to skip
+     * that filter.
+     */
+    private void enqueueToSilentObservers(long conversationId, Conversation conv, String excludeId, Response response) {
+        if (conv == null) return;
+        Set<String> linked = dataManager.getLinkedUserIds(conversationId);
+        if (linked.isEmpty()) return;
+        Set<String> participantIds = new HashSet<>();
+        for (UserInfo p : conv.getParticipants()) {
+            if (p != null && p.getUserId() != null) participantIds.add(p.getUserId());
+        }
+        for (String id : linked) {
+            if (id == null) continue;
+            if (participantIds.contains(id)) continue; // already covered by participant loop
+            if (excludeId != null && excludeId.equals(id)) continue; // requester gets the direct return
+            if (hasActiveSession(id)) {
+                responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(id, response));
+            }
+        }
+    }
+
     private void enqueueMessageBroadcast(Request request, Response response) {
         if (!(response.getPayload() instanceof Message)) return;
         Message message = (Message) response.getPayload();
         String senderId = request.getSenderId();
-        for (UserInfo participant : dataManager.getParticipantList(message.getConversationId())) {
+        long conversationId = message.getConversationId();
+        for (UserInfo participant : dataManager.getParticipantList(conversationId)) {
             if (participant == null || participant.getUserId() == null) continue;
             String id = participant.getUserId();
             if (id.equals(senderId)) continue; // sender already gets the response via direct return
@@ -227,6 +260,7 @@ public class ServerController {
                 responseQueue.offer(new AbstractMap.SimpleImmutableEntry<>(id, response));
             }
         }
+        enqueueToSilentObservers(conversationId, dataManager.getConversation(conversationId), senderId, response);
     }
 
     private void enqueueCreateConversationBroadcast(String requesterId, Response response) {
@@ -246,12 +280,50 @@ public class ServerController {
         // getParticipantList returns the roster AFTER the leaver was removed, so every
         // entry here is a remaining participant — no need to skip by leaverId.
         ArrayList<UserInfo> remaining = dataManager.getParticipantList(conversationId);
-        if (remaining.isEmpty()) return;
         Conversation conversation = dataManager.getConversation(conversationId);
         if (conversation == null) return;
         ConversationMetadata metadata = conversation.toMetadata();
         Response metadataResponse = new Response(ResponseType.CONVERSATION_METADATA, metadata);
-        enqueueToActiveParticipants(remaining, metadataResponse);
+        if (!remaining.isEmpty()) {
+            enqueueToActiveParticipants(remaining, metadataResponse);
+        }
+        // Silent admin observers also need the updated roster, even when no real participants remain.
+        enqueueToSilentObservers(conversationId, conversation, leaverId, metadataResponse);
+    }
+
+    private void enqueueSilentJoinBroadcast(Request request, Response response) {
+        if (request == null || response == null) return;
+        if (!(response.getPayload() instanceof Conversation)) return;
+        Conversation conversation = (Conversation) response.getPayload();
+        String joinerId = request.getSenderId();
+        if (joinerId == null) return;
+        ArrayList<UserInfo> participantsSnapshot;
+        ConversationMetadata fullMeta;
+        synchronized (conversation) {
+            for (UserInfo p : conversation.getParticipants()) {
+                if (p != null && joinerId.equals(p.getUserId())) return;
+            }
+            participantsSnapshot = new ArrayList<>(conversation.getParticipants());
+            fullMeta = conversation.toMetadata();
+        }
+        ArrayList<UserInfo> scrubbedHistorical = new ArrayList<>();
+        for (UserInfo u : fullMeta.getHistoricalParticipants()) {
+            if (u != null && joinerId.equals(u.getUserId())) continue;
+            scrubbedHistorical.add(u);
+        }
+        ConversationMetadata scrubbedMeta = new ConversationMetadata(
+                fullMeta.getConversationId(),
+                fullMeta.getParticipants(),
+                scrubbedHistorical,
+                fullMeta.getType(),
+                fullMeta.getLastMessagePreview(),
+                fullMeta.getLastMessageTimestampMillis(),
+                fullMeta.getUnreadCount(),
+                fullMeta.getDisplayName());
+        Response participantResponse = new Response(ResponseType.CONVERSATION_METADATA, scrubbedMeta);
+        Response observerResponse = new Response(ResponseType.CONVERSATION_METADATA, fullMeta);
+        enqueueToActiveParticipants(participantsSnapshot, participantResponse);
+        enqueueToSilentObservers(conversation.getConversationId(), conversation, joinerId, observerResponse);
     }
 
     private void enqueueAddParticipantBroadcast(Request request, Response response) {
@@ -298,6 +370,7 @@ public class ServerController {
             }
         }
         enqueueToActiveParticipants(existingParticipants, metadataResponse);
+        enqueueToSilentObservers(conversation.getConversationId(), conversation, request.getSenderId(), metadataResponse);
 
         // Also broadcast the SYSTEM "X added Y" message so existing members'
         // handleMessageResponse appends it, bumping lastMessageSequenceNumber and moving

--- a/src/shared/payload/Conversation.java
+++ b/src/shared/payload/Conversation.java
@@ -68,6 +68,52 @@ public class Conversation implements ResponsePayload {
         }
     }
 
+    /**
+     * Records {@code user} in {@link #getHistoricalParticipants()} only — does NOT add to the
+     * active {@link #getParticipants()} roster. Used by the silent admin "join" flow so the
+     * admin's sender id resolves to a name in every client's message renderer without
+     * appearing in the participant list. Idempotent; returns {@code true} only when an
+     * entry was actually appended.
+     */
+    public synchronized boolean addToHistoricalOnly(UserInfo user) {
+        if (user == null || user.getUserId() == null || historicalParticipants == null) {
+            return false;
+        }
+        for (UserInfo u : historicalParticipants) {
+            if (u != null && user.getUserId().equals(u.getUserId())) {
+                return false;
+            }
+        }
+        historicalParticipants.add(user);
+        return true;
+    }
+
+    /**
+     * Merges {@code meta} into this conversation: replaces the active {@link #getParticipants()}
+     * list with the snapshot, and appends any new entries to {@link #getHistoricalParticipants()}
+     * (historical is monotonic — never trim). Used by the client to apply
+     * {@link ConversationMetadata} updates received from the server.
+     */
+    public synchronized void applyMetadata(ConversationMetadata meta) {
+        if (meta == null) return;
+        participants.clear();
+        if (meta.getParticipants() != null) {
+            for (UserInfo u : meta.getParticipants()) {
+                if (u != null) participants.add(u);
+            }
+        }
+        if (historicalParticipants != null && meta.getHistoricalParticipants() != null) {
+            for (UserInfo u : meta.getHistoricalParticipants()) {
+                if (u == null || u.getUserId() == null) continue;
+                boolean exists = false;
+                for (UserInfo h : historicalParticipants) {
+                    if (u.getUserId().equals(h.getUserId())) { exists = true; break; }
+                }
+                if (!exists) historicalParticipants.add(u);
+            }
+        }
+    }
+
     private int indexOfParticipant(String userId) {
         for (int i = 0; i < participants.size(); i++) {
             if (userId.equals(participants.get(i).getUserId())) {


### PR DESCRIPTION
## Summary
Fixes a batch of bugs in the admin "join conversation from admin panel" flow. Eight focused source edits across four files; ~+45/-10 LOC net.

### Server
- **Authorization gate** on `DataManager.handleAdminConversationQuery` — non-admin callers now get a null payload instead of being able to enumerate any user's conversations.
- **Null/empty userId guard** on the same method — no more NPE on a malformed payload.
- **Idempotency on historical** in `handleJoinConversation` — a second admin click on the same conversation no longer refires the silent JOIN broadcast.
- **Atomic admin CSV load + UTF-8 BOM strip** in `loadAuthorizedAdminsCsv` — a mid-read IOException no longer wipes the admin set, and a BOM on the first line no longer hides the first admin id.
- **Restart persistence** — startup now also links historical participants into the conversation index, so silent admins still see their joined conversations after a server restart.
- **Snapshot + scrub** in `enqueueSilentJoinBroadcast` — participant snapshot is taken under the conversation monitor (no concurrent-mutation race), and active participants receive a metadata copy with the joining admin scrubbed from `historicalParticipants`. Silent observers (other admins) still receive the full metadata.

### Client
- **Null `Conversation` payload guard** in `ClientController.handleConversationResponse` — paired with the new server-side null returns.
- **EDT dispatch** for the conversation list and message view updates in the same handler.
- **Auto-open gate** — the conversation only auto-opens when the current user is in the active participants list, so a silent admin JOIN no longer hijacks the main view.
- **Admin Join button** — now also checks `historicalParticipants` so a re-click on an already-joined conversation just opens locally.
- **In-flight Join button disable** — prevents a fast double-click from firing two JOIN requests.

## Files touched
- `src/server/DataManager.java`
- `src/server/ServerController.java`
- `src/client/ClientController.java`
- `src/client/ClientUI.java`
- `src/shared/payload/Conversation.java` (helpers `addToHistoricalOnly` / `applyMetadata` that the silent-join flow depends on)

## Test plan
- [x] Build: `javac -d out @sources.txt` — clean compile (verified locally).
- [x] Run server + 2 non-admin clients + 1 admin client; admin silent-joins a 1:1 conversation. Confirm participant list on the non-admins does not contain the admin.
- [x] Admin double-clicks Join — confirm only one broadcast on the wire (other clients do not flicker twice).
- [x] Restart the server with a silent-joined conversation on disk; admin re-logs in and sees the conversation in their list with full message history.
- [x] Non-admin login: Admin button hidden; if a crafted ADMIN_CONVERSATION_QUERY is sent, server returns null payload.
- [x] Regression: a regular user creating a new conversation still auto-opens it in the main view.

## Notes
- Existing JUnit tests under `test/` may need assertion updates: tests that previously asserted populated results from a non-admin admin-query, NPE on null userId, presence of admin in participant-side metadata, or auto-open on JOIN will now flip.
- `Bug #6` (silent admin missing offline message replay) and `Bug #10` (1:1 historical-size invariant) are addressed transitively / confirmed not-a-bug per the audit.