### PR TITLE
feat: add empty seeder mode and switch demo to clickable clients

### DIFF
--- a/docs/Product-Demo-Procedure.md
+++ b/docs/Product-Demo-Procedure.md
@@ -17,11 +17,9 @@ Use this as a literal step-by-step script during the live demo.
 
 ## Terminal mapping
 
-- [ ] Open 4 terminals at repo root.
+- [ ] Open 1 terminal at repo root.
 - [ ] Terminal 1 = **Server**
-- [ ] Terminal 2 = **Jon**
-- [ ] Terminal 3 = **Quan**
-- [ ] Terminal 4 = **Harumi**
+- [ ] Client apps are launched from the clickable desktop app (not terminal commands).
 
 ## Server startup
 
@@ -32,9 +30,9 @@ Use this as a literal step-by-step script during the live demo.
 
 ## Client startup
 
-- [ ] **Jon** (Terminal 2): `java -cp out client.ClientController <SERVER_IP>`
-- [ ] **Quan** (Terminal 3): `java -cp out client.ClientController <SERVER_IP>`
-- [ ] **Harumi** (Terminal 4): `java -cp out client.ClientController <SERVER_IP>`
+- [ ] Launch the client app by clicking it three times (one instance each for **Jon**, **Quan**, and **Harumi**).
+- [ ] In each client instance, use the IP discovery prompt to connect to the server.
+- [ ] Enter the IPv4 printed by the server launcher and keep port `8080` unless a different port was explicitly configured.
 - [ ] Confirm all three show login screen.
 
 ## Demo identities

--- a/utils/SeedSerializedData.java
+++ b/utils/SeedSerializedData.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * seedMode:
  *   bottomOnly  -> seed only the bottom-N users (no premade Jon/Quan/Harumi overrides or hero-thread extras)
  *   withHeroes  -> current behavior (seed bottom-N users + premade Jon/Quan/Harumi accounts + extra hero threads)
+ *   empty       -> clear persisted user/conversation blobs and reset counters to zero (no seeded history)
  *
  * Defaults:
  *   dataRoot = "data"
@@ -50,13 +51,19 @@ public class SeedSerializedData {
         int bottomUserCount = args.length > 1 ? Integer.parseInt(args[1]) : 80;
         String seedMode = args.length > 2 ? args[2] : "withHeroes";
         boolean includeHeroes;
+        boolean emptyMode;
         if (seedMode.equalsIgnoreCase("bottomOnly")) {
             includeHeroes = false;
+            emptyMode = false;
         } else if (seedMode.equalsIgnoreCase("withHeroes")) {
             includeHeroes = true;
+            emptyMode = false;
+        } else if (seedMode.equalsIgnoreCase("empty")) {
+            includeHeroes = false;
+            emptyMode = true;
         } else {
             throw new IllegalArgumentException("Unknown seedMode '" + seedMode
-                    + "'. Expected 'bottomOnly' or 'withHeroes'.");
+                    + "'. Expected 'bottomOnly', 'withHeroes', or 'empty'.");
         }
 
         Path root = Path.of(dataRoot);
