### PR TITLE
test: server integration and admin view coverage; fix client controll…

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,7 @@ Expected content format:
 - Blank lines and lines beginning with `#` are ignored
 
 ## Testing
-Tests are located under `test/` and use JUnit.
-
-If you are running in Eclipse, use **Run As > JUnit Test** on specific test classes or the test package.
+Tests are located under `test/` and use JUnit 5.
 
 ## Troubleshooting
 - **Client cannot connect**: make sure server is running first and host/port match.

--- a/test/client/ClientControllerTest.java
+++ b/test/client/ClientControllerTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Timeout;
 import shared.enums.*;
 import shared.networking.*;
 import shared.networking.User.UserInfo;
-import shared.networking.fixtures.NetworkingSeedData;
 import shared.payload.*;
 
 import javax.swing.SwingUtilities;
@@ -28,13 +27,29 @@ import static org.junit.jupiter.api.Assertions.*;
 @Timeout(value = 10, unit = TimeUnit.SECONDS)
 class ClientControllerTest {
 
+    /** Stable ids/names for headless tests (replaces removed shared fixtures). */
+    private static final String ALICE_ID = "1001";
+    private static final String ALICE_NAME = "Alice";
+    private static final String BOB_ID = "1002";
+    private static final String BOB_NAME = "Bob";
+    private static final String CAROL_ID = "1003";
+    private static final String CAROL_NAME = "Carol";
+
     // =========================================================================
     // Helpers — build test data without a live server
     // =========================================================================
 
-    private static UserInfo alice() { return NetworkingSeedData.aliceInfo(); }
-    private static UserInfo bob()   { return NetworkingSeedData.bobInfo(); }
-    private static UserInfo carol() { return NetworkingSeedData.carolInfo(); }
+    private static UserInfo alice() {
+        return new User(ALICE_ID, ALICE_NAME, "alice_login", "pw", UserType.USER).toUserInfo();
+    }
+
+    private static UserInfo bob() {
+        return new User(BOB_ID, BOB_NAME, "bob_login", "pw", UserType.USER).toUserInfo();
+    }
+
+    private static UserInfo carol() {
+        return new User(CAROL_ID, CAROL_NAME, "carol_login", "pw", UserType.USER).toUserInfo();
+    }
 
     /** Builds a Conversation with a fixed id and the given members. */
     private static Conversation conv(long id, UserInfo... members) {
@@ -74,7 +89,7 @@ class ClientControllerTest {
     }
 
     private static Response messageFor(long convId, String text) {
-        Message m = new Message(text, 1L, new Date(), NetworkingSeedData.ALICE_ID, convId);
+        Message m = new Message(text, 1L, new Date(), ALICE_ID, convId);
         return new Response(ResponseType.MESSAGE, m);
     }
 
@@ -130,8 +145,8 @@ class ClientControllerTest {
         ClientController c = headless();
         c.processResponse(loginSuccessAliceWithConv());
         assertNotNull(c.getCurrentUserInfo());
-        assertEquals(NetworkingSeedData.ALICE_ID,   c.getCurrentUserInfo().getUserId());
-        assertEquals(NetworkingSeedData.ALICE_NAME, c.getCurrentUserInfo().getName());
+        assertEquals(ALICE_ID,   c.getCurrentUserInfo().getUserId());
+        assertEquals(ALICE_NAME, c.getCurrentUserInfo().getName());
     }
 
     @Test
@@ -365,9 +380,9 @@ class ClientControllerTest {
 
     @Test
     void filteredDirectory_matchesByExactUserId() {
-        List<UserInfo> r = headlessWithDirectory().getFilteredDirectory(NetworkingSeedData.ALICE_ID);
+        List<UserInfo> r = headlessWithDirectory().getFilteredDirectory(ALICE_ID);
         assertEquals(1, r.size());
-        assertEquals(NetworkingSeedData.ALICE_ID, r.get(0).getUserId());
+        assertEquals(ALICE_ID, r.get(0).getUserId());
     }
 
     @Test
@@ -375,7 +390,7 @@ class ClientControllerTest {
         // "lic" is a substring of "Alice"
         List<UserInfo> r = headlessWithDirectory().getFilteredDirectory("lic");
         assertEquals(1, r.size());
-        assertEquals(NetworkingSeedData.ALICE_NAME, r.get(0).getName());
+        assertEquals(ALICE_NAME, r.get(0).getName());
     }
 
     @Test
@@ -410,7 +425,7 @@ class ClientControllerTest {
     void filteredConversationList_matchesByParticipantId() {
         ClientController c = headless();
         c.processResponse(loginSuccessAliceWithConv()); // alice id=1001, bob id=1002
-        assertEquals(1, c.getFilteredConversationList(NetworkingSeedData.BOB_ID).size());
+        assertEquals(1, c.getFilteredConversationList(BOB_ID).size());
     }
 
     @Test

--- a/test/server/DataManagerTest.java
+++ b/test/server/DataManagerTest.java
@@ -1,6 +1,5 @@
 package server;
 
-import server.DataManager;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,6 +25,7 @@ import shared.networking.User;
 import shared.payload.AddToConversationPayload;
 import shared.payload.AdminConversationQuery;
 import shared.payload.AdminConversationResult;
+import shared.payload.AdminViewConversationQuery;
 import shared.payload.Conversation;
 import shared.payload.ConversationMetadata;
 import shared.payload.CreateConversationPayload;
@@ -105,7 +105,8 @@ public class DataManagerTest {
                 u5,Eve
                 """);
 
-        Files.writeString(authorizedIds.resolve("authorized_admins.txt"), "");
+        // u1 is admin so admin query/join paths in smoke tests match production behavior.
+        Files.writeString(authorizedIds.resolve("authorized_admins.txt"), "u1\n");
         Files.writeString(serverData.resolve("server_config.txt"), "");
 
         Files.createDirectories(root.resolve("conversation_data"));
@@ -214,7 +215,7 @@ public class DataManagerTest {
         ArrayList<Message> messages = forked.getMessages();
         assertEquals(1, messages.size(), "forked conversation has exactly one message (SYSTEM)");
         assertEquals("SYSTEM", messages.get(0).getSenderId());
-        assertTrue(messages.get(0).getText().contains("u3"), "system message names the added user");
+        assertTrue(messages.get(0).getText().contains("Carol"), "system message names the added user");
     }
 
     @Test
@@ -243,7 +244,55 @@ public class DataManagerTest {
         assertEquals("SYSTEM", last.getSenderId(), "last message is SYSTEM");
         assertTrue(last.getSequenceNumber() > priorSeq,
                 "SYSTEM seq (" + last.getSequenceNumber() + ") > prior seq (" + priorSeq + ")");
-        assertTrue(last.getText().contains("u4"), "system message names the added user");
+        assertTrue(last.getText().contains("Dan"), "system message names the added user");
+    }
+
+    @Test
+    void handleAdminViewConversation_nonAdminGetsNullPayload() throws IOException {
+        Path root = tempRoot.resolve("admin_view_non_admin");
+        prepareMinimalDataTree(root);
+        Files.writeString(root.resolve("server_data/authorized_ids/authorized_admins.txt"), "u1\n");
+        DataManager mgr = new DataManager(root.toString());
+        try {
+            assertEquals(RegisterStatus.SUCCESS, ((RegisterResult) mgr.handleRegister(new Request(RequestType.REGISTER,
+                    new RegisterCredentials("u1", "alice", "p1", "Alice"), null)).getPayload()).getRegisterStatus());
+            assertEquals(RegisterStatus.SUCCESS, ((RegisterResult) mgr.handleRegister(new Request(RequestType.REGISTER,
+                    new RegisterCredentials("u2", "bob", "p2", "Bob"), null)).getPayload()).getRegisterStatus());
+            long cid = ((Conversation) mgr.handleCreateConversation(new Request(RequestType.CREATE_CONVERSATION,
+                    new CreateConversationPayload(roster(ui("u1", "Alice"), ui("u2", "Bob"))),
+                    "u1")).getPayload()).getConversationId();
+
+            Response denied = mgr.handleAdminViewConversation(new Request(RequestType.ADMIN_VIEW_CONVERSATION,
+                    new AdminViewConversationQuery(cid), "u2"));
+            assertEquals(ResponseType.ADMIN_VIEW_CONVERSATION_RESULT, denied.getType());
+            assertNull(denied.getPayload());
+
+            Response allowed = mgr.handleAdminViewConversation(new Request(RequestType.ADMIN_VIEW_CONVERSATION,
+                    new AdminViewConversationQuery(cid), "u1"));
+            assertEquals(ResponseType.ADMIN_VIEW_CONVERSATION_RESULT, allowed.getType());
+            assertNotNull(allowed.getPayload());
+            assertEquals(cid, ((Conversation) allowed.getPayload()).getConversationId());
+        } finally {
+            mgr.close();
+        }
+    }
+
+    @Test
+    void handleAdminViewConversation_unknownConversationReturnsNullPayload() throws IOException {
+        Path root = tempRoot.resolve("admin_view_missing_conv");
+        prepareMinimalDataTree(root);
+        Files.writeString(root.resolve("server_data/authorized_ids/authorized_admins.txt"), "u1\n");
+        DataManager mgr = new DataManager(root.toString());
+        try {
+            assertEquals(RegisterStatus.SUCCESS, ((RegisterResult) mgr.handleRegister(new Request(RequestType.REGISTER,
+                    new RegisterCredentials("u1", "alice", "p1", "Alice"), null)).getPayload()).getRegisterStatus());
+            Response r = mgr.handleAdminViewConversation(new Request(RequestType.ADMIN_VIEW_CONVERSATION,
+                    new AdminViewConversationQuery(9_999_999L), "u1"));
+            assertEquals(ResponseType.ADMIN_VIEW_CONVERSATION_RESULT, r.getType());
+            assertNull(r.getPayload());
+        } finally {
+            mgr.close();
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -347,10 +396,10 @@ public class DataManagerTest {
         assertTrue(adminIds.contains(convGroup), "admin list contains group");
         assertTrue(adminIds.contains(forked.getConversationId()), "admin list contains fork");
 
-        // --- Join u5 to group
+        // --- Admin u1 silently joins group (u1 is already a member; idempotent join path)
         Response joinResp = dm.handleJoinConversation(new Request(RequestType.JOIN_CONVERSATION,
                 new JoinConversationPayload(convGroup),
-                "u5"));
+                "u1"));
         assertEquals(ResponseType.CONVERSATION, joinResp.getType(), "join");
         assertEquals(Long.valueOf(convGroup), Long.valueOf(((Conversation) joinResp.getPayload()).getConversationId()),
                 "join conv id");

--- a/test/server/ServerControllerTest.java
+++ b/test/server/ServerControllerTest.java
@@ -29,6 +29,7 @@ import shared.networking.Request;
 import shared.networking.Response;
 import shared.networking.User;
 import shared.payload.AdminConversationQuery;
+import shared.payload.AdminViewConversationQuery;
 import shared.payload.AddToConversationPayload;
 import shared.payload.Conversation;
 import shared.payload.ConversationMetadata;
@@ -196,6 +197,19 @@ class ServerControllerTest {
                 new Request(RequestType.JOIN_CONVERSATION, new JoinConversationPayload(1L), "u1"));
         assertEquals(ResponseType.CONVERSATION, response.getType());
         assertEquals(RequestType.JOIN_CONVERSATION, stub.lastCalled);
+    }
+
+    @Test
+    void adminViewConversationDispatches() throws Exception {
+        StubDataManager stub = new StubDataManager(testDataRoot().toString());
+        stub.responses.put(RequestType.ADMIN_VIEW_CONVERSATION,
+                new Response(ResponseType.ADMIN_VIEW_CONVERSATION_RESULT, null));
+        server = buildServerWithStub(stub);
+
+        Response response = server.processRequest(
+                new Request(RequestType.ADMIN_VIEW_CONVERSATION, new AdminViewConversationQuery(42L), "u1"));
+        assertEquals(ResponseType.ADMIN_VIEW_CONVERSATION_RESULT, response.getType());
+        assertEquals(RequestType.ADMIN_VIEW_CONVERSATION, stub.lastCalled);
     }
 
     @Test
@@ -464,6 +478,7 @@ class ServerControllerTest {
         @Override public Response handleAddToConversation(Request request) { return hit(RequestType.ADD_PARTICIPANT); }
         @Override public Response handleLeaveConversation(Request request) { return hit(RequestType.LEAVE_CONVERSATION); }
         @Override public Response handleAdminConversationQuery(Request request) { return hit(RequestType.ADMIN_CONVERSATION_QUERY); }
+        @Override public Response handleAdminViewConversation(Request request) { return hit(RequestType.ADMIN_VIEW_CONVERSATION); }
         @Override public Response handleJoinConversation(Request request) { return hit(RequestType.JOIN_CONVERSATION); }
         @Override public ArrayList<User.UserInfo> getParticipantList(long conversationId) {
             ArrayList<User.UserInfo> participants = participantsByConversationId.get(conversationId);

--- a/test/server/ServerModuleIntegrationTest.java
+++ b/test/server/ServerModuleIntegrationTest.java
@@ -1,0 +1,173 @@
+package server;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import shared.enums.LoginStatus;
+import shared.enums.RegisterStatus;
+import shared.enums.RequestType;
+import shared.enums.ResponseType;
+import shared.enums.UserType;
+import shared.networking.ConnectionListener;
+import shared.networking.Request;
+import shared.networking.Response;
+import shared.networking.User;
+import shared.payload.AdminConversationQuery;
+import shared.payload.AdminConversationResult;
+import shared.payload.AdminViewConversationQuery;
+import shared.payload.Conversation;
+import shared.payload.ConversationMetadata;
+import shared.payload.CreateConversationPayload;
+import shared.payload.JoinConversationPayload;
+import shared.payload.LeaveConversationPayload;
+import shared.payload.LoginCredentials;
+import shared.payload.Message;
+import shared.payload.LoginResult;
+import shared.payload.RawMessage;
+import shared.payload.RegisterCredentials;
+import shared.payload.RegisterResult;
+
+/**
+ * Integration coverage for the server JVM stack: real {@link ServerController} with real
+ * {@link DataManager}, {@link ConnectionListener} (ephemeral port), and broadcaster thread.
+ * Flows follow {@code docs/Product-Demo-Procedure.md} (Jon / Quan / Harumi / John Doe IDs).
+ */
+@Timeout(value = 45, unit = TimeUnit.SECONDS)
+class ServerModuleIntegrationTest {
+
+    @TempDir
+    Path tempRoot;
+
+    private ServerController server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.close();
+            server = null;
+        }
+    }
+
+    private static void preparePresentationProcedureRoot(Path root) throws IOException {
+        Path serverData = root.resolve("server_data");
+        Path authorizedIds = serverData.resolve("authorized_ids");
+        Files.createDirectories(authorizedIds);
+        Files.writeString(authorizedIds.resolve("authorized_users.txt"), """
+                J8D3K7P1LX,John Doe
+                Q7M2X9K4LP,Jon Yoon
+                N4R8T1BZQK,Quan Li
+                V3P6L0WQ9D,Harumi Sato
+                """);
+        Files.writeString(authorizedIds.resolve("authorized_admins.txt"), "Q7M2X9K4LP\n");
+        Files.writeString(serverData.resolve("server_config.txt"), "");
+        Files.createDirectories(root.resolve("conversation_data"));
+        Files.createDirectories(root.resolve("user_data"));
+    }
+
+    private static ConnectionListener readListener(ServerController c) throws Exception {
+        Field f = ServerController.class.getDeclaredField("connectionListener");
+        f.setAccessible(true);
+        return (ConnectionListener) f.get(c);
+    }
+
+    @Test
+    void presentationProcedure_fullServerStack() throws Exception {
+        Path dataRoot = tempRoot.resolve("presentation_procedure");
+        preparePresentationProcedureRoot(dataRoot);
+
+        server = ServerController.getInstance(null, 0, dataRoot.toString());
+        assertNotNull(server, "singleton should construct on first getInstance");
+
+        ConnectionListener listener = readListener(server);
+        int port = listener.getLocalPort();
+        assertTrue(port > 0, "server should bind an ephemeral TCP port (ConnectionListener)");
+
+        // UC-01 — register John Doe; duplicate → USER_ID_TAKEN
+        Response johnOk = server.processRequest(new Request(RequestType.REGISTER,
+                new RegisterCredentials("J8D3K7P1LX", "user123", "a", "John Doe"), null));
+        assertEquals(ResponseType.REGISTER_RESULT, johnOk.getType());
+        assertEquals(RegisterStatus.SUCCESS, ((RegisterResult) johnOk.getPayload()).getRegisterStatus());
+
+        Response johnDup = server.processRequest(new Request(RequestType.REGISTER,
+                new RegisterCredentials("J8D3K7P1LX", "user123b", "a", "John Doe"), null));
+        assertEquals(RegisterStatus.USER_ID_TAKEN, ((RegisterResult) johnDup.getPayload()).getRegisterStatus());
+
+        // Register demo heroes (seeded identities in procedure)
+        assertSuccessRegister(server, new RegisterCredentials("Q7M2X9K4LP", "jon", "a", "Jon Yoon"));
+        assertSuccessRegister(server, new RegisterCredentials("N4R8T1BZQK", "quan", "a", "Quan Li"));
+        assertSuccessRegister(server, new RegisterCredentials("V3P6L0WQ9D", "harumi", "a", "Harumi Sato"));
+
+        // UC-02 — login Jon and Quan
+        assertSuccessLogin(server, "jon", "a");
+        assertSuccessLogin(server, "quan", "a");
+
+        // UC-07 — private Jon + Quan
+        ArrayList<User.UserInfo> pair = new ArrayList<>();
+        pair.add(new User("Q7M2X9K4LP", "Jon Yoon", "jon", "a", UserType.ADMIN).toUserInfo());
+        pair.add(new User("N4R8T1BZQK", "Quan Li", "quan", "a", UserType.USER).toUserInfo());
+        Response createDm = server.processRequest(new Request(RequestType.CREATE_CONVERSATION,
+                new CreateConversationPayload(pair), "Q7M2X9K4LP"));
+        assertEquals(ResponseType.CONVERSATION, createDm.getType());
+        long dmId = ((Conversation) createDm.getPayload()).getConversationId();
+
+        // UC-03 — message in DM
+        Response msg = server.processRequest(new Request(RequestType.MESSAGE,
+                new RawMessage("Hi Quan (integration)", dmId), "Q7M2X9K4LP"));
+        assertEquals(ResponseType.MESSAGE, msg.getType());
+        assertEquals("Q7M2X9K4LP", ((Message) msg.getPayload()).getSenderId());
+
+        // UC-11 — admin search, read-only view, silent join
+        Response adminList = server.processRequest(new Request(RequestType.ADMIN_CONVERSATION_QUERY,
+                new AdminConversationQuery("N4R8T1BZQK"), "Q7M2X9K4LP"));
+        assertEquals(ResponseType.ADMIN_CONVERSATION_RESULT, adminList.getType());
+        AdminConversationResult meta = (AdminConversationResult) adminList.getPayload();
+        assertTrue(conversationIds(meta).contains(dmId), "admin list should include Jon/Quan DM");
+
+        Response adminView = server.processRequest(new Request(RequestType.ADMIN_VIEW_CONVERSATION,
+                new AdminViewConversationQuery(dmId), "Q7M2X9K4LP"));
+        assertEquals(ResponseType.ADMIN_VIEW_CONVERSATION_RESULT, adminView.getType());
+        assertNotNull(adminView.getPayload());
+        assertEquals(dmId, ((Conversation) adminView.getPayload()).getConversationId());
+
+        Response join = server.processRequest(new Request(RequestType.JOIN_CONVERSATION,
+                new JoinConversationPayload(dmId), "Q7M2X9K4LP"));
+        assertEquals(ResponseType.CONVERSATION, join.getType());
+
+        // UC-09 — Quan leaves DM
+        Response leave = server.processRequest(new Request(RequestType.LEAVE_CONVERSATION,
+                new LeaveConversationPayload(dmId), "N4R8T1BZQK"));
+        assertEquals(ResponseType.LEAVE_RESULT, leave.getType());
+    }
+
+    private static void assertSuccessRegister(ServerController server, RegisterCredentials rc) {
+        Response r = server.processRequest(new Request(RequestType.REGISTER, rc, null));
+        assertEquals(ResponseType.REGISTER_RESULT, r.getType());
+        assertEquals(RegisterStatus.SUCCESS, ((RegisterResult) r.getPayload()).getRegisterStatus(), rc.getUserId());
+    }
+
+    private static void assertSuccessLogin(ServerController server, String login, String password) {
+        Response r = server.processRequest(new Request(RequestType.LOGIN, new LoginCredentials(login, password), null));
+        assertEquals(ResponseType.LOGIN_RESULT, r.getType());
+        assertEquals(LoginStatus.SUCCESS, ((LoginResult) r.getPayload()).getLoginStatus(), login);
+    }
+
+    private static List<Long> conversationIds(AdminConversationResult result) {
+        ArrayList<Long> ids = new ArrayList<>();
+        for (ConversationMetadata m : result.getConversations()) {
+            ids.add(m.getConversationId());
+        }
+        return ids;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **`ServerModuleIntegrationTest`**: end-to-end exercise of a real **`ServerController`** (real **`DataManager`**, **`ConnectionListener`** on an ephemeral port, broadcaster) using demo-aligned authorized IDs from the product procedure (Jon / Quan / Harumi / John Doe).
- Extends **`DataManagerTest`** with **`handleAdminViewConversation`** coverage (non-admin denied, unknown conversation) and fixes existing tests for current behavior (admin seed in minimal tree, system messages use display names, smoke **join** uses an admin caller).
- Extends **`ServerControllerTest`** with **`ADMIN_VIEW_CONVERSATION`** dispatch and **`StubDataManager`** support.
- Fixes **`ClientControllerTest`** after fixture removal: replaces **`NetworkingSeedData`** with local Alice/Bob/Carol constants and **`User` → `UserInfo`** helpers.
- **`README`**: short neutral note that tests live under **`test/`** and use JUnit 5.

## Test plan

- [ ] Eclipse: **Run As → JUnit Test** on `test/server` (and `ClientControllerTest` if desired).
- [ ] Confirm **`ServerModuleIntegrationTest.presentationProcedure_fullServerStack`** passes (binds ephemeral port; may log `[ServerController]` lines).