@@ -65,6 +72,27 @@ public class SeedSerializedData {
         Path userDataPath = root.resolve("user_data");
         Path convDataPath = root.resolve("conversation_data");
         Path serverConfigPath = root.resolve("server_data/server_config.txt");
+
+        Files.createDirectories(userDataPath);
+        Files.createDirectories(convDataPath);
+        Files.createDirectories(serverConfigPath.getParent());
+
+        clearSerializedFiles(userDataPath, ".user");
+        clearSerializedFiles(convDataPath, ".conversation");
+
+        if (emptyMode) {
+            Properties props = new Properties();
+            props.setProperty("conversationIdCounter", "0");
+            props.setProperty("messageSequenceCounter", "0");
+            try (FileOutputStream out = new FileOutputStream(serverConfigPath.toFile())) {
+                props.store(out, "Server counters (message sequence and conversation id)");
+            }
+            System.out.println("Seed complete.");
+            System.out.println("Users seeded: 0 (empty mode)");
+            System.out.println("Conversations seeded: 0 (empty mode)");
+            System.out.println("Messages seeded: 0 (empty mode)");
+            return;
+        }
 
         List<String> allAuthorizedUsers = Files.readAllLines(authUsersPath, StandardCharsets.UTF_8).stream()
                 .map(String::trim)
@@ -81,13 +109,6 @@ public class SeedSerializedData {
                 .map(String::trim)
                 .filter(line -> !line.isEmpty() && !line.startsWith("#"))
                 .toList());
-
-        Files.createDirectories(userDataPath);
-        Files.createDirectories(convDataPath);
-        Files.createDirectories(serverConfigPath.getParent());
-
-        clearSerializedFiles(userDataPath, ".user");
-        clearSerializedFiles(convDataPath, ".conversation");
 
         ArrayList<User> users = new ArrayList<>();
         ArrayList<UserInfo> userInfos = new ArrayList<>();

--- a/utils/ServerWithIPLauncher.java
+++ b/utils/ServerWithIPLauncher.java
@@ -14,7 +14,7 @@ import java.net.SocketException;
 public class ServerWithIPLauncher {
     public static void main(String[] args) {
         String dataRoot = "data";
-        String seedMode = null; // bottomOnly | withHeroes
+        String seedMode = null; // bottomOnly | withHeroes | empty
         for (int i = 0; i < args.length; i++) {
             String a = args[i];
             if (a == null) continue;
@@ -30,28 +30,34 @@ public class ServerWithIPLauncher {
                 seedMode = "bottomOnly";
             } else if (a.equals("2")) {
                 seedMode = "withHeroes";
+            } else if (a.equals("3")) {
+                seedMode = "empty";
             }
         }
 
         if (seedMode == null) {
-            // Interactive selection for demos; accepts: 1 or 2, or bottomOnly/withHeroes tokens.
+            // Interactive selection for demos; accepts 1/2/3 or bottomOnly/withHeroes/empty tokens.
             System.out.println("Select seeding runmode:");
             System.out.println("  1) bottomOnly   (seed only bottom-N users)");
             System.out.println("  2) withHeroes   (seed bottom-N users + premade Jon/Quan/Harumi accounts)");
-            System.out.print("Enter 1 or 2 (or bottomOnly/withHeroes): ");
+            System.out.println("  3) empty        (clear seeded user/conversation data and reset server counters)");
+            System.out.print("Enter 1, 2, or 3 (or bottomOnly/withHeroes/empty): ");
+            @SuppressWarnings("resource")
             Scanner sc = new Scanner(System.in);
             String line = sc.nextLine();
             seedMode = line == null ? "" : line.trim();
             if (seedMode.equals("1")) seedMode = "bottomOnly";
             if (seedMode.equals("2")) seedMode = "withHeroes";
+            if (seedMode.equals("3")) seedMode = "empty";
         }
 
         seedMode = seedMode.toLowerCase(Locale.ROOT);
         if (seedMode.equals("1")) seedMode = "bottomonly";
         if (seedMode.equals("2")) seedMode = "withheroes";
-        if (!seedMode.equals("bottomonly") && !seedMode.equals("withheroes")) {
+        if (seedMode.equals("3")) seedMode = "empty";
+        if (!seedMode.equals("bottomonly") && !seedMode.equals("withheroes") && !seedMode.equals("empty")) {
             // Defensive: SeedSerializedData validates these, but keep error message readable here too.
-            System.out.println("Unrecognized mode '" + seedMode + "'. Expected bottomOnly or withHeroes.");
+            System.out.println("Unrecognized mode '" + seedMode + "'. Expected bottomOnly, withHeroes, or empty.");
         }
 
         // Reseed before starting server.


### PR DESCRIPTION
## Summary

- Added a third seeding mode, `empty`, to `SeedSerializedData` to start with no persisted history.
- `empty` mode now clears serialized user/conversation files and resets server counters (`conversationIdCounter`, `messageSequenceCounter`) to `0`.
- Updated `ServerWithIPLauncher` to support `empty` mode via CLI (`--mode=empty`) and interactive selection (`3`), with validation/error messaging updated accordingly.
- Updated `docs/Product-Demo-Procedure.md` so clients are launched via the clickable client app with IP discovery prompt; only the server runs from command line via jar.

## Why

- Enables clean demo/test starts without any pre-seeded conversations or users.
- Aligns the presentation procedure with the intended UX (desktop client launch flow) instead of terminal-based client startup.

## Test Plan

- [x] Compile check: `javac -d out src/**/*.java utils/*.java`
- [x] Seeder smoke test: `java -cp out SeedSerializedData data 80 empty`
- [x] Verified output shows:
  - `Users seeded: 0 (empty mode)`
  - `Conversations seeded: 0 (empty mode)`
  - `Messages seeded: 0 (empty mode)